### PR TITLE
Update snarkyjs & deploy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "mina-signer": "^1.1.0",
         "ora": "^5.4.1",
         "shelljs": "^0.8.5",
-        "snarkyjs": "^0.4.0",
+        "snarkyjs": "^0.4.1",
         "table": "^6.8.0",
         "yargs": "^17.5.1"
       },
@@ -5201,9 +5201,9 @@
       }
     },
     "node_modules/snarkyjs": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/snarkyjs/-/snarkyjs-0.4.0.tgz",
-      "integrity": "sha512-JvofYiZ/F4z4BFtnMEfZBJnzvzH3f1D5QFZuIbzbw3JZvNapMasT2uaplrYtJsSXIeK2LLEOocdC4jgjYOLTEg==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/snarkyjs/-/snarkyjs-0.4.1.tgz",
+      "integrity": "sha512-W6QiUU6BncOBKq8H1lTDNUbYsi1n6zGGKZCr734m7X5+1F35Fz9Ah25m1yQG0Mnc8BrmkmD9fG5Ju2M6aDRm+g==",
       "dependencies": {
         "env": "^0.0.2",
         "isomorphic-fetch": "^3.0.0",
@@ -9836,9 +9836,9 @@
       }
     },
     "snarkyjs": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/snarkyjs/-/snarkyjs-0.4.0.tgz",
-      "integrity": "sha512-JvofYiZ/F4z4BFtnMEfZBJnzvzH3f1D5QFZuIbzbw3JZvNapMasT2uaplrYtJsSXIeK2LLEOocdC4jgjYOLTEg==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/snarkyjs/-/snarkyjs-0.4.1.tgz",
+      "integrity": "sha512-W6QiUU6BncOBKq8H1lTDNUbYsi1n6zGGKZCr734m7X5+1F35Fz9Ah25m1yQG0Mnc8BrmkmD9fG5Ju2M6aDRm+g==",
       "requires": {
         "env": "^0.0.2",
         "isomorphic-fetch": "^3.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "mina-signer": "^1.1.0",
         "ora": "^5.4.1",
         "shelljs": "^0.8.5",
-        "snarkyjs": "^0.3.7",
+        "snarkyjs": "^0.4.0",
         "table": "^6.8.0",
         "yargs": "^17.5.1"
       },
@@ -5201,9 +5201,9 @@
       }
     },
     "node_modules/snarkyjs": {
-      "version": "0.3.7",
-      "resolved": "https://registry.npmjs.org/snarkyjs/-/snarkyjs-0.3.7.tgz",
-      "integrity": "sha512-RXng5Hqapx9bA8IG2eNzOHEnUtZyxDElm5eTt8w5CNpwWunRrI50vpyJ0bNqZ3wU734O147guaLyetZqruONRA==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/snarkyjs/-/snarkyjs-0.4.0.tgz",
+      "integrity": "sha512-JvofYiZ/F4z4BFtnMEfZBJnzvzH3f1D5QFZuIbzbw3JZvNapMasT2uaplrYtJsSXIeK2LLEOocdC4jgjYOLTEg==",
       "dependencies": {
         "env": "^0.0.2",
         "isomorphic-fetch": "^3.0.0",
@@ -9836,9 +9836,9 @@
       }
     },
     "snarkyjs": {
-      "version": "0.3.7",
-      "resolved": "https://registry.npmjs.org/snarkyjs/-/snarkyjs-0.3.7.tgz",
-      "integrity": "sha512-RXng5Hqapx9bA8IG2eNzOHEnUtZyxDElm5eTt8w5CNpwWunRrI50vpyJ0bNqZ3wU734O147guaLyetZqruONRA==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/snarkyjs/-/snarkyjs-0.4.0.tgz",
+      "integrity": "sha512-JvofYiZ/F4z4BFtnMEfZBJnzvzH3f1D5QFZuIbzbw3JZvNapMasT2uaplrYtJsSXIeK2LLEOocdC4jgjYOLTEg==",
       "requires": {
         "env": "^0.0.2",
         "isomorphic-fetch": "^3.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zkapp-cli",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "zkapp-cli",
-      "version": "0.3.6",
+      "version": "0.3.7",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zkapp-cli",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "zkapp-cli",
-      "version": "0.3.5",
+      "version": "0.3.6",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -15,14 +15,14 @@
         "envinfo": "^7.8.1",
         "fast-glob": "^3.2.11",
         "find-npm-prefix": "^1.0.2",
-        "fs-extra": "^10.0.0",
+        "fs-extra": "^10.1.0",
         "gittar": "^0.1.1",
         "mina-signer": "^1.1.0",
         "ora": "^5.4.1",
-        "shelljs": "^0.8.4",
-        "snarkyjs": "^0.3.3",
+        "shelljs": "^0.8.5",
+        "snarkyjs": "^0.3.7",
         "table": "^6.8.0",
-        "yargs": "^17.2.0"
+        "yargs": "^17.5.1"
       },
       "bin": {
         "zk": "src/bin/index.js",
@@ -30,15 +30,15 @@
         "zkapp-cli": "src/bin/index.js"
       },
       "devDependencies": {
-        "@types/jest": "^27.0.2",
-        "@typescript-eslint/eslint-plugin": "^5.5.0",
-        "@typescript-eslint/parser": "^5.5.0",
-        "eslint": "^8.7.0",
+        "@types/jest": "^27.5.1",
+        "@typescript-eslint/eslint-plugin": "^5.26.0",
+        "@typescript-eslint/parser": "^5.26.0",
+        "eslint": "^8.16.0",
         "husky": "^7.0.2",
         "jest": "^27.2.1",
         "lint-staged": "^11.1.2",
-        "prettier": "^2.4.1",
-        "typescript": "^4.4.3"
+        "prettier": "^2.6.2",
+        "typescript": "^4.7.2"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -5201,9 +5201,9 @@
       }
     },
     "node_modules/snarkyjs": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/snarkyjs/-/snarkyjs-0.3.4.tgz",
-      "integrity": "sha512-91zUC/o4ncn4ZQT2h8IoZdel3QjTOXELHoSeDNFhIpbAYmcLoui0A40VkiRvAEJ9tE/jhfZkbPShQRUWuyFIcA==",
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/snarkyjs/-/snarkyjs-0.3.7.tgz",
+      "integrity": "sha512-RXng5Hqapx9bA8IG2eNzOHEnUtZyxDElm5eTt8w5CNpwWunRrI50vpyJ0bNqZ3wU734O147guaLyetZqruONRA==",
       "dependencies": {
         "env": "^0.0.2",
         "isomorphic-fetch": "^3.0.0",
@@ -9836,9 +9836,9 @@
       }
     },
     "snarkyjs": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/snarkyjs/-/snarkyjs-0.3.4.tgz",
-      "integrity": "sha512-91zUC/o4ncn4ZQT2h8IoZdel3QjTOXELHoSeDNFhIpbAYmcLoui0A40VkiRvAEJ9tE/jhfZkbPShQRUWuyFIcA==",
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/snarkyjs/-/snarkyjs-0.3.7.tgz",
+      "integrity": "sha512-RXng5Hqapx9bA8IG2eNzOHEnUtZyxDElm5eTt8w5CNpwWunRrI50vpyJ0bNqZ3wU734O147guaLyetZqruONRA==",
       "requires": {
         "env": "^0.0.2",
         "isomorphic-fetch": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zkapp-cli",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "CLI to create a zkApp (\"zero-knowledge app\") for Mina Protocol.",
   "keywords": [
     "cli",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "mina-signer": "^1.1.0",
     "ora": "^5.4.1",
     "shelljs": "^0.8.5",
-    "snarkyjs": "^0.4.0",
+    "snarkyjs": "^0.4.1",
     "table": "^6.8.0",
     "yargs": "^17.5.1"
   },

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "mina-signer": "^1.1.0",
     "ora": "^5.4.1",
     "shelljs": "^0.8.5",
-    "snarkyjs": "^0.3.3",
+    "snarkyjs": "^0.3.7",
     "table": "^6.8.0",
     "yargs": "^17.5.1"
   },

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "mina-signer": "^1.1.0",
     "ora": "^5.4.1",
     "shelljs": "^0.8.5",
-    "snarkyjs": "^0.3.7",
+    "snarkyjs": "^0.4.0",
     "table": "^6.8.0",
     "yargs": "^17.5.1"
   },

--- a/templates/project-ts/package-lock.json
+++ b/templates/project-ts/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.5",
       "license": "Apache-2.0",
       "dependencies": {
-        "snarkyjs": "^0.4.0"
+        "snarkyjs": "^0.4.1"
       },
       "devDependencies": {
         "@babel/preset-env": "^7.16.4",
@@ -7929,9 +7929,9 @@
       "dev": true
     },
     "node_modules/snarkyjs": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/snarkyjs/-/snarkyjs-0.4.0.tgz",
-      "integrity": "sha512-JvofYiZ/F4z4BFtnMEfZBJnzvzH3f1D5QFZuIbzbw3JZvNapMasT2uaplrYtJsSXIeK2LLEOocdC4jgjYOLTEg==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/snarkyjs/-/snarkyjs-0.4.1.tgz",
+      "integrity": "sha512-W6QiUU6BncOBKq8H1lTDNUbYsi1n6zGGKZCr734m7X5+1F35Fz9Ah25m1yQG0Mnc8BrmkmD9fG5Ju2M6aDRm+g==",
       "dependencies": {
         "env": "^0.0.2",
         "isomorphic-fetch": "^3.0.0",
@@ -14577,9 +14577,9 @@
       }
     },
     "snarkyjs": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/snarkyjs/-/snarkyjs-0.4.0.tgz",
-      "integrity": "sha512-JvofYiZ/F4z4BFtnMEfZBJnzvzH3f1D5QFZuIbzbw3JZvNapMasT2uaplrYtJsSXIeK2LLEOocdC4jgjYOLTEg==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/snarkyjs/-/snarkyjs-0.4.1.tgz",
+      "integrity": "sha512-W6QiUU6BncOBKq8H1lTDNUbYsi1n6zGGKZCr734m7X5+1F35Fz9Ah25m1yQG0Mnc8BrmkmD9fG5Ju2M6aDRm+g==",
       "requires": {
         "env": "^0.0.2",
         "isomorphic-fetch": "^3.0.0",

--- a/templates/project-ts/package-lock.json
+++ b/templates/project-ts/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.5",
       "license": "Apache-2.0",
       "dependencies": {
-        "snarkyjs": "^0.3.3"
+        "snarkyjs": "^0.3.7"
       },
       "devDependencies": {
         "@babel/preset-env": "^7.16.4",
@@ -24,7 +24,7 @@
         "lint-staged": "^11.0.1",
         "prettier": "^2.3.2",
         "ts-jest": "^27.0.7",
-        "typescript": "^4.5.2"
+        "typescript": "^4.7.2"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -7929,9 +7929,9 @@
       "dev": true
     },
     "node_modules/snarkyjs": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/snarkyjs/-/snarkyjs-0.3.3.tgz",
-      "integrity": "sha512-qOJFAQv5EktQEvx2cP42lb/MeKOjON16benaYrhvsEL+JFlbKskTiHbQKjcG3RM6pZ+dWth7WMfNMzTSxGHYag==",
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/snarkyjs/-/snarkyjs-0.3.7.tgz",
+      "integrity": "sha512-RXng5Hqapx9bA8IG2eNzOHEnUtZyxDElm5eTt8w5CNpwWunRrI50vpyJ0bNqZ3wU734O147guaLyetZqruONRA==",
       "dependencies": {
         "env": "^0.0.2",
         "isomorphic-fetch": "^3.0.0",
@@ -8379,9 +8379,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.5.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.3.tgz",
-      "integrity": "sha512-eVYaEHALSt+s9LbvgEv4Ef+Tdq7hBiIZgii12xXJnukryt3pMgJf6aKhoCZ3FWQsu6sydEnkg11fYXLzhLBjeQ==",
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.2.tgz",
+      "integrity": "sha512-Mamb1iX2FDUpcTRzltPxgWMKy3fhg0TN378ylbktPGPK/99KbDtMQ4W1hwgsbPAsG3a0xKa1vmw4VKZQbkvz5A==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -14577,9 +14577,9 @@
       }
     },
     "snarkyjs": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/snarkyjs/-/snarkyjs-0.3.3.tgz",
-      "integrity": "sha512-qOJFAQv5EktQEvx2cP42lb/MeKOjON16benaYrhvsEL+JFlbKskTiHbQKjcG3RM6pZ+dWth7WMfNMzTSxGHYag==",
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/snarkyjs/-/snarkyjs-0.3.7.tgz",
+      "integrity": "sha512-RXng5Hqapx9bA8IG2eNzOHEnUtZyxDElm5eTt8w5CNpwWunRrI50vpyJ0bNqZ3wU734O147guaLyetZqruONRA==",
       "requires": {
         "env": "^0.0.2",
         "isomorphic-fetch": "^3.0.0",
@@ -14909,9 +14909,9 @@
       }
     },
     "typescript": {
-      "version": "4.5.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.3.tgz",
-      "integrity": "sha512-eVYaEHALSt+s9LbvgEv4Ef+Tdq7hBiIZgii12xXJnukryt3pMgJf6aKhoCZ3FWQsu6sydEnkg11fYXLzhLBjeQ==",
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.2.tgz",
+      "integrity": "sha512-Mamb1iX2FDUpcTRzltPxgWMKy3fhg0TN378ylbktPGPK/99KbDtMQ4W1hwgsbPAsG3a0xKa1vmw4VKZQbkvz5A==",
       "dev": true
     },
     "unicode-canonical-property-names-ecmascript": {

--- a/templates/project-ts/package-lock.json
+++ b/templates/project-ts/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.5",
       "license": "Apache-2.0",
       "dependencies": {
-        "snarkyjs": "^0.3.7"
+        "snarkyjs": "^0.4.0"
       },
       "devDependencies": {
         "@babel/preset-env": "^7.16.4",
@@ -7929,9 +7929,9 @@
       "dev": true
     },
     "node_modules/snarkyjs": {
-      "version": "0.3.7",
-      "resolved": "https://registry.npmjs.org/snarkyjs/-/snarkyjs-0.3.7.tgz",
-      "integrity": "sha512-RXng5Hqapx9bA8IG2eNzOHEnUtZyxDElm5eTt8w5CNpwWunRrI50vpyJ0bNqZ3wU734O147guaLyetZqruONRA==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/snarkyjs/-/snarkyjs-0.4.0.tgz",
+      "integrity": "sha512-JvofYiZ/F4z4BFtnMEfZBJnzvzH3f1D5QFZuIbzbw3JZvNapMasT2uaplrYtJsSXIeK2LLEOocdC4jgjYOLTEg==",
       "dependencies": {
         "env": "^0.0.2",
         "isomorphic-fetch": "^3.0.0",
@@ -14577,9 +14577,9 @@
       }
     },
     "snarkyjs": {
-      "version": "0.3.7",
-      "resolved": "https://registry.npmjs.org/snarkyjs/-/snarkyjs-0.3.7.tgz",
-      "integrity": "sha512-RXng5Hqapx9bA8IG2eNzOHEnUtZyxDElm5eTt8w5CNpwWunRrI50vpyJ0bNqZ3wU734O147guaLyetZqruONRA==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/snarkyjs/-/snarkyjs-0.4.0.tgz",
+      "integrity": "sha512-JvofYiZ/F4z4BFtnMEfZBJnzvzH3f1D5QFZuIbzbw3JZvNapMasT2uaplrYtJsSXIeK2LLEOocdC4jgjYOLTEg==",
       "requires": {
         "env": "^0.0.2",
         "isomorphic-fetch": "^3.0.0",

--- a/templates/project-ts/package.json
+++ b/templates/project-ts/package.json
@@ -29,7 +29,7 @@
     ]
   },
   "dependencies": {
-    "snarkyjs": "^0.3.3"
+    "snarkyjs": "^0.3.7"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.16.4",
@@ -44,6 +44,6 @@
     "lint-staged": "^11.0.1",
     "prettier": "^2.3.2",
     "ts-jest": "^27.0.7",
-    "typescript": "^4.5.2"
+    "typescript": "^4.7.2"
   }
 }

--- a/templates/project-ts/package.json
+++ b/templates/project-ts/package.json
@@ -29,7 +29,7 @@
     ]
   },
   "dependencies": {
-    "snarkyjs": "^0.4.0"
+    "snarkyjs": "^0.4.1"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.16.4",

--- a/templates/project-ts/package.json
+++ b/templates/project-ts/package.json
@@ -29,7 +29,7 @@
     ]
   },
   "dependencies": {
-    "snarkyjs": "^0.3.7"
+    "snarkyjs": "^0.4.0"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.16.4",


### PR DESCRIPTION
this updates snarkyjs and typescript, fixes the deploy command, and tweaks the error output when the graphql endpoint returns an error, to show the actual output instead of demanding to "try again"
