### PR TITLE
Query node status and report if not stable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zkapp-cli",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "zkapp-cli",
-      "version": "0.3.3",
+      "version": "0.3.4",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zkapp-cli",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "CLI to create a zkApp (\"zero-knowledge app\") for Mina Protocol.",
   "keywords": [
     "cli",


### PR DESCRIPTION
**Description**

Check the specified URL for the node status before deploying. If the node is completely offline or gives a bad response, we return early. If the node is in either `CONNECTING`, `BOOTSTRAP`, or `CATCHUP`, we also report an error and return early.

**Tested By**
Manual testing.