### PR TITLE
fix: Switch to using named export instead of default export

### DIFF
--- a/templates/project-ts/src/index.ts
+++ b/templates/project-ts/src/index.ts
@@ -7,7 +7,7 @@ import { Field, SmartContract, state, State, method } from 'snarkyjs';
  * The Add contract initializes the state variable 'num' to be a Field(1) value by default when deployed.
  * When the 'update' method is called, the Add contract adds Field(2) to its 'num' contract state.
  */
-export default class Add extends SmartContract {
+export class Add extends SmartContract {
   @state(Field) num = State<Field>();
 
   // initialization


### PR DESCRIPTION
**Description**
Removes the `default export` statement from the template Smart Contract. This is non-idiomatic as we expect Smart Contracts to be exported using named exports instead.