### PR TITLE
Remove node_modules from examples/templates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
           cd templates/project-ts
           npm ci || true
           npm run test
+          rm -rf node_modules
         env:
           CI: true
       - name: Publish to NPM if version has changed


### PR DESCRIPTION
**Description**
The `node_modules` for the template zkApp was being included in the build for our npm package. This makes our unpacked size `206 MB` at the moment! https://www.npmjs.com/package/zkapp-cli/v/0.3.7

After running the tests in CI, we delete the node_modules manually