### PR TITLE
Add configurable fee amount to config and deploy to reenable non-interactivity

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zkapp-cli",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "zkapp-cli",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zkapp-cli",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "CLI to create a zkApp (\"zero-knowledge app\") for Mina Protocol.",
   "keywords": [
     "cli",

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -124,9 +124,7 @@ async function config() {
       name: 'fee',
       message: (state) => {
         const style = state.submitted && !state.cancelled ? green : reset;
-        return style(
-          'Set default transaction fee to deploy a zkApp (in MINA):'
-        );
+        return style('Set transaction fee to use when deploying (in MINA):');
       },
       prefix: formatPrefixSymbol,
       validate: (val) => {

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -119,11 +119,28 @@ async function config() {
       },
       result: (val) => val.trim().replace(/ /, ''),
     },
+    {
+      type: 'input',
+      name: 'fee',
+      message: (state) => {
+        const style = state.submitted && !state.cancelled ? green : reset;
+        return style(
+          'Set default transaction fee to deploy a zkApp (in MINA):'
+        );
+      },
+      prefix: formatPrefixSymbol,
+      validate: (val) => {
+        if (!val) return red('Fee is required.');
+        if (isNaN(val)) return red('Fee must be a number.');
+        return true;
+      },
+      result: (val) => val.trim().replace(/ /, ''),
+    },
   ]);
 
   // If user presses "ctrl + c" during interactive prompt, exit.
-  const { network, url } = response;
-  if (!network || !url) return;
+  const { network, url, fee } = response;
+  if (!network || !url || !fee) return;
 
   const keyPair = await step(
     `Create key pair at keys/${network}.json`,
@@ -136,7 +153,7 @@ async function config() {
   );
 
   await step(`Add network to config.json`, async () => {
-    config.networks[network] = { url, keyPath: `keys/${network}.json` };
+    config.networks[network] = { url, keyPath: `keys/${network}.json`, fee };
     fs.outputJsonSync(`${DIR}/config.json`, config, { spaces: 2 });
   });
 

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -132,6 +132,7 @@ async function config() {
       validate: (val) => {
         if (!val) return red('Fee is required.');
         if (isNaN(val)) return red('Fee must be a number.');
+        if (val < 0) return red("Fee can't be negative.");
         return true;
       },
       result: (val) => val.trim().replace(/ /, ''),

--- a/src/lib/deploy.js
+++ b/src/lib/deploy.js
@@ -180,7 +180,7 @@ async function deploy({ network, yes }) {
   let zkAppPrivateKey = PrivateKey.fromBase58(privateKey); //  The private key of the zkApp
   let zkAppAddress = zkAppPrivateKey.toPublicKey(); //  The public key of the zkApp
 
-  let verificationKey = await step(
+  const verificationKey = await step(
     'Generate verification key (takes 1-2 min)',
     async () => {
       let { verificationKey } = await zkApp.compile(zkAppAddress);
@@ -188,42 +188,62 @@ async function deploy({ network, yes }) {
     }
   );
 
-  // Get the transaction fee amount to deploy specified by the user
-  let response = await prompt({
-    type: 'input',
-    name: 'fee',
-    message: (state) => {
-      const style = state.submitted && !state.cancelled ? green : reset;
-      return style('Set transaction fee to deploy (in MINA):');
-    },
-    validate: (val) => {
-      if (!val) return red('Fee is required.');
-      if (isNaN(val)) return red('Fee must be a number.');
-      return true;
-    },
-    result: (val) => val.trim().replace(/ /, ''),
-  });
-
-  let { fee } = response;
-  if (!fee) return;
+  let fee;
+  if (yes) {
+    // If running in non-interactive mode, get the transaction fee amount from the user's config file
+    fee = config.networks[network]?.fee;
+  } else {
+    // If running in interactive mode, get the transaction fee amount from the user's input
+    let feeResponse = await prompt({
+      type: 'input',
+      name: 'fee',
+      message: (state) => {
+        const style = state.submitted && !state.cancelled ? green : reset;
+        return style('Set transaction fee to deploy (in MINA):');
+      },
+      validate: (val) => {
+        if (!val) return red('Fee is required.');
+        if (isNaN(val)) return red('Fee must be a number.');
+        return true;
+      },
+      result: (val) => val.trim().replace(/ /, ''),
+    });
+    fee = feeResponse.fee;
+  }
+  if (!fee) {
+    log(
+      red(
+        `  Failed to find the deploy fee amount.\n  Please make sure your config.json has the correct 'fee' property.`
+      )
+    );
+    return;
+  }
   fee = `${Number(fee) * 1e9}`; // in nanomina (1 billion = 1.0 mina)
 
   const graphQLEndpoint = config?.networks[network]?.url ?? DEFAULT_GRAPHQL;
   const zkAppAddressBase58 = zkAppAddress.toBase58();
   const accountQuery = getAccountQuery(zkAppAddressBase58);
-  let nonce = 0;
-  response = await sendGraphQL(graphQLEndpoint, accountQuery);
+  const accountResponse = await sendGraphQL(graphQLEndpoint, accountQuery);
 
-  // If fetching the nonce does not work, we ask the user to specify a nonce value manually
-  if (response?.data?.account?.nonce) {
-    nonce = Number(response.data.account.nonce);
-  } else {
-    let response = await prompt({
+  let nonce = 0;
+  if (yes && !accountResponse?.data?.account?.nonce) {
+    // If running in non-interactive mode and no nonce is found, show an error message and return early
+    log(
+      red(
+        `  Failed to find the account nonce.\n  Please run in interactive mode and specify an account nonce.`
+      )
+    );
+    return;
+  } else if (!yes && !accountResponse?.data?.account?.nonce) {
+    // If running in interactive mode and no nonce is found, ask for the user's input
+    let nonceResponse = await prompt({
       type: 'input',
       name: 'nonce',
       message: (state) => {
         const style = state.submitted && !state.cancelled ? green : reset;
-        return style('Please confirm the nonce of the account:');
+        return style(
+          'Could not find account nonce. Please confirm the nonce of the account:'
+        );
       },
       validate: (val) => {
         if (!val) return red('Nonce is required.');
@@ -232,7 +252,10 @@ async function deploy({ network, yes }) {
       },
       result: (val) => val.trim().replace(/ /, ''),
     });
-    nonce = Number(response.nonce);
+    nonce = Number(nonceResponse.nonce);
+  } else {
+    // Account nonce value is found from the network
+    nonce = Number(accountResponse.data.account.nonce);
   }
 
   let transactionJson = await step('Build transaction', async () => {

--- a/src/lib/deploy.js
+++ b/src/lib/deploy.js
@@ -227,6 +227,7 @@ async function deploy({ network, yes }) {
       validate: (val) => {
         if (!val) return red('Nonce is required.');
         if (isNaN(val)) return red('Nonce must be a number.');
+        if (val < 0) return red("Nonce can't be negative.");
         return true;
       },
       result: (val) => val.trim().replace(/ /, ''),

--- a/src/lib/deploy.js
+++ b/src/lib/deploy.js
@@ -192,7 +192,7 @@ async function deploy({ network, yes }) {
   if (!fee) {
     log(
       red(
-        `  Failed to find the deploy fee amount.\n  Please make sure your config.json has the correct 'fee' property.`
+        `  The "fee" property is not specified for this network alias in config.json. Please update your config.json and try again.`
       )
     );
     return;

--- a/src/lib/deploy.js
+++ b/src/lib/deploy.js
@@ -188,28 +188,7 @@ async function deploy({ network, yes }) {
     }
   );
 
-  let fee;
-  if (yes) {
-    // If running in non-interactive mode, get the transaction fee amount from the user's config file
-    fee = config.networks[network]?.fee;
-  } else {
-    // If running in interactive mode, get the transaction fee amount from the user's input
-    let feeResponse = await prompt({
-      type: 'input',
-      name: 'fee',
-      message: (state) => {
-        const style = state.submitted && !state.cancelled ? green : reset;
-        return style('Set transaction fee to deploy (in MINA):');
-      },
-      validate: (val) => {
-        if (!val) return red('Fee is required.');
-        if (isNaN(val)) return red('Fee must be a number.');
-        return true;
-      },
-      result: (val) => val.trim().replace(/ /, ''),
-    });
-    fee = feeResponse.fee;
-  }
+  let { fee } = config.networks[network];
   if (!fee) {
     log(
       red(


### PR DESCRIPTION
**Description**
Adding the fee step when running `zk deploy` broke the non-interactive workflow. To fix this, we ask the user to specify a default amount in their `config.json`. When running the deploy non-interactively, the CLI will look inside `config.json` to use the specified fee amount.

**Tested By**
Running `npm link` and then manual testing.