### PR TITLE
Update tsconfig to allow extending CircuitValue without a constructor

### DIFF
--- a/templates/project-ts/tsconfig.json
+++ b/templates/project-ts/tsconfig.json
@@ -6,6 +6,7 @@
     "outDir": "./build",
     "rootDir": ".",
     "strict": true,
+    "strictPropertyInitialization": false, // to enable generic constructors, e.g. on CircuitValue
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "esModuleInterop": true,


### PR DESCRIPTION
**Description**
Addresses #228 

Adds a tsconfig option to avoid errors when not using a constructor on classes that extends CircuitValue.
