### PR TITLE
Add SnarkyJS as a peer dependency in project and example templates

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zkapp-cli",
-  "version": "0.4.8",
+  "version": "0.4.9",
   "description": "CLI to create a zkApp (\"zero-knowledge app\") for Mina Protocol.",
   "keywords": [
     "cli",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zkapp-cli",
-  "version": "0.4.10",
+  "version": "0.4.11",
   "description": "CLI to create a zkApp (\"zero-knowledge app\") for Mina Protocol.",
   "keywords": [
     "cli",

--- a/templates/project-ts/package.json
+++ b/templates/project-ts/package.json
@@ -44,6 +44,6 @@
     "typescript": "^4.7.2"
   },
   "peerDependencies": {
-    "snarkyjs": "^0.4.1"
+    "snarkyjs": "^0.4.4"
   }
 }

--- a/templates/project-ts/package.json
+++ b/templates/project-ts/package.json
@@ -28,9 +28,7 @@
       "prettier --write --ignore-unknown"
     ]
   },
-  "dependencies": {
-    "snarkyjs": "^0.4.1"
-  },
+
   "devDependencies": {
     "@babel/preset-env": "^7.16.4",
     "@babel/preset-typescript": "^7.16.0",
@@ -45,5 +43,8 @@
     "prettier": "^2.3.2",
     "ts-jest": "^27.0.7",
     "typescript": "^4.7.2"
+  },
+  "peerDependencies": {
+    "snarkyjs": "^0.4.1"
   }
 }


### PR DESCRIPTION
**Description**
Fixes #222

Add SnarkyJS as a peer dependency on CLI project and example templates. 

Tested

Used this version of the CLI to successfully create new template and example projects that have SnarkyJS as a peer dependency. 