### PR TITLE
Fix deploy command

### DIFF
--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -11,7 +11,7 @@ const log = console.log;
 /**
  * Show existing networks in `config.json` and allow a user to add a new
  * network and url--and generate a key pair for it.
- * @returns {void}
+ * @returns {Promise<void>}
  */
 async function config() {
   // Get project root, so the CLI command can be run anywhere inside their proj.

--- a/src/lib/deploy.js
+++ b/src/lib/deploy.js
@@ -21,7 +21,7 @@ const DEFAULT_GRAPHQL = 'https://proxy.berkeley.minaexplorer.com/graphql'; // Th
  * provided, yargs will tell the user that the network param is required.
  * @param {string} network Network name to deploy to.
  * @param {string} yes     Run non-interactively. I.e. skip confirmation steps.
- * @return {void}          Sends tx to a relayer, if confirmed by user.
+ * @return {Promise<void>} Sends tx to a relayer, if confirmed by user.
  */
 async function deploy({ network, yes }) {
   // Get project root, so the CLI command can be run anywhere inside their proj.
@@ -351,7 +351,7 @@ async function deploy({ network, yes }) {
  * Find the user-specified class names for every instance of `SmartContract`
  * in the build dir.
  * @param {string} path The glob pattern--e.g. `build/**\/*.js`
- * @returns {array}     The user-specified class names--e.g. ['Foo', 'Bar']
+ * @returns {Promise<array>} The user-specified class names--e.g. ['Foo', 'Bar']
  */
 async function findSmartContracts(path) {
   const files = await glob(path);
@@ -394,7 +394,7 @@ function chooseSmartContract(config, deploy, network) {
  * Find the file name of the smart contract to be deployed.
  * @param {string}    buildPath    The glob pattern--e.g. `build/**\/*.js`
  * @param {string}    contractName The user-specified contract name to deploy.
- * @returns {string}  The file name of the user-specified smart contract.
+ * @returns {Promise<string>}      The file name of the user-specified smart contract.
  */
 async function findSmartContractToDeploy(buildPath, contractName) {
   const files = await glob(buildPath);

--- a/src/lib/deploy.js
+++ b/src/lib/deploy.js
@@ -248,7 +248,7 @@ async function deploy({ network, yes }) {
     let feePayerDeploy = {
       feePayer,
       nonce,
-      fee: `${fee}000000000`, // add 9 zeros -- in nanomina (1 billion = 1.0 mina)
+      fee: `${Number(fee) * 1e9}`, // in nanomina (1 billion = 1.0 mina)
       memo: '',
     };
     return client.signTransaction(

--- a/src/lib/example.js
+++ b/src/lib/example.js
@@ -15,7 +15,7 @@ const shExec = util.promisify(sh.exec);
  * testing lib, etc. Warns if already exists and does NOT overwrite.
  * @param {string} name  Desired dir name or path. Will recursively create
  *                       dirs without overwriting existing content, if needed.
- * @return {void}
+ * @return {Promise<void>}
  */
 async function example(example) {
   const dir = findUniqueDir(example);
@@ -70,9 +70,9 @@ async function example(example) {
 
 /**
  * Fetch project template.
- * @param {string} example Name of the destination dir.
- * @param {string} lang    ts or js
- * @returns {boolean}      True if successful; false if not.
+ * @param {string} example     Name of the destination dir.
+ * @param {string} lang        ts or js
+ * @returns {Promise<boolean>} True if successful; false if not.
  */
 async function fetchProjectTemplate(name, lang) {
   const projectName = lang === 'ts' ? 'project-ts' : 'project';
@@ -107,6 +107,7 @@ async function fetchProjectTemplate(name, lang) {
  * Helper for any steps that need to call a shell command.
  * @param {string} step Name of step to show user
  * @param {string} cmd  Shell command to execute.
+ * @returns {Promise<void>}
  */
 async function step(step, cmd) {
   const spin = ora(`${step}...`).start();
@@ -122,6 +123,7 @@ async function step(step, cmd) {
  * Step to replace placeholder names in the project with the properly-formatted
  * version of the user-supplied name as specified via `zk project <name>`
  * @param {string} projDir Full path to terminal dir + path/to/name
+ * @returns {Promise<void>}
  */
 async function setProjectName(projDir) {
   const step = 'Set project name';
@@ -149,7 +151,7 @@ async function setProjectName(projDir) {
  * @param {string} b    New text.
  */
 function replaceInFile(file, a, b) {
-  content = fs.readFileSync(file, 'utf8');
+  let content = fs.readFileSync(file, 'utf8');
   content = content.replace(a, b);
   fs.writeFileSync(file, content);
 }
@@ -167,10 +169,10 @@ function kebabCase(str) {
 
 /**
  * Fetch an example & place in the `src` directory.
- * @param {string} example Name of the example, as found in our Github repo.
- * @param {string} name    Destination dir name.
- * @param {string} lang    ts or js
- * @returns {boolean}      True if successful; false if not.
+ * @param {string} example     Name of the example, as found in our Github repo.
+ * @param {string} name        Destination dir name.
+ * @param {string} lang        ts or js
+ * @returns {Promise<boolean>} True if successful; false if not.
  */
 async function extractExample(example, name, lang) {
   const step = 'Extract example';

--- a/src/lib/file.js
+++ b/src/lib/file.js
@@ -10,7 +10,7 @@ const _i = chalk.italic;
  * Create `foo.js` and `foo.test.js` in current directory. Warn if destination
  * already exists and do NOT overwrite.
  * @param {string} _path Desired file name or `path/to/name`
- * @return {void}
+ * @return {Promise<void>}
  */
 async function file(_path) {
   let { userPath, projName } = parsePath(process.cwd(), _path);
@@ -63,6 +63,7 @@ describe('${projName}.js', () => {
  * @param {string} cwd   Current working directory. E.g. process.cwd().
  * @param {string} _path User's desired filename with optional path.
  *                       E.g. `path/to/name` or `name` (with no path).
+ * @returns {{fullPath: string, projName: string, userPath: string}}
  */
 function parsePath(cwd, _path) {
   const fullPath = path.join(cwd, _path);

--- a/src/lib/helpers.js
+++ b/src/lib/helpers.js
@@ -3,8 +3,10 @@ const { green, red } = require('chalk');
 
 /**
  * Helper for any steps for a consistent UX.
+ * @template T
  * @param {string} step  Name of step to show user.
- * @param {function} fn  An async function to execute.
+ * @param {() => Promise<T>} fn  An async function to execute.
+ * @returns {Promise<T>}
  */
 async function step(str, fn) {
   const spin = ora(`${str}...`).start();

--- a/src/lib/project.js
+++ b/src/lib/project.js
@@ -15,7 +15,7 @@ const shExec = util.promisify(sh.exec);
  * testing lib, etc. Warns if already exists and does NOT overwrite.
  * @param {string} name  Desired dir name or path. Will recursively create
  *                       dirs without overwriting existing content, if needed.
- * @return {void}
+ * @return {Promise<void>}
  */
 async function project(name) {
   const lang = 'ts';
@@ -71,9 +71,9 @@ async function project(name) {
 
 /**
  * Fetch project template.
- * @param {string} example Name of the destination dir.
- * @param {string} lang    ts or js
- * @returns {boolean}      True if successful; false if not.
+ * @param {string} example     Name of the destination dir.
+ * @param {string} lang        ts or js
+ * @returns {Promise<boolean>} True if successful; false if not.
  */
 async function fetchProjectTemplate(name, lang) {
   const projectName = lang === 'ts' ? 'project-ts' : 'project';
@@ -113,6 +113,7 @@ async function fetchProjectTemplate(name, lang) {
  * Helper for any steps that need to call a shell command.
  * @param {string} step Name of step to show user
  * @param {string} cmd  Shell command to execute.
+ * @returns {Promise<void>}
  */
 async function step(step, cmd) {
   const spin = ora(`${step}...`).start();
@@ -128,6 +129,7 @@ async function step(step, cmd) {
  * Step to replace placeholder names in the project with the properly-formatted
  * version of the user-supplied name as specified via `zk project <name>`
  * @param {string} projDir Full path to terminal dir + path/to/name
+ * @returns {Promise<void>}
  */
 async function setProjectName(projDir) {
   const step = 'Set project name';


### PR DESCRIPTION
This should fix all problems with `zk deploy`.

* To avoid complications with two instances of snarkyjs, we import snarkyjs from the user directory:
```js
let snarkyjs = await import(`${DIR}/node_modules/snarkyjs/dist/server/index.mjs`);
```
* To avoid another dependency that has to be kept up to date, we sign the transaction with snarkyjs instead of mina-signer. Thus, `zk deploy` _only_ depends on libraries present in the user directory. This enables us to deploy zkapps in up to date user projects even with an older version of the zkapp cli, provided that the snarkyjs APIs we use for deploying remain stable.
* To circumvent issues with the existing snarkyjs `deploy()` command, which lead to a wrong nonce & other stuff, we construct the deploy transaction directly with `Mina.transaction`. `deploy()` issues will be addressed separately: https://github.com/o1-labs/snarkyjs/pull/154

Some unrelated fixes that crept in:
* fix how the transaction fee is computed, so that it works with fractional numbers e.g. < 1 MINA
* fix jsdoc type annotations across the entire code base
