### PR TITLE
Feature/exit cli on unsuccess

### DIFF
--- a/src/lib/deploy.js
+++ b/src/lib/deploy.js
@@ -164,6 +164,10 @@ async function deploy({ network, yes }) {
   );
 
   let smartContractImports;
+  // import snarkyjs from the user directory
+  let { isReady, shutdown, PrivateKey, addCachedAccount, Mina } = await import(
+    `${DIR}/node_modules/snarkyjs/dist/server/index.mjs`
+  );
 
   try {
     smartContractImports = await import(
@@ -175,6 +179,7 @@ async function deploy({ network, yes }) {
         `  Failed to find the "${contractName}" smart contract in your build directory.\n Please confirm that your config.json contains the name of the smart contract that you desire to deploy to this network alias.`
       )
     );
+    await shutdown();
     return;
   }
 
@@ -186,6 +191,7 @@ async function deploy({ network, yes }) {
         `  Failed to find the "${contractName}" smart contract in your build directory.\n Check that you have exported your smart contract class using a named export and try again.`
       )
     );
+    await shutdown();
     return;
   }
 
@@ -199,13 +205,9 @@ async function deploy({ network, yes }) {
         `  Failed to find the zkApp private key.\n  Please make sure your config.json has the correct 'keyPath' property.`
       )
     );
+    await shutdown();
     return;
   }
-
-  // import snarkyjs from the user directory
-  let { isReady, shutdown, PrivateKey, addCachedAccount, Mina } = await import(
-    `${DIR}/node_modules/snarkyjs/dist/server/index.mjs`
-  );
 
   await isReady;
 

--- a/src/lib/deploy.js
+++ b/src/lib/deploy.js
@@ -164,10 +164,7 @@ async function deploy({ network, yes }) {
   );
 
   let smartContractImports;
-  // import snarkyjs from the user directory
-  let { isReady, shutdown, PrivateKey, addCachedAccount, Mina } = await import(
-    `${DIR}/node_modules/snarkyjs/dist/server/index.mjs`
-  );
+
   try {
     smartContractImports = await import(
       `${DIR}/build/src/${smartContractFile}`
@@ -178,7 +175,6 @@ async function deploy({ network, yes }) {
         `  Failed to find the "${contractName}" smart contract in your build directory.\n Please confirm that your config.json contains the name of the smart contract that you desire to deploy to this network alias.`
       )
     );
-    await shutdown();
     return;
   }
 
@@ -190,7 +186,6 @@ async function deploy({ network, yes }) {
         `  Failed to find the "${contractName}" smart contract in your build directory.\n Check that you have exported your smart contract class using a named export and try again.`
       )
     );
-    await shutdown();
     return;
   }
 
@@ -204,9 +199,13 @@ async function deploy({ network, yes }) {
         `  Failed to find the zkApp private key.\n  Please make sure your config.json has the correct 'keyPath' property.`
       )
     );
-    await shutdown();
     return;
   }
+
+  // import snarkyjs from the user directory
+  let { isReady, shutdown, PrivateKey, addCachedAccount, Mina } = await import(
+    `${DIR}/node_modules/snarkyjs/dist/server/index.mjs`
+  );
 
   await isReady;
 

--- a/src/lib/deploy.js
+++ b/src/lib/deploy.js
@@ -247,6 +247,7 @@ async function deploy({ network, yes }) {
         `  Failed to find the account nonce.\n  Please run in interactive mode and specify an account nonce.`
       )
     );
+    await shutdown();
     return;
   } else if (!yes && !accountResponse?.data?.account?.nonce) {
     // If running in interactive mode and no nonce is found, ask for the user's input

--- a/src/lib/deploy.js
+++ b/src/lib/deploy.js
@@ -355,6 +355,7 @@ async function deploy({ network, yes }) {
       return (await sendGraphQL(graphQLEndpoint, zkAppMutation)).data.sendZkapp
         .zkapp;
     } catch (error) {
+      await shutdown();
       return error;
     }
   });
@@ -362,6 +363,7 @@ async function deploy({ network, yes }) {
   if (!txn || txn?.kind === 'error') {
     // Note that the thrown error object is already console logged via step().
     log(red('  Failed to send transaction to relayer. Please try again.'));
+    await shutdown();
     return;
   }
 

--- a/src/lib/deploy.js
+++ b/src/lib/deploy.js
@@ -178,6 +178,7 @@ async function deploy({ network, yes }) {
         `  Failed to find the "${contractName}" smart contract in your build directory.\n Please confirm that your config.json contains the name of the smart contract that you desire to deploy to this network alias.`
       )
     );
+    await shutdown();
     return;
   }
 
@@ -189,6 +190,7 @@ async function deploy({ network, yes }) {
         `  Failed to find the "${contractName}" smart contract in your build directory.\n Check that you have exported your smart contract class using a named export and try again.`
       )
     );
+    await shutdown();
     return;
   }
 

--- a/src/lib/deploy.js
+++ b/src/lib/deploy.js
@@ -204,6 +204,7 @@ async function deploy({ network, yes }) {
         `  Failed to find the zkApp private key.\n  Please make sure your config.json has the correct 'keyPath' property.`
       )
     );
+    await shutdown();
     return;
   }
 
@@ -228,6 +229,7 @@ async function deploy({ network, yes }) {
         `  The "fee" property is not specified for this network alias in config.json. Please update your config.json and try again.`
       )
     );
+    await shutdown();
     return;
   }
   fee = `${Number(fee) * 1e9}`; // in nanomina (1 billion = 1.0 mina)

--- a/src/lib/helpers.js
+++ b/src/lib/helpers.js
@@ -6,6 +6,7 @@ const { green, red } = require('chalk');
  * @template T
  * @param {string} step  Name of step to show user.
  * @param {() => Promise<T>} fn  An async function to execute.
+ * @param {() => Promise<T>} fn  An async function to execute.
  * @returns {Promise<T>}
  */
 async function step(str, fn) {
@@ -17,6 +18,7 @@ async function step(str, fn) {
   } catch (err) {
     spin.fail(str);
     console.error('  ' + red(err)); // maintain expected indentation
+    process.exit();
   }
 }
 

--- a/src/lib/helpers.js
+++ b/src/lib/helpers.js
@@ -6,7 +6,6 @@ const { green, red } = require('chalk');
  * @template T
  * @param {string} step  Name of step to show user.
  * @param {() => Promise<T>} fn  An async function to execute.
- * @param {() => Promise<T>} fn  An async function to execute.
  * @returns {Promise<T>}
  */
 async function step(str, fn) {


### PR DESCRIPTION
This pr adds functionality to allow the CLI to exit when the current step is unsuccessful for a better ux. This was accomplished by:
- Calling the SnarkyJs  async shutdown function on error cases
- Adding code to exit the process on the error catch block of the step helper function 