### PR TITLE
Remove manual nonce request from user

### DIFF
--- a/src/lib/deploy.js
+++ b/src/lib/deploy.js
@@ -275,26 +275,6 @@ async function deploy({ network, yes }) {
     );
     await shutdown();
     return;
-  } else if (!yes && !accountResponse?.data?.account?.nonce) {
-    // If running in interactive mode and no account is found, ask for the user's input
-    let nonceResponse = await prompt({
-      type: 'input',
-      name: 'nonce',
-      message: (state) => {
-        const style = state.submitted && !state.cancelled ? green : reset;
-        return style(
-          'Could not find account nonce. Please confirm the nonce of the account:'
-        );
-      },
-      validate: (val) => {
-        if (!val) return red('Nonce is required.');
-        if (isNaN(val)) return red('Nonce must be a number.');
-        if (val < 0) return red("Nonce can't be negative.");
-        return true;
-      },
-      result: (val) => val.trim().replace(/ /, ''),
-    });
-    nonce = Number(nonceResponse.nonce);
   } else {
     // Account nonce value is found from the network
     nonce = Number(accountResponse.data.account.nonce);
@@ -519,7 +499,6 @@ function getAccountQuery(publicKey) {
   return `
   query {
     account(publicKey: "${publicKey}") {
-      publicKey
       nonce
     }
   }`;


### PR DESCRIPTION
**Description**
Removes the nonce request from the user when the cli cannot find the specified account information. It was noted that asking for a manual nonce value doesn't really make sense in the situation since if we cannot find the account information on the network, deploying with the same endpoint probably won't work. 

To make the code simpler in the cli, we can remove this check and always assume we will get the account information from the specified network graphql endpoint.