### PR TITLE
Change all references of 'snapps' to 'zk' in all example files

### DIFF
--- a/examples/sudoku/ts/src/index.test.ts
+++ b/examples/sudoku/ts/src/index.test.ts
@@ -1,4 +1,4 @@
-import { deploy, submitSolution, getSnappState } from './sudoku-snapp';
+import { deploy, submitSolution, getZkState } from './sudoku-zkapp';
 import { cloneSudoku, generateSudoku, solveSudoku } from './sudoku-lib';
 import { shutdown } from 'snarkyjs';
 
@@ -11,7 +11,7 @@ describe('sudoku', () => {
     let sudoku = generateSudoku(0.5);
     await deploy(sudoku);
 
-    let state = await getSnappState();
+    let state = await getZkState();
     expect(state).toBeDefined();
     expect(state.isSolved).toBe(false);
   });
@@ -25,7 +25,7 @@ describe('sudoku', () => {
     let accepted = await submitSolution(sudoku, solution);
     expect(accepted).toBe(true);
 
-    let { isSolved } = await getSnappState();
+    let { isSolved } = await getZkState();
     expect(isSolved).toBe(true);
   });
 
@@ -42,7 +42,7 @@ describe('sudoku', () => {
     let accepted = await submitSolution(sudoku, noSolution);
     expect(accepted).toBe(false);
 
-    let { isSolved } = await getSnappState();
+    let { isSolved } = await getZkState();
     expect(isSolved).toBe(false);
   });
 });

--- a/examples/sudoku/ts/src/index.ts
+++ b/examples/sudoku/ts/src/index.ts
@@ -1,4 +1,4 @@
-import { deploy, submitSolution, getSnappState } from './sudoku-snapp.js';
+import { deploy, submitSolution, getZkState } from './sudoku-zkapp.js';
 import { cloneSudoku, generateSudoku, solveSudoku } from './sudoku-lib.js';
 import { shutdown } from 'snarkyjs';
 
@@ -6,7 +6,7 @@ let sudoku = generateSudoku(0.5);
 
 console.log('Deploying Sudoku...');
 await deploy(sudoku);
-console.log('Is the sudoku solved?', (await getSnappState()).isSolved);
+console.log('Is the sudoku solved?', (await getZkState()).isSolved);
 
 let solution = solveSudoku(sudoku);
 if (solution === undefined) throw Error('cannot happen');
@@ -17,11 +17,11 @@ noSolution[0][0] = (noSolution[0][0] % 9) + 1;
 
 console.log('Submitting solution...');
 await submitSolution(sudoku, noSolution);
-console.log('Is the sudoku solved?', (await getSnappState()).isSolved);
+console.log('Is the sudoku solved?', (await getZkState()).isSolved);
 
 // submit the actual solution
 console.log('Submitting solution...');
 await submitSolution(sudoku, solution);
-console.log('Is the sudoku solved?', (await getSnappState()).isSolved);
+console.log('Is the sudoku solved?', (await getZkState()).isSolved);
 
 shutdown();

--- a/examples/tictactoe/ts/src/index.ts
+++ b/examples/tictactoe/ts/src/index.ts
@@ -162,7 +162,7 @@ class TicTacToe extends SmartContract {
     finished.assertEquals(false);
 
     // 2. ensure that we know the private key associated to the public key
-    //    and that our public key is known to the snapp
+    //    and that our public key is known to the zkapp
 
     // ensure player owns the associated private key
     signature.verify(pubkey, [x, y]).assertEquals(true);
@@ -216,27 +216,28 @@ export async function main() {
   const player1Public = player1.toPublicKey();
   const player2Public = player2.toPublicKey();
 
-  const snappPrivkey = PrivateKey.random();
-  const snappPubkey = snappPrivkey.toPublicKey();
+  const zkPrivkey = PrivateKey.random();
+  const zkPubkey = zkPrivkey.toPublicKey();
 
   // Create a new instance of the contract
   console.log('\n\n====== DEPLOYING ======\n\n');
-  let snappInstance = new TicTacToe(snappPubkey);
+  let zkInstance = new TicTacToe(zkPubkey);
   await Mina.transaction(player1, async () => {
-    // player2 sends 1000000000 to the new snapp account
+    // player2 sends 1000000000 to the new zkapp account
     const amount = UInt64.fromNumber(1000000000);
     const p = await Party.createSigned(player2);
     p.body.delta = Int64.fromUnsigned(amount).neg();
 
-    snappInstance.deploy(amount);
+    zkInstance.deploy(amount);
   })
     .send()
     .wait();
 
   // initial state
-  let b = await Mina.getAccount(snappPubkey);
-  console.log('initial state of the snapp');
+  let b = await Mina.getAccount(zkPubkey);
+  console.log('initial state of the zkapp');
   for (const i in [0, 1, 2, 3, 4, 5, 6, 7]) {
+  // TODO: All references of `snapp` and possibly `appState` should be changed in SnarkyJS before merging
     console.log('state', i, ':', b.snapp.appState[i].toString());
   }
 
@@ -249,7 +250,7 @@ export async function main() {
     const x = Field.zero;
     const y = Field.zero;
     const signature = Signature.create(player1, [x, y]);
-    await snappInstance.play(
+    await zkInstance.play(
       player1Public,
       signature,
       Field.zero,
@@ -262,7 +263,7 @@ export async function main() {
     .wait();
 
   // debug
-  b = await Mina.getAccount(snappPubkey);
+  b = await Mina.getAccount(zkPubkey);
   new Board(b.snapp.appState[0]).printState();
 
   // play
@@ -272,7 +273,7 @@ export async function main() {
     const x = Field.one;
     const y = Field.zero;
     const signature = Signature.create(player2, [x, y]);
-    await snappInstance
+    await zkInstance
       .play(
         player2Public,
         signature,
@@ -287,7 +288,7 @@ export async function main() {
     .wait();
 
   // debug
-  b = await Mina.getAccount(snappPubkey);
+  b = await Mina.getAccount(zkPubkey);
   new Board(b.snapp.appState[0]).printState();
 
   // play
@@ -296,7 +297,7 @@ export async function main() {
     const x = Field.one;
     const y = Field.one;
     const signature = Signature.create(player1, [x, y]);
-    await snappInstance
+    await zkInstance
       .play(
         player1Public,
         signature,
@@ -311,7 +312,7 @@ export async function main() {
     .wait();
 
   // debug
-  b = await Mina.getAccount(snappPubkey);
+  b = await Mina.getAccount(zkPubkey);
   new Board(b.snapp.appState[0]).printState();
 
   // play
@@ -320,7 +321,7 @@ export async function main() {
     const x = two;
     const y = Field.one;
     const signature = Signature.create(player2, [x, y]);
-    await snappInstance
+    await zkInstance
       .play(
         player2Public,
         signature,
@@ -335,7 +336,7 @@ export async function main() {
     .wait();
 
   // debug
-  b = await Mina.getAccount(snappPubkey);
+  b = await Mina.getAccount(zkPubkey);
   new Board(b.snapp.appState[0]).printState();
 
   // play
@@ -344,7 +345,7 @@ export async function main() {
     const x = two;
     const y = two;
     const signature = Signature.create(player1, [x, y]);
-    await snappInstance
+    await zkInstance
       .play(player1Public, signature, two, two, player1Public, player2Public)
       .catch((e) => console.log(e));
   })
@@ -352,7 +353,7 @@ export async function main() {
     .wait();
 
   // debug
-  b = await Mina.getAccount(snappPubkey);
+  b = await Mina.getAccount(zkPubkey);
   new Board(b.snapp.appState[0]).printState();
   console.log('did someone win?', b.snapp.appState[2].toString());
 


### PR DESCRIPTION
**Description**
This renames all the references of `snapp` to `zk` in the examples. 

Left a `TODO` to change the `Mina.getAccount.snapp` member to whatever `SnarkyJS` changes too. That should be done before merging this in.

**Tested By**
Examples can be built without errors.
Examples pass existing unit tests