### PR TITLE
Update tests to use local ledger and setting state in template project

### DIFF
--- a/templates/project-ts/src/index.ts
+++ b/templates/project-ts/src/index.ts
@@ -1,11 +1,11 @@
 import {
   Field,
-  PrivateKey,
   SmartContract,
   state,
   State,
   method,
   DeployArgs,
+  Permissions,
 } from 'snarkyjs';
 
 /**
@@ -18,9 +18,15 @@ import {
 export class Add extends SmartContract {
   @state(Field) num = State<Field>();
 
-  // initialization
   deploy(args: DeployArgs) {
     super.deploy(args);
+    this.setPermissions({
+      ...Permissions.default(),
+      editState: Permissions.proofOrSignature(),
+    });
+  }
+
+  @method init() {
     this.num.set(Field(1));
   }
 


### PR DESCRIPTION
**Description**

This PR adds better unit tests to the template zkapp project. It scaffolds using the local ledger and simulates updating the state in the local ledger. This will give users a much better starting point when they are messing around with the API.

This was also additionally done to make writing documentation for testing easier. As I was writing docs for methods for testing your smart contract, it felt weird that this sort of code wasn't already included.

**Tested By**
Updating and running the unit tests