### PR TITLE
Update examples to use new APIs and remove `snapp` references

### DIFF
--- a/examples/sudoku/ts/src/index.ts
+++ b/examples/sudoku/ts/src/index.ts
@@ -1,4 +1,4 @@
-import { deploy, submitSolution, getZkappState } from './sudoku-zkapp.js';
+import { deploy, submitSolution, getZkAppState } from './sudoku-zkapp.js';
 import { cloneSudoku, generateSudoku, solveSudoku } from './sudoku-lib.js';
 import { shutdown } from 'snarkyjs';
 
@@ -6,7 +6,7 @@ let sudoku = generateSudoku(0.5);
 
 console.log('Deploying Sudoku...');
 await deploy(sudoku);
-console.log('Is the sudoku solved?', (await getZkappState()).isSolved);
+console.log('Is the sudoku solved?', (await getZkAppState()).isSolved);
 
 let solution = solveSudoku(sudoku);
 if (solution === undefined) throw Error('cannot happen');
@@ -21,11 +21,11 @@ try {
 } catch {
   //
 }
-console.log('Is the sudoku solved?', (await getZkappState()).isSolved);
+console.log('Is the sudoku solved?', (await getZkAppState()).isSolved);
 
 // submit the actual solution
 console.log('Submitting solution...');
 await submitSolution(sudoku, solution);
-console.log('Is the sudoku solved?', (await getZkappState()).isSolved);
+console.log('Is the sudoku solved?', (await getZkAppState()).isSolved);
 
 shutdown();

--- a/examples/sudoku/ts/src/index.ts
+++ b/examples/sudoku/ts/src/index.ts
@@ -1,4 +1,4 @@
-import { deploy, submitSolution, getSnappState } from './sudoku-snapp.js';
+import { deploy, submitSolution, getZkappState } from './sudoku-zkapp.js';
 import { cloneSudoku, generateSudoku, solveSudoku } from './sudoku-lib.js';
 import { shutdown } from 'snarkyjs';
 
@@ -6,7 +6,7 @@ let sudoku = generateSudoku(0.5);
 
 console.log('Deploying Sudoku...');
 await deploy(sudoku);
-console.log('Is the sudoku solved?', (await getSnappState()).isSolved);
+console.log('Is the sudoku solved?', (await getZkappState()).isSolved);
 
 let solution = solveSudoku(sudoku);
 if (solution === undefined) throw Error('cannot happen');
@@ -21,11 +21,11 @@ try {
 } catch {
   //
 }
-console.log('Is the sudoku solved?', (await getSnappState()).isSolved);
+console.log('Is the sudoku solved?', (await getZkappState()).isSolved);
 
 // submit the actual solution
 console.log('Submitting solution...');
 await submitSolution(sudoku, solution);
-console.log('Is the sudoku solved?', (await getSnappState()).isSolved);
+console.log('Is the sudoku solved?', (await getZkappState()).isSolved);
 
 shutdown();

--- a/examples/sudoku/ts/src/sudoku-zkapp.ts
+++ b/examples/sudoku/ts/src/sudoku-zkapp.ts
@@ -103,7 +103,7 @@ let zkappAddress = zkappKey.toPublicKey();
 
 async function deploy(sudoku: number[][]) {
   let tx = await Mina.transaction(account1, () => {
-    Party.fundNewAcount(account1);
+    Party.fundNewAccount(account1);
     let zkapp = new SudokuZkapp(zkappAddress);
     let sudokuInstance = new Sudoku(sudoku);
     zkapp.deploy({ zkappKey });

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "graphql.js": "^0.6.8",
         "ora": "^5.4.1",
         "shelljs": "^0.8.4",
-        "snarkyjs": "^0.3.0",
+        "snarkyjs": "^0.3.1",
         "table": "^6.8.0",
         "yargs": "^17.2.0"
       },
@@ -5194,9 +5194,9 @@
       }
     },
     "node_modules/snarkyjs": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/snarkyjs/-/snarkyjs-0.3.0.tgz",
-      "integrity": "sha512-kEwXCW/aSqKOjyrk5DJdNE8A84JfAZ/iYsSrBLBMTtoGsc1Qyqh0HjE7s3jODb7DXdjmwCAFLv9I5ciAX0XVzg==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/snarkyjs/-/snarkyjs-0.3.1.tgz",
+      "integrity": "sha512-9Ve1gNLEGglfmpOHSa3T1EJNJHY3SlZ4vPa5hm/AtS2okOckD39rs3ibELC603GAt/Qjcuz8iTg6GfapmPpocA==",
       "dependencies": {
         "env": "^0.0.2",
         "isomorphic-fetch": "^3.0.0",
@@ -9839,9 +9839,9 @@
       }
     },
     "snarkyjs": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/snarkyjs/-/snarkyjs-0.3.0.tgz",
-      "integrity": "sha512-kEwXCW/aSqKOjyrk5DJdNE8A84JfAZ/iYsSrBLBMTtoGsc1Qyqh0HjE7s3jODb7DXdjmwCAFLv9I5ciAX0XVzg==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/snarkyjs/-/snarkyjs-0.3.1.tgz",
+      "integrity": "sha512-9Ve1gNLEGglfmpOHSa3T1EJNJHY3SlZ4vPa5hm/AtS2okOckD39rs3ibELC603GAt/Qjcuz8iTg6GfapmPpocA==",
       "requires": {
         "env": "^0.0.2",
         "isomorphic-fetch": "^3.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "graphql.js": "^0.6.8",
         "ora": "^5.4.1",
         "shelljs": "^0.8.4",
-        "snarkyjs": "^0.3.1",
+        "snarkyjs": "^0.3.3",
         "table": "^6.8.0",
         "yargs": "^17.2.0"
       },
@@ -5194,9 +5194,9 @@
       }
     },
     "node_modules/snarkyjs": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/snarkyjs/-/snarkyjs-0.3.1.tgz",
-      "integrity": "sha512-9Ve1gNLEGglfmpOHSa3T1EJNJHY3SlZ4vPa5hm/AtS2okOckD39rs3ibELC603GAt/Qjcuz8iTg6GfapmPpocA==",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/snarkyjs/-/snarkyjs-0.3.3.tgz",
+      "integrity": "sha512-qOJFAQv5EktQEvx2cP42lb/MeKOjON16benaYrhvsEL+JFlbKskTiHbQKjcG3RM6pZ+dWth7WMfNMzTSxGHYag==",
       "dependencies": {
         "env": "^0.0.2",
         "isomorphic-fetch": "^3.0.0",
@@ -9839,9 +9839,9 @@
       }
     },
     "snarkyjs": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/snarkyjs/-/snarkyjs-0.3.1.tgz",
-      "integrity": "sha512-9Ve1gNLEGglfmpOHSa3T1EJNJHY3SlZ4vPa5hm/AtS2okOckD39rs3ibELC603GAt/Qjcuz8iTg6GfapmPpocA==",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/snarkyjs/-/snarkyjs-0.3.3.tgz",
+      "integrity": "sha512-qOJFAQv5EktQEvx2cP42lb/MeKOjON16benaYrhvsEL+JFlbKskTiHbQKjcG3RM6pZ+dWth7WMfNMzTSxGHYag==",
       "requires": {
         "env": "^0.0.2",
         "isomorphic-fetch": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "graphql.js": "^0.6.8",
     "ora": "^5.4.1",
     "shelljs": "^0.8.4",
-    "snarkyjs": "^0.3.0",
+    "snarkyjs": "^0.3.1",
     "table": "^6.8.0",
     "yargs": "^17.2.0"
   },

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "graphql.js": "^0.6.8",
     "ora": "^5.4.1",
     "shelljs": "^0.8.4",
-    "snarkyjs": "^0.3.1",
+    "snarkyjs": "^0.3.3",
     "table": "^6.8.0",
     "yargs": "^17.2.0"
   },

--- a/templates/project-ts/package-lock.json
+++ b/templates/project-ts/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.5",
       "license": "Apache-2.0",
       "dependencies": {
-        "snarkyjs": "^0.3.0"
+        "snarkyjs": "^0.3.3"
       },
       "devDependencies": {
         "@babel/preset-env": "^7.16.4",
@@ -7929,9 +7929,9 @@
       "dev": true
     },
     "node_modules/snarkyjs": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/snarkyjs/-/snarkyjs-0.3.0.tgz",
-      "integrity": "sha512-kEwXCW/aSqKOjyrk5DJdNE8A84JfAZ/iYsSrBLBMTtoGsc1Qyqh0HjE7s3jODb7DXdjmwCAFLv9I5ciAX0XVzg==",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/snarkyjs/-/snarkyjs-0.3.3.tgz",
+      "integrity": "sha512-qOJFAQv5EktQEvx2cP42lb/MeKOjON16benaYrhvsEL+JFlbKskTiHbQKjcG3RM6pZ+dWth7WMfNMzTSxGHYag==",
       "dependencies": {
         "env": "^0.0.2",
         "isomorphic-fetch": "^3.0.0",
@@ -14577,9 +14577,9 @@
       }
     },
     "snarkyjs": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/snarkyjs/-/snarkyjs-0.3.0.tgz",
-      "integrity": "sha512-kEwXCW/aSqKOjyrk5DJdNE8A84JfAZ/iYsSrBLBMTtoGsc1Qyqh0HjE7s3jODb7DXdjmwCAFLv9I5ciAX0XVzg==",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/snarkyjs/-/snarkyjs-0.3.3.tgz",
+      "integrity": "sha512-qOJFAQv5EktQEvx2cP42lb/MeKOjON16benaYrhvsEL+JFlbKskTiHbQKjcG3RM6pZ+dWth7WMfNMzTSxGHYag==",
       "requires": {
         "env": "^0.0.2",
         "isomorphic-fetch": "^3.0.0",

--- a/templates/project-ts/package.json
+++ b/templates/project-ts/package.json
@@ -29,7 +29,7 @@
     ]
   },
   "dependencies": {
-    "snarkyjs": "^0.3.0"
+    "snarkyjs": "^0.3.3"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.16.4",

--- a/templates/project-ts/src/index.ts
+++ b/templates/project-ts/src/index.ts
@@ -1,4 +1,11 @@
-import { Field, SmartContract, state, State, method } from 'snarkyjs';
+import {
+  Field,
+  PrivateKey,
+  SmartContract,
+  state,
+  State,
+  method,
+} from 'snarkyjs';
 
 /**
  * Basic Example
@@ -11,7 +18,10 @@ export class Add extends SmartContract {
   @state(Field) num = State<Field>();
 
   // initialization
-  deploy(args: unknown) {
+  deploy(args: {
+    verificationKey?: string | undefined;
+    zkappKey?: PrivateKey | undefined;
+  }) {
     super.deploy(args);
     this.num.set(Field(1));
   }


### PR DESCRIPTION
**Description**:
1. Update `snarkyjs` to `0.3.3`
2. Update examples to use new APIs that are exposed by `snarkyjs`
3. Remove any references of `snapp` and replace with `zkApp`

**Tested By**:
Manually testing. Built the new examples and ran them as normal. Compared output with previous iterations to confirm the same behavior.