### PR TITLE
Add Tests to tictactoe example

### DIFF
--- a/examples/tictactoe/ts/src/index.ts
+++ b/examples/tictactoe/ts/src/index.ts
@@ -1,6 +1,6 @@
 /**
  * This file specifies how to run the `TicTacToe` smart contract locally using the `Mina.LocalBlockchain()` method.
- * The `Mina.LocalBlockchain()` method specifes a ledger of accounts and contains logic for updating the ledger.
+ * The `Mina.LocalBlockchain()` method specifies a ledger of accounts and contains logic for updating the ledger.
  *
  * Please note that this deployment is local and does not deploy to a live network.
  * If you wish to deploy to a live network, please use the zkapp-cli to deploy.

--- a/examples/tictactoe/ts/src/index.ts
+++ b/examples/tictactoe/ts/src/index.ts
@@ -10,40 +10,26 @@
  * Run with node:     `$ node build/src/index.js`.
  */
 
-import {
-  Field,
-  PrivateKey,
-  Mina,
-  Party,
-  shutdown,
-  Signature,
-  isReady,
-} from 'snarkyjs';
+import { Field, PrivateKey, Mina, shutdown, isReady } from 'snarkyjs';
+import { createLocalBlockchain, makeMove, deploy } from './tictactoe-lib.js';
 import { TicTacToe, Board } from './tictactoe.js';
 
-async function main() {
+async function playTicTacToe() {
   await isReady;
 
-  const Local = Mina.LocalBlockchain();
-  Mina.setActiveInstance(Local);
-
-  const player1 = Local.testAccounts[0].privateKey;
-  const player2 = Local.testAccounts[1].privateKey;
+  const accounts = createLocalBlockchain();
+  const player1 = accounts[0];
+  const player2 = accounts[1];
   const player1Public = player1.toPublicKey();
   const player2Public = player2.toPublicKey();
 
   const zkAppPrivkey = PrivateKey.random();
   const zkAppPubkey = zkAppPrivkey.toPublicKey();
+  let zkAppInstance = new TicTacToe(zkAppPubkey);
 
   // Create a new instance of the contract
   console.log('\n\n====== DEPLOYING ======\n\n');
-  let zkAppInstance = new TicTacToe(zkAppPubkey);
-
-  let txn = await Local.transaction(player1, () => {
-    Party.fundNewAccount(player1);
-    zkAppInstance.deploy({ zkappKey: zkAppPrivkey });
-  });
-  await txn.send().wait();
+  await deploy(zkAppInstance, zkAppPrivkey, player1);
 
   console.log('after transaction');
 
@@ -59,21 +45,15 @@ async function main() {
 
   // play
   console.log('\n\n====== FIRST MOVE ======\n\n');
-  txn = await Local.transaction(player1, async () => {
-    const x = Field.zero;
-    const y = Field.zero;
-    const signature = Signature.create(player1, [x, y]);
-    zkAppInstance.play(
-      player1Public,
-      signature,
-      Field.zero,
-      Field.zero,
-      player1Public,
-      player2Public
-    );
-    zkAppInstance.sign(zkAppPrivkey);
-  });
-  txn.send().wait();
+  await makeMove(
+    zkAppInstance,
+    zkAppPrivkey,
+    player1,
+    player1Public,
+    player2Public,
+    Field.zero,
+    Field.zero
+  );
 
   // debug
   b = await Mina.getAccount(zkAppPubkey);
@@ -81,66 +61,45 @@ async function main() {
 
   // play
   console.log('\n\n====== SECOND MOVE ======\n\n');
-  txn = await Local.transaction(player1, async () => {
-    const x = Field.one;
-    const y = Field.zero;
-    const signature = Signature.create(player2, [x, y]);
-    zkAppInstance.play(
-      player2Public,
-      signature,
-      Field.one,
-      Field.zero,
-      player1Public,
-      player2Public
-    );
-    zkAppInstance.sign(zkAppPrivkey);
-  });
-  txn.send().wait();
-
+  await makeMove(
+    zkAppInstance,
+    zkAppPrivkey,
+    player2,
+    player1Public,
+    player2Public,
+    Field.one,
+    Field.zero
+  );
   // debug
   b = await Mina.getAccount(zkAppPubkey);
   new Board(b.zkapp?.appState?.[0]!).printState();
 
   // play
   console.log('\n\n====== THIRD MOVE ======\n\n');
-  txn = await Local.transaction(player1, async () => {
-    const x = Field.one;
-    const y = Field.one;
-    const signature = Signature.create(player1, [x, y]);
-    zkAppInstance.play(
-      player1Public,
-      signature,
-      Field.one,
-      Field.one,
-      player1Public,
-      player2Public
-    );
-    zkAppInstance.sign(zkAppPrivkey);
-  });
-  txn.send().wait();
-
+  await makeMove(
+    zkAppInstance,
+    zkAppPrivkey,
+    player1,
+    player1Public,
+    player2Public,
+    Field.one,
+    Field.one
+  );
   // debug
   b = await Mina.getAccount(zkAppPubkey);
   new Board(b.zkapp?.appState?.[0]!).printState();
 
   // play
   console.log('\n\n====== FOURTH MOVE ======\n\n');
-  const two = new Field(2);
-  txn = await Local.transaction(player2, async () => {
-    const x = two;
-    const y = Field.one;
-    const signature = Signature.create(player2, [x, y]);
-    zkAppInstance.play(
-      player2Public,
-      signature,
-      two,
-      Field.one,
-      player1Public,
-      player2Public
-    );
-    zkAppInstance.sign(zkAppPrivkey);
-  });
-  await txn.send().wait();
+  await makeMove(
+    zkAppInstance,
+    zkAppPrivkey,
+    player2,
+    player1Public,
+    player2Public,
+    Field(2),
+    Field.one
+  );
 
   // debug
   b = await Mina.getAccount(zkAppPubkey);
@@ -148,21 +107,15 @@ async function main() {
 
   // play
   console.log('\n\n====== FIFTH MOVE ======\n\n');
-  txn = await Local.transaction(player1, async () => {
-    const x = two;
-    const y = two;
-    const signature = Signature.create(player1, [x, y]);
-    zkAppInstance.play(
-      player1Public,
-      signature,
-      two,
-      two,
-      player1Public,
-      player2Public
-    );
-    zkAppInstance.sign(zkAppPrivkey);
-  });
-  await txn.send().wait();
+  await makeMove(
+    zkAppInstance,
+    zkAppPrivkey,
+    player1,
+    player1Public,
+    player2Public,
+    Field(2),
+    Field(2)
+  );
 
   // debug
   b = await Mina.getAccount(zkAppPubkey);
@@ -176,4 +129,4 @@ async function main() {
   await shutdown();
 }
 
-main();
+playTicTacToe();

--- a/examples/tictactoe/ts/src/index.ts
+++ b/examples/tictactoe/ts/src/index.ts
@@ -13,7 +13,6 @@
 import {
   Field,
   PrivateKey,
-  Bool,
   Mina,
   Party,
   shutdown,
@@ -73,7 +72,6 @@ async function main() {
       player2Public
     );
     zkAppInstance.sign(zkAppPrivkey);
-    zkAppInstance.self.body.incrementNonce = Bool(true);
   });
   txn.send().wait();
 
@@ -96,7 +94,6 @@ async function main() {
       player2Public
     );
     zkAppInstance.sign(zkAppPrivkey);
-    zkAppInstance.self.body.incrementNonce = Bool(true);
   });
   txn.send().wait();
 
@@ -119,7 +116,6 @@ async function main() {
       player2Public
     );
     zkAppInstance.sign(zkAppPrivkey);
-    zkAppInstance.self.body.incrementNonce = Bool(true);
   });
   txn.send().wait();
 
@@ -143,7 +139,6 @@ async function main() {
       player2Public
     );
     zkAppInstance.sign(zkAppPrivkey);
-    zkAppInstance.self.body.incrementNonce = Bool(true);
   });
   await txn.send().wait();
 
@@ -166,7 +161,6 @@ async function main() {
       player2Public
     );
     zkAppInstance.sign(zkAppPrivkey);
-    zkAppInstance.self.body.incrementNonce = Bool(true);
   });
   await txn.send().wait();
 

--- a/examples/tictactoe/ts/src/index.ts
+++ b/examples/tictactoe/ts/src/index.ts
@@ -17,15 +17,13 @@ import { TicTacToe, Board } from './tictactoe.js';
 async function playTicTacToe() {
   await isReady;
 
-  const accounts = createLocalBlockchain();
-  const player1 = accounts[0];
-  const player2 = accounts[1];
+  const [player1, player2] = createLocalBlockchain();
   const player1Public = player1.toPublicKey();
   const player2Public = player2.toPublicKey();
 
   const zkAppPrivkey = PrivateKey.random();
   const zkAppPubkey = zkAppPrivkey.toPublicKey();
-  let zkAppInstance = new TicTacToe(zkAppPubkey);
+  const zkAppInstance = new TicTacToe(zkAppPubkey);
 
   // Create a new instance of the contract
   console.log('\n\n====== DEPLOYING ======\n\n');

--- a/examples/tictactoe/ts/src/tictactoe-lib.ts
+++ b/examples/tictactoe/ts/src/tictactoe-lib.ts
@@ -1,0 +1,45 @@
+import { Field, PrivateKey, PublicKey, Mina, Party, Signature } from 'snarkyjs';
+import { TicTacToe } from './tictactoe.js';
+
+export function createLocalBlockchain(): PrivateKey[] {
+  let Local = Mina.LocalBlockchain();
+  Mina.setActiveInstance(Local);
+  return [Local.testAccounts[0].privateKey, Local.testAccounts[1].privateKey];
+}
+
+export async function deploy(
+  zkAppInstance: TicTacToe,
+  zkAppPrivkey: PrivateKey,
+  deployer: PrivateKey
+) {
+  const txn = await Mina.transaction(deployer, () => {
+    Party.fundNewAccount(deployer);
+    zkAppInstance.deploy({ zkappKey: zkAppPrivkey });
+    zkAppInstance.init();
+  });
+  await txn.send().wait();
+}
+
+export async function makeMove(
+  zkAppInstance: TicTacToe,
+  zkAppPrivkey: PrivateKey,
+  currentPlayer: PrivateKey,
+  player1Public: PublicKey,
+  player2Public: PublicKey,
+  x: Field,
+  y: Field
+) {
+  const txn = await Mina.transaction(currentPlayer, async () => {
+    const signature = Signature.create(currentPlayer, [x, y]);
+    zkAppInstance.play(
+      currentPlayer.toPublicKey(),
+      signature,
+      x,
+      y,
+      player1Public,
+      player2Public
+    );
+    zkAppInstance.sign(zkAppPrivkey);
+  });
+  await txn.send().wait();
+}

--- a/examples/tictactoe/ts/src/tictactoe.test.ts
+++ b/examples/tictactoe/ts/src/tictactoe.test.ts
@@ -1,0 +1,57 @@
+import { TicTacToe } from './tictactoe';
+import { createLocalBlockchain, makeMove, deploy } from './tictactoe-lib';
+import {
+  isReady,
+  shutdown,
+  Field,
+  Bool,
+  PrivateKey,
+  PublicKey,
+} from 'snarkyjs';
+
+describe('tictactoe', () => {
+  let player1: PrivateKey,
+    player2: PrivateKey,
+    zkAppAddress: PublicKey,
+    zkAppPrivateKey: PrivateKey;
+
+  beforeEach(async () => {
+    await isReady;
+    const players = createLocalBlockchain();
+    player1 = players[0];
+    player2 = players[1];
+
+    zkAppPrivateKey = PrivateKey.random();
+    zkAppAddress = zkAppPrivateKey.toPublicKey();
+    return;
+  });
+
+  afterAll(async () => {
+    setTimeout(shutdown, 0);
+  });
+
+  it('generates and deploys tictactoe', async () => {
+    const zkAppInstance = new TicTacToe(zkAppAddress);
+    await deploy(zkAppInstance, zkAppPrivateKey, player1);
+
+    const board = zkAppInstance.board.get();
+    expect(board).toEqual(Field.zero);
+  });
+
+  it('accepts a correct move', async () => {
+    const zkAppInstance = new TicTacToe(zkAppAddress);
+    await deploy(zkAppInstance, zkAppPrivateKey, player1);
+    await makeMove(
+      zkAppInstance,
+      zkAppPrivateKey,
+      player1,
+      player1.toPublicKey(),
+      player2.toPublicKey(),
+      Field.zero,
+      Field.zero
+    );
+
+    const nextPlayer = zkAppInstance.nextPlayer.get();
+    expect(nextPlayer).toEqual(Bool(true));
+  });
+});

--- a/examples/tictactoe/ts/src/tictactoe.test.ts
+++ b/examples/tictactoe/ts/src/tictactoe.test.ts
@@ -17,10 +17,7 @@ describe('tictactoe', () => {
 
   beforeEach(async () => {
     await isReady;
-    const players = createLocalBlockchain();
-    player1 = players[0];
-    player2 = players[1];
-
+    [player1, player2] = createLocalBlockchain();
     zkAppPrivateKey = PrivateKey.random();
     zkAppAddress = zkAppPrivateKey.toPublicKey();
     return;

--- a/examples/tictactoe/ts/src/tictactoe.ts
+++ b/examples/tictactoe/ts/src/tictactoe.ts
@@ -148,6 +148,9 @@ export class TicTacToe extends SmartContract {
       ...Permissions.default(),
       editState: Permissions.proofOrSignature(),
     });
+  }
+
+  @method init() {
     this.board.set(Field.zero);
     this.nextPlayer.set(new Bool(false)); // player 1 starts
     this.gameDone.set(new Bool(false));

--- a/examples/tictactoe/ts/src/tictactoe.ts
+++ b/examples/tictactoe/ts/src/tictactoe.ts
@@ -9,11 +9,11 @@ import {
   SmartContract,
   state,
   method,
-  PrivateKey,
   Bool,
   Circuit,
   Signature,
   Permissions,
+  DeployArgs,
 } from 'snarkyjs';
 
 class Optional<T> {
@@ -142,7 +142,7 @@ export class TicTacToe extends SmartContract {
   // defaults to false, set to true when a player wins
   @state(Bool) gameDone = State<Bool>();
 
-  deploy(args: { zkappKey: PrivateKey }) {
+  deploy(args: DeployArgs) {
     super.deploy(args);
     this.self.update.permissions.setValue({
       ...Permissions.default(),


### PR DESCRIPTION
**Description**
This PR adds two different things for the `TicTacToe` example.

Firstly, it adds tests for the `TicTacToe` smart contract.
Secondly, applied some refactoring to make the smart contract more unit testable.

Separated out some common helper functions into `tictactoe-lib.ts` to make the functionality easier to test. Refactored `index.ts` to use these helper functions to make things shorter and easier to read. 

Additionally made the `deploy` function on the `TicTacToe` example not set any state and instead used an `init` method to do that. [See reasoning here.](https://github.com/o1-labs/zkapp-cli/pull/198#discussion_r885330941)

If users still want to run the example, they run `npm run build && node build/src/index.js`

**Tested By**
Running unit tests and deployed to Berkeley