### PR TITLE
feat(deploy): Add better error handling when deploy fails

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zkapp-cli",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "zkapp-cli",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zkapp-cli",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "CLI to create a zkApp (\"zero-knowledge app\") for Mina Protocol.",
   "keywords": [
     "cli",

--- a/src/lib/deploy.js
+++ b/src/lib/deploy.js
@@ -214,7 +214,6 @@ async function deploy({ network, yes }) {
   let zkApp = smartContractImports[contractName]; //  The specified zkApp class to deploy
   let zkAppPrivateKey = PrivateKey.fromBase58(privateKey); //  The private key of the zkApp
   let zkAppAddress = zkAppPrivateKey.toPublicKey(); //  The public key of the zkApp
-  const zkAppAddressBase58 = zkAppAddress.toBase58();
 
   const verificationKey = await step(
     'Generate verification key (takes 1-2 min)',
@@ -237,13 +236,13 @@ async function deploy({ network, yes }) {
   fee = `${Number(fee) * 1e9}`; // in nanomina (1 billion = 1.0 mina)
 
   const graphQLEndpoint = config?.networks[network]?.url ?? DEFAULT_GRAPHQL;
+  const zkAppAddressBase58 = zkAppAddress.toBase58();
   const accountQuery = getAccountQuery(zkAppAddressBase58);
   const accountResponse = await sendGraphQL(graphQLEndpoint, accountQuery);
 
   let nonce = 0;
   if (!accountResponse?.data?.account) {
     // No account is found, show an error message and return early
-    console.log(accountResponse);
     log(
       red(
         `  Failed to find the specified account in the ledger using the specified URL.\n  Please make sure the account "${zkAppAddressBase58}" has previously been funded.`
@@ -252,7 +251,7 @@ async function deploy({ network, yes }) {
     await shutdown();
     return;
   } else if (!yes && !accountResponse?.data?.account?.nonce) {
-    // If running in interactive mode and no account is found, ask for the user's input, show an error message and return early
+    // If running in interactive mode and no account is found, ask for the user's input
     let nonceResponse = await prompt({
       type: 'input',
       name: 'nonce',
@@ -506,7 +505,7 @@ function getErrorMessage(errors) {
     '  Failed to send transaction to relayer. Please try again.';
   for (const error of errors) {
     if (error.message.includes('Invalid_nonce')) {
-      errorMessage = `  Failed to send transaction to the relayer. An invalid nonce value of was specified. Please try again.`;
+      errorMessage = `  Failed to send transaction to the relayer. An invalid account nonce was specified. Please try again.`;
       break;
     }
   }

--- a/src/lib/deploy.js
+++ b/src/lib/deploy.js
@@ -245,7 +245,7 @@ async function deploy({ network, yes }) {
     // No account is found, show an error message and return early
     log(
       red(
-        `  Failed to find the specified account in the ledger using the specified URL.\n  Please make sure the account "${zkAppAddressBase58}" has previously been funded.`
+        `  Failed to find the fee payer's account on chain.\n Please make sure the account "${zkAppAddressBase58}" has previously been funded.`
       )
     );
     await shutdown();


### PR DESCRIPTION
**Description**
This PR handles several different UX issues.

1. If there was an error submitting a deploy mutation, there was inconsistent error handling which made it so that it would show a success message with an undefined deploy hash value. This has been fixed by fixing the error handling case when submitting the mutation.
2. If the user tries to deploy their zkApp without their account being funded, it will not be in the ledger and fetching account info will fail. This has been fixed by providing better error messages to indicate what failed and how the user can fix it.
3. If the user specifies an invalid nonce value, show a better error message as a failure reason.

Related to this Discord discussion: https://discordapp.com/channels/484437221055922177/915745847692636181/976178836284776498

![image](https://user-images.githubusercontent.com/9512405/168891370-5e40fecb-f45c-4254-8429-58a4263b5768.png)

![image](https://user-images.githubusercontent.com/9512405/168891275-444c9048-272b-4698-b8dc-d8a1921ebd8f.png)
