### PR TITLE
Update template and examples with preconditions and new CircuitValue improvements [Do Not Merge Until New Published Version of SnarkyJS is Added] 

### DIFF
--- a/examples/sudoku/ts/src/sudoku.ts
+++ b/examples/sudoku/ts/src/sudoku.ts
@@ -23,8 +23,9 @@ await isReady;
 class Sudoku extends CircuitValue {
   @matrixProp(Field, 9, 9) value: Field[][];
 
-  static from(value: number[][]) {
-    return new Sudoku(value.map((row) => row.map(Field)));
+  constructor(value: number[][]) {
+    super();
+    this.value = value.map((row) => row.map(Field));
   }
 
   hash() {
@@ -116,8 +117,8 @@ async function deploy(
 ) {
   let tx = await Mina.transaction(account, () => {
     Party.fundNewAccount(account);
-    
-    let sudokuInstance = Sudoku.from(sudoku);
+
+    let sudokuInstance = new Sudoku(sudoku);
     zkAppInstance.deploy({ zkappKey: zkAppPrivateKey });
     zkAppInstance.setPermissions({
       ...Permissions.default(),
@@ -138,7 +139,7 @@ async function submitSolution(
 ) {
   let tx = await Mina.transaction(account, () => {
     let zkApp = new SudokuZkApp(zkAppAddress);
-    zkApp.submitSolution(Sudoku.from(sudoku), Sudoku.from(solution));
+    zkApp.submitSolution(new Sudoku(sudoku), new Sudoku(solution));
     zkApp.sign(zkAppPrivateKey);
   });
   try {

--- a/examples/sudoku/ts/src/sudoku.ts
+++ b/examples/sudoku/ts/src/sudoku.ts
@@ -116,7 +116,8 @@ async function deploy(
 ) {
   let tx = await Mina.transaction(account, () => {
     Party.fundNewAccount(account);
-    let sudokuInstance = new Sudoku(sudoku);
+    
+    let sudokuInstance = Sudoku.from(sudoku);
     zkAppInstance.deploy({ zkappKey: zkAppPrivateKey });
     zkAppInstance.setPermissions({
       ...Permissions.default(),
@@ -137,7 +138,7 @@ async function submitSolution(
 ) {
   let tx = await Mina.transaction(account, () => {
     let zkApp = new SudokuZkApp(zkAppAddress);
-    zkApp.submitSolution(new Sudoku(sudoku), new Sudoku(solution));
+    zkApp.submitSolution(Sudoku.from(sudoku), Sudoku.from(solution));
     zkApp.sign(zkAppPrivateKey);
   });
   try {

--- a/examples/sudoku/ts/src/sudoku.ts
+++ b/examples/sudoku/ts/src/sudoku.ts
@@ -23,9 +23,8 @@ await isReady;
 class Sudoku extends CircuitValue {
   @matrixProp(Field, 9, 9) value: Field[][];
 
-  constructor(value: number[][]) {
-    super();
-    this.value = value.map((row) => row.map(Field));
+  static from(value: number[][]) {
+    return new Sudoku(value.map((row) => row.map(Field)));
   }
 
   hash() {

--- a/examples/sudoku/ts/src/sudoku.ts
+++ b/examples/sudoku/ts/src/sudoku.ts
@@ -92,6 +92,7 @@ export class SudokuZkApp extends SmartContract {
 
     // finally, we check that the sudoku is the one that was originally deployed
     let sudokuHash = this.sudokuHash.get(); // get the hash from the blockchain
+    this.sudokuHash.assertEquals(sudokuHash); // precondition that links this.sudokuHash.get() to the actual on-chain state
     sudokuInstance.hash().assertEquals(sudokuHash);
 
     // all checks passed => the sudoku is solved!

--- a/examples/tictactoe/ts/src/run.ts
+++ b/examples/tictactoe/ts/src/run.ts
@@ -33,13 +33,14 @@ async function playTicTacToe() {
 
   // initial state
   let b = await Mina.getAccount(zkAppPubkey);
+  console.log('b', b);
   console.log('initial state of the zkApp');
   for (const i in [0, 1, 2, 3, 4, 5, 6, 7]) {
-    console.log('state', i, ':', b.zkapp?.appState[i].toString());
+    console.log('state', i, ':', b.appState?.[i].toString());
   }
 
   console.log('\ninitial board');
-  new Board(b.zkapp?.appState?.[0]!).printState();
+  new Board(b.appState?.[0]!).printState();
 
   // play
   console.log('\n\n====== FIRST MOVE ======\n\n');
@@ -55,7 +56,7 @@ async function playTicTacToe() {
 
   // debug
   b = await Mina.getAccount(zkAppPubkey);
-  new Board(b.zkapp?.appState?.[0]!).printState();
+  new Board(b.appState?.[0]!).printState();
 
   // play
   console.log('\n\n====== SECOND MOVE ======\n\n');
@@ -70,7 +71,7 @@ async function playTicTacToe() {
   );
   // debug
   b = await Mina.getAccount(zkAppPubkey);
-  new Board(b.zkapp?.appState?.[0]!).printState();
+  new Board(b.appState?.[0]!).printState();
 
   // play
   console.log('\n\n====== THIRD MOVE ======\n\n');
@@ -85,7 +86,7 @@ async function playTicTacToe() {
   );
   // debug
   b = await Mina.getAccount(zkAppPubkey);
-  new Board(b.zkapp?.appState?.[0]!).printState();
+  new Board(b.appState?.[0]!).printState();
 
   // play
   console.log('\n\n====== FOURTH MOVE ======\n\n');
@@ -101,7 +102,7 @@ async function playTicTacToe() {
 
   // debug
   b = await Mina.getAccount(zkAppPubkey);
-  new Board(b.zkapp?.appState?.[0]!).printState();
+  new Board(b.appState?.[0]!).printState();
 
   // play
   console.log('\n\n====== FIFTH MOVE ======\n\n');
@@ -117,10 +118,10 @@ async function playTicTacToe() {
 
   // debug
   b = await Mina.getAccount(zkAppPubkey);
-  new Board(b.zkapp?.appState?.[0]!).printState();
+  new Board(b.appState?.[0]!).printState();
   console.log(
     'did someone win?',
-    b.zkapp?.appState[2].toString() ? 'Player 1!' : 'Player 2!'
+    b.appState?.[2].toString() ? 'Player 1!' : 'Player 2!'
   );
 
   // cleanup

--- a/examples/tictactoe/ts/src/tictactoe.ts
+++ b/examples/tictactoe/ts/src/tictactoe.ts
@@ -172,6 +172,7 @@ export class TicTacToe extends SmartContract {
   ) {
     // 1. if the game is already finished, abort.
     const finished = this.gameDone.get();
+    this.gameDone.assertEquals(finished); // precondition that links this.gameDone.get() to the actual on-chain state
     finished.assertEquals(false);
 
     // 2. ensure that we know the private key associated to the public key

--- a/examples/tictactoe/ts/src/tictactoe.ts
+++ b/examples/tictactoe/ts/src/tictactoe.ts
@@ -144,7 +144,7 @@ export class TicTacToe extends SmartContract {
 
   deploy(args: DeployArgs) {
     super.deploy(args);
-    this.self.update.permissions.setValue({
+    this.setPermissions({
       ...Permissions.default(),
       editState: Permissions.proofOrSignature(),
     });

--- a/examples/tictactoe/ts/src/tictactoe.ts
+++ b/examples/tictactoe/ts/src/tictactoe.ts
@@ -199,6 +199,7 @@ export class TicTacToe extends SmartContract {
     this.nextPlayer.set(player.not());
 
     // 4. get and deserialize the board
+    this.board.assertEquals(this.board.get()); // precondition that links this.board.get() to the actual on-chain state
     let board = new Board(this.board.get());
 
     // 5. update the board (and the state) with our move

--- a/examples/tictactoe/ts/src/tictactoe.ts
+++ b/examples/tictactoe/ts/src/tictactoe.ts
@@ -192,6 +192,7 @@ export class TicTacToe extends SmartContract {
 
     // ensure its their turn
     const nextPlayer = this.nextPlayer.get();
+    this.nextPlayer.assertEquals(nextPlayer); // precondition that links this.nextPlayer.get() to the actual on-chain state
     nextPlayer.assertEquals(player);
 
     // set the next player

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "@typescript-eslint/eslint-plugin": "^5.26.0",
         "@typescript-eslint/parser": "^5.26.0",
         "eslint": "^8.16.0",
+        "eslint-plugin-snarkyjs": "^0.3.0",
         "husky": "^7.0.2",
         "jest": "^27.2.1",
         "lint-staged": "^11.1.2",
@@ -645,9 +646,9 @@
       }
     },
     "node_modules/@humanwhocodes/config-array": {
-      "version": "0.9.5",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.9.5.tgz",
-      "integrity": "sha512-ObyMyWxZiCu/yTisA7uzx81s40xR2fD5Cg/2Kq7G02ajkNubJf6BopgDTmDyc3U7sXpNKM8cYOw7s7Tyr+DnCw==",
+      "version": "0.10.4",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.10.4.tgz",
+      "integrity": "sha512-mXAIHxZT3Vcpg83opl1wGlVZ9xydbfZO3r5YfRSH6Gpp2J/PfdBP0wbDa2sO6/qRbcalpoevVyW6A/fI6LfeMw==",
       "dev": true,
       "dependencies": {
         "@humanwhocodes/object-schema": "^1.2.1",
@@ -656,6 +657,16 @@
       },
       "engines": {
         "node": ">=10.10.0"
+      }
+    },
+    "node_modules/@humanwhocodes/gitignore-to-minimatch": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/gitignore-to-minimatch/-/gitignore-to-minimatch-1.0.2.tgz",
+      "integrity": "sha512-rSqmMJDdLFUsyxR6FMtD00nfQKKLFb1kv+qBbOVKqErvloEIJLo5bDTJTQNTYgeyp78JsA7u/NPi5jT1GR/MuA==",
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
       }
     },
     "node_modules/@humanwhocodes/object-schema": {
@@ -1196,14 +1207,14 @@
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "5.26.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.26.0.tgz",
-      "integrity": "sha512-oGCmo0PqnRZZndr+KwvvAUvD3kNE4AfyoGCwOZpoCncSh4MVD06JTE8XQa2u9u+NX5CsyZMBTEc2C72zx38eYA==",
+      "version": "5.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.33.0.tgz",
+      "integrity": "sha512-jHvZNSW2WZ31OPJ3enhLrEKvAZNyAFWZ6rx9tUwaessTc4sx9KmgMNhVcqVAl1ETnT5rU5fpXTLmY9YvC1DCNg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.26.0",
-        "@typescript-eslint/type-utils": "5.26.0",
-        "@typescript-eslint/utils": "5.26.0",
+        "@typescript-eslint/scope-manager": "5.33.0",
+        "@typescript-eslint/type-utils": "5.33.0",
+        "@typescript-eslint/utils": "5.33.0",
         "debug": "^4.3.4",
         "functional-red-black-tree": "^1.0.1",
         "ignore": "^5.2.0",
@@ -1229,14 +1240,14 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "5.26.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.26.0.tgz",
-      "integrity": "sha512-n/IzU87ttzIdnAH5vQ4BBDnLPly7rC5VnjN3m0xBG82HK6rhRxnCb3w/GyWbNDghPd+NktJqB/wl6+YkzZ5T5Q==",
+      "version": "5.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.33.0.tgz",
+      "integrity": "sha512-cgM5cJrWmrDV2KpvlcSkelTBASAs1mgqq+IUGKJvFxWrapHpaRy5EXPQz9YaKF3nZ8KY18ILTiVpUtbIac86/w==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.26.0",
-        "@typescript-eslint/types": "5.26.0",
-        "@typescript-eslint/typescript-estree": "5.26.0",
+        "@typescript-eslint/scope-manager": "5.33.0",
+        "@typescript-eslint/types": "5.33.0",
+        "@typescript-eslint/typescript-estree": "5.33.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -1256,13 +1267,13 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "5.26.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.26.0.tgz",
-      "integrity": "sha512-gVzTJUESuTwiju/7NiTb4c5oqod8xt5GhMbExKsCTp6adU3mya6AGJ4Pl9xC7x2DX9UYFsjImC0mA62BCY22Iw==",
+      "version": "5.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.33.0.tgz",
+      "integrity": "sha512-/Jta8yMNpXYpRDl8EwF/M8It2A9sFJTubDo0ATZefGXmOqlaBffEw0ZbkbQ7TNDK6q55NPHFshGBPAZvZkE8Pw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.26.0",
-        "@typescript-eslint/visitor-keys": "5.26.0"
+        "@typescript-eslint/types": "5.33.0",
+        "@typescript-eslint/visitor-keys": "5.33.0"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -1273,12 +1284,12 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "5.26.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.26.0.tgz",
-      "integrity": "sha512-7ccbUVWGLmcRDSA1+ADkDBl5fP87EJt0fnijsMFTVHXKGduYMgienC/i3QwoVhDADUAPoytgjbZbCOMj4TY55A==",
+      "version": "5.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.33.0.tgz",
+      "integrity": "sha512-2zB8uEn7hEH2pBeyk3NpzX1p3lF9dKrEbnXq1F7YkpZ6hlyqb2yZujqgRGqXgRBTHWIUG3NGx/WeZk224UKlIA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/utils": "5.26.0",
+        "@typescript-eslint/utils": "5.33.0",
         "debug": "^4.3.4",
         "tsutils": "^3.21.0"
       },
@@ -1299,9 +1310,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "5.26.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.26.0.tgz",
-      "integrity": "sha512-8794JZFE1RN4XaExLWLI2oSXsVImNkl79PzTOOWt9h0UHROwJedNOD2IJyfL0NbddFllcktGIO2aOu10avQQyA==",
+      "version": "5.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.33.0.tgz",
+      "integrity": "sha512-nIMt96JngB4MYFYXpZ/3ZNU4GWPNdBbcB5w2rDOCpXOVUkhtNlG2mmm8uXhubhidRZdwMaMBap7Uk8SZMU/ppw==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -1312,13 +1323,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "5.26.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.26.0.tgz",
-      "integrity": "sha512-EyGpw6eQDsfD6jIqmXP3rU5oHScZ51tL/cZgFbFBvWuCwrIptl+oueUZzSmLtxFuSOQ9vDcJIs+279gnJkfd1w==",
+      "version": "5.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.33.0.tgz",
+      "integrity": "sha512-tqq3MRLlggkJKJUrzM6wltk8NckKyyorCSGMq4eVkyL5sDYzJJcMgZATqmF8fLdsWrW7OjjIZ1m9v81vKcaqwQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.26.0",
-        "@typescript-eslint/visitor-keys": "5.26.0",
+        "@typescript-eslint/types": "5.33.0",
+        "@typescript-eslint/visitor-keys": "5.33.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -1339,15 +1350,15 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "5.26.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.26.0.tgz",
-      "integrity": "sha512-PJFwcTq2Pt4AMOKfe3zQOdez6InIDOjUJJD3v3LyEtxHGVVRK3Vo7Dd923t/4M9hSH2q2CLvcTdxlLPjcIk3eg==",
+      "version": "5.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.33.0.tgz",
+      "integrity": "sha512-JxOAnXt9oZjXLIiXb5ZIcZXiwVHCkqZgof0O8KPgz7C7y0HS42gi75PdPlqh1Tf109M0fyUw45Ao6JLo7S5AHw==",
       "dev": true,
       "dependencies": {
         "@types/json-schema": "^7.0.9",
-        "@typescript-eslint/scope-manager": "5.26.0",
-        "@typescript-eslint/types": "5.26.0",
-        "@typescript-eslint/typescript-estree": "5.26.0",
+        "@typescript-eslint/scope-manager": "5.33.0",
+        "@typescript-eslint/types": "5.33.0",
+        "@typescript-eslint/typescript-estree": "5.33.0",
         "eslint-scope": "^5.1.1",
         "eslint-utils": "^3.0.0"
       },
@@ -1363,12 +1374,12 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.26.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.26.0.tgz",
-      "integrity": "sha512-wei+ffqHanYDOQgg/fS6Hcar6wAWv0CUPQ3TZzOWd2BLfgP539rb49bwua8WRAs7R6kOSLn82rfEu2ro6Llt8Q==",
+      "version": "5.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.33.0.tgz",
+      "integrity": "sha512-/XsqCzD4t+Y9p5wd9HZiptuGKBlaZO5showwqODii5C0nZawxWLF+Q6k5wYHBrQv96h6GYKyqqMHCSTqta8Kiw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.26.0",
+        "@typescript-eslint/types": "5.33.0",
         "eslint-visitor-keys": "^3.3.0"
       },
       "engines": {
@@ -1386,9 +1397,9 @@
       "dev": true
     },
     "node_modules/acorn": {
-      "version": "8.7.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.1.tgz",
-      "integrity": "sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A==",
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
+      "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
       "dev": true,
       "bin": {
         "acorn": "bin/acorn"
@@ -2366,13 +2377,14 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.16.0.tgz",
-      "integrity": "sha512-MBndsoXY/PeVTDJeWsYj7kLZ5hQpJOfMYLsF6LicLHQWbRDG19lK5jOix4DPl8yY4SUFcE3txy86OzFLWT+yoA==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.21.0.tgz",
+      "integrity": "sha512-/XJ1+Qurf1T9G2M5IHrsjp+xrGT73RZf23xA1z5wB1ZzzEAWSZKvRwhWxTFp1rvkvCfwcvAUNAP31bhKTTGfDA==",
       "dev": true,
       "dependencies": {
         "@eslint/eslintrc": "^1.3.0",
-        "@humanwhocodes/config-array": "^0.9.2",
+        "@humanwhocodes/config-array": "^0.10.4",
+        "@humanwhocodes/gitignore-to-minimatch": "^1.0.2",
         "ajv": "^6.10.0",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.2",
@@ -2382,14 +2394,17 @@
         "eslint-scope": "^7.1.1",
         "eslint-utils": "^3.0.0",
         "eslint-visitor-keys": "^3.3.0",
-        "espree": "^9.3.2",
+        "espree": "^9.3.3",
         "esquery": "^1.4.0",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
         "file-entry-cache": "^6.0.1",
+        "find-up": "^5.0.0",
         "functional-red-black-tree": "^1.0.1",
         "glob-parent": "^6.0.1",
         "globals": "^13.15.0",
+        "globby": "^11.1.0",
+        "grapheme-splitter": "^1.0.4",
         "ignore": "^5.2.0",
         "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
@@ -2416,6 +2431,12 @@
       "funding": {
         "url": "https://opencollective.com/eslint"
       }
+    },
+    "node_modules/eslint-plugin-snarkyjs": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-snarkyjs/-/eslint-plugin-snarkyjs-0.3.0.tgz",
+      "integrity": "sha512-ncREhfSXrd+F2yp2e5en/WOYBHBGHNJY65JSYqi6Hc/UVyqkAS8tHnZ4tiPRb2cotewFfLhguLftkmYzUhpoEw==",
+      "dev": true
     },
     "node_modules/eslint-scope": {
       "version": "5.1.1",
@@ -2488,18 +2509,82 @@
         "node": ">=4.0"
       }
     },
-    "node_modules/espree": {
-      "version": "9.3.2",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-9.3.2.tgz",
-      "integrity": "sha512-D211tC7ZwouTIuY5x9XnS0E9sWNChB7IYKX/Xp5eQj3nFXhqmiUDB9q27y76oFl8jTg3pXcQx/bpxMfs3CIZbA==",
+    "node_modules/eslint/node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
       "dev": true,
       "dependencies": {
-        "acorn": "^8.7.1",
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/espree": {
+      "version": "9.3.3",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.3.3.tgz",
+      "integrity": "sha512-ORs1Rt/uQTqUKjDdGCyrtYxbazf5umATSf/K4qxjmZHORR6HJk+2s/2Pqe+Kk49HHINC/xNIrGfgh8sZcll0ng==",
+      "dev": true,
+      "dependencies": {
+        "acorn": "^8.8.0",
         "acorn-jsx": "^5.3.2",
         "eslint-visitor-keys": "^3.3.0"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/esprima": {
@@ -2933,6 +3018,12 @@
       "version": "4.2.10",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
       "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
+    },
+    "node_modules/grapheme-splitter": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
+      "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
+      "dev": true
     },
     "node_modules/has": {
       "version": "1.0.3",
@@ -5971,6 +6062,18 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     }
   },
   "dependencies": {
@@ -6434,15 +6537,21 @@
       }
     },
     "@humanwhocodes/config-array": {
-      "version": "0.9.5",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.9.5.tgz",
-      "integrity": "sha512-ObyMyWxZiCu/yTisA7uzx81s40xR2fD5Cg/2Kq7G02ajkNubJf6BopgDTmDyc3U7sXpNKM8cYOw7s7Tyr+DnCw==",
+      "version": "0.10.4",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.10.4.tgz",
+      "integrity": "sha512-mXAIHxZT3Vcpg83opl1wGlVZ9xydbfZO3r5YfRSH6Gpp2J/PfdBP0wbDa2sO6/qRbcalpoevVyW6A/fI6LfeMw==",
       "dev": true,
       "requires": {
         "@humanwhocodes/object-schema": "^1.2.1",
         "debug": "^4.1.1",
         "minimatch": "^3.0.4"
       }
+    },
+    "@humanwhocodes/gitignore-to-minimatch": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/gitignore-to-minimatch/-/gitignore-to-minimatch-1.0.2.tgz",
+      "integrity": "sha512-rSqmMJDdLFUsyxR6FMtD00nfQKKLFb1kv+qBbOVKqErvloEIJLo5bDTJTQNTYgeyp78JsA7u/NPi5jT1GR/MuA==",
+      "dev": true
     },
     "@humanwhocodes/object-schema": {
       "version": "1.2.1",
@@ -6902,14 +7011,14 @@
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "5.26.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.26.0.tgz",
-      "integrity": "sha512-oGCmo0PqnRZZndr+KwvvAUvD3kNE4AfyoGCwOZpoCncSh4MVD06JTE8XQa2u9u+NX5CsyZMBTEc2C72zx38eYA==",
+      "version": "5.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.33.0.tgz",
+      "integrity": "sha512-jHvZNSW2WZ31OPJ3enhLrEKvAZNyAFWZ6rx9tUwaessTc4sx9KmgMNhVcqVAl1ETnT5rU5fpXTLmY9YvC1DCNg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "5.26.0",
-        "@typescript-eslint/type-utils": "5.26.0",
-        "@typescript-eslint/utils": "5.26.0",
+        "@typescript-eslint/scope-manager": "5.33.0",
+        "@typescript-eslint/type-utils": "5.33.0",
+        "@typescript-eslint/utils": "5.33.0",
         "debug": "^4.3.4",
         "functional-red-black-tree": "^1.0.1",
         "ignore": "^5.2.0",
@@ -6919,52 +7028,52 @@
       }
     },
     "@typescript-eslint/parser": {
-      "version": "5.26.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.26.0.tgz",
-      "integrity": "sha512-n/IzU87ttzIdnAH5vQ4BBDnLPly7rC5VnjN3m0xBG82HK6rhRxnCb3w/GyWbNDghPd+NktJqB/wl6+YkzZ5T5Q==",
+      "version": "5.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.33.0.tgz",
+      "integrity": "sha512-cgM5cJrWmrDV2KpvlcSkelTBASAs1mgqq+IUGKJvFxWrapHpaRy5EXPQz9YaKF3nZ8KY18ILTiVpUtbIac86/w==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "5.26.0",
-        "@typescript-eslint/types": "5.26.0",
-        "@typescript-eslint/typescript-estree": "5.26.0",
+        "@typescript-eslint/scope-manager": "5.33.0",
+        "@typescript-eslint/types": "5.33.0",
+        "@typescript-eslint/typescript-estree": "5.33.0",
         "debug": "^4.3.4"
       }
     },
     "@typescript-eslint/scope-manager": {
-      "version": "5.26.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.26.0.tgz",
-      "integrity": "sha512-gVzTJUESuTwiju/7NiTb4c5oqod8xt5GhMbExKsCTp6adU3mya6AGJ4Pl9xC7x2DX9UYFsjImC0mA62BCY22Iw==",
+      "version": "5.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.33.0.tgz",
+      "integrity": "sha512-/Jta8yMNpXYpRDl8EwF/M8It2A9sFJTubDo0ATZefGXmOqlaBffEw0ZbkbQ7TNDK6q55NPHFshGBPAZvZkE8Pw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.26.0",
-        "@typescript-eslint/visitor-keys": "5.26.0"
+        "@typescript-eslint/types": "5.33.0",
+        "@typescript-eslint/visitor-keys": "5.33.0"
       }
     },
     "@typescript-eslint/type-utils": {
-      "version": "5.26.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.26.0.tgz",
-      "integrity": "sha512-7ccbUVWGLmcRDSA1+ADkDBl5fP87EJt0fnijsMFTVHXKGduYMgienC/i3QwoVhDADUAPoytgjbZbCOMj4TY55A==",
+      "version": "5.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.33.0.tgz",
+      "integrity": "sha512-2zB8uEn7hEH2pBeyk3NpzX1p3lF9dKrEbnXq1F7YkpZ6hlyqb2yZujqgRGqXgRBTHWIUG3NGx/WeZk224UKlIA==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/utils": "5.26.0",
+        "@typescript-eslint/utils": "5.33.0",
         "debug": "^4.3.4",
         "tsutils": "^3.21.0"
       }
     },
     "@typescript-eslint/types": {
-      "version": "5.26.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.26.0.tgz",
-      "integrity": "sha512-8794JZFE1RN4XaExLWLI2oSXsVImNkl79PzTOOWt9h0UHROwJedNOD2IJyfL0NbddFllcktGIO2aOu10avQQyA==",
+      "version": "5.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.33.0.tgz",
+      "integrity": "sha512-nIMt96JngB4MYFYXpZ/3ZNU4GWPNdBbcB5w2rDOCpXOVUkhtNlG2mmm8uXhubhidRZdwMaMBap7Uk8SZMU/ppw==",
       "dev": true
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "5.26.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.26.0.tgz",
-      "integrity": "sha512-EyGpw6eQDsfD6jIqmXP3rU5oHScZ51tL/cZgFbFBvWuCwrIptl+oueUZzSmLtxFuSOQ9vDcJIs+279gnJkfd1w==",
+      "version": "5.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.33.0.tgz",
+      "integrity": "sha512-tqq3MRLlggkJKJUrzM6wltk8NckKyyorCSGMq4eVkyL5sDYzJJcMgZATqmF8fLdsWrW7OjjIZ1m9v81vKcaqwQ==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.26.0",
-        "@typescript-eslint/visitor-keys": "5.26.0",
+        "@typescript-eslint/types": "5.33.0",
+        "@typescript-eslint/visitor-keys": "5.33.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -6973,26 +7082,26 @@
       }
     },
     "@typescript-eslint/utils": {
-      "version": "5.26.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.26.0.tgz",
-      "integrity": "sha512-PJFwcTq2Pt4AMOKfe3zQOdez6InIDOjUJJD3v3LyEtxHGVVRK3Vo7Dd923t/4M9hSH2q2CLvcTdxlLPjcIk3eg==",
+      "version": "5.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.33.0.tgz",
+      "integrity": "sha512-JxOAnXt9oZjXLIiXb5ZIcZXiwVHCkqZgof0O8KPgz7C7y0HS42gi75PdPlqh1Tf109M0fyUw45Ao6JLo7S5AHw==",
       "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.9",
-        "@typescript-eslint/scope-manager": "5.26.0",
-        "@typescript-eslint/types": "5.26.0",
-        "@typescript-eslint/typescript-estree": "5.26.0",
+        "@typescript-eslint/scope-manager": "5.33.0",
+        "@typescript-eslint/types": "5.33.0",
+        "@typescript-eslint/typescript-estree": "5.33.0",
         "eslint-scope": "^5.1.1",
         "eslint-utils": "^3.0.0"
       }
     },
     "@typescript-eslint/visitor-keys": {
-      "version": "5.26.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.26.0.tgz",
-      "integrity": "sha512-wei+ffqHanYDOQgg/fS6Hcar6wAWv0CUPQ3TZzOWd2BLfgP539rb49bwua8WRAs7R6kOSLn82rfEu2ro6Llt8Q==",
+      "version": "5.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.33.0.tgz",
+      "integrity": "sha512-/XsqCzD4t+Y9p5wd9HZiptuGKBlaZO5showwqODii5C0nZawxWLF+Q6k5wYHBrQv96h6GYKyqqMHCSTqta8Kiw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.26.0",
+        "@typescript-eslint/types": "5.33.0",
         "eslint-visitor-keys": "^3.3.0"
       }
     },
@@ -7003,9 +7112,9 @@
       "dev": true
     },
     "acorn": {
-      "version": "8.7.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.1.tgz",
-      "integrity": "sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A==",
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
+      "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
       "dev": true
     },
     "acorn-globals": {
@@ -7711,13 +7820,14 @@
       }
     },
     "eslint": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.16.0.tgz",
-      "integrity": "sha512-MBndsoXY/PeVTDJeWsYj7kLZ5hQpJOfMYLsF6LicLHQWbRDG19lK5jOix4DPl8yY4SUFcE3txy86OzFLWT+yoA==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.21.0.tgz",
+      "integrity": "sha512-/XJ1+Qurf1T9G2M5IHrsjp+xrGT73RZf23xA1z5wB1ZzzEAWSZKvRwhWxTFp1rvkvCfwcvAUNAP31bhKTTGfDA==",
       "dev": true,
       "requires": {
         "@eslint/eslintrc": "^1.3.0",
-        "@humanwhocodes/config-array": "^0.9.2",
+        "@humanwhocodes/config-array": "^0.10.4",
+        "@humanwhocodes/gitignore-to-minimatch": "^1.0.2",
         "ajv": "^6.10.0",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.2",
@@ -7727,14 +7837,17 @@
         "eslint-scope": "^7.1.1",
         "eslint-utils": "^3.0.0",
         "eslint-visitor-keys": "^3.3.0",
-        "espree": "^9.3.2",
+        "espree": "^9.3.3",
         "esquery": "^1.4.0",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
         "file-entry-cache": "^6.0.1",
+        "find-up": "^5.0.0",
         "functional-red-black-tree": "^1.0.1",
         "glob-parent": "^6.0.1",
         "globals": "^13.15.0",
+        "globby": "^11.1.0",
+        "grapheme-splitter": "^1.0.4",
         "ignore": "^5.2.0",
         "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
@@ -7768,8 +7881,51 @@
           "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
           "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
           "dev": true
+        },
+        "find-up": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+          "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^6.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+          "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^5.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+          "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+          "dev": true,
+          "requires": {
+            "yocto-queue": "^0.1.0"
+          }
+        },
+        "p-locate": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+          "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^3.0.2"
+          }
         }
       }
+    },
+    "eslint-plugin-snarkyjs": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-snarkyjs/-/eslint-plugin-snarkyjs-0.3.0.tgz",
+      "integrity": "sha512-ncREhfSXrd+F2yp2e5en/WOYBHBGHNJY65JSYqi6Hc/UVyqkAS8tHnZ4tiPRb2cotewFfLhguLftkmYzUhpoEw==",
+      "dev": true
     },
     "eslint-scope": {
       "version": "5.1.1",
@@ -7805,12 +7961,12 @@
       "dev": true
     },
     "espree": {
-      "version": "9.3.2",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-9.3.2.tgz",
-      "integrity": "sha512-D211tC7ZwouTIuY5x9XnS0E9sWNChB7IYKX/Xp5eQj3nFXhqmiUDB9q27y76oFl8jTg3pXcQx/bpxMfs3CIZbA==",
+      "version": "9.3.3",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.3.3.tgz",
+      "integrity": "sha512-ORs1Rt/uQTqUKjDdGCyrtYxbazf5umATSf/K4qxjmZHORR6HJk+2s/2Pqe+Kk49HHINC/xNIrGfgh8sZcll0ng==",
       "dev": true,
       "requires": {
-        "acorn": "^8.7.1",
+        "acorn": "^8.8.0",
         "acorn-jsx": "^5.3.2",
         "eslint-visitor-keys": "^3.3.0"
       }
@@ -8145,6 +8301,12 @@
       "version": "4.2.10",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
       "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
+    },
+    "grapheme-splitter": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
+      "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
+      "dev": true
     },
     "has": {
       "version": "1.0.3",
@@ -10414,6 +10576,12 @@
       "version": "21.0.1",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.1.tgz",
       "integrity": "sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg=="
+    },
+    "yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zkapp-cli",
-  "version": "0.4.10",
+  "version": "0.4.11",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "zkapp-cli",
-      "version": "0.4.10",
+      "version": "0.4.11",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -20,7 +20,7 @@
         "mina-signer": "^1.1.0",
         "ora": "^5.4.1",
         "shelljs": "^0.8.5",
-        "snarkyjs": "^0.4.4",
+        "snarkyjs": "^0.5.0",
         "table": "^6.8.0",
         "yargs": "^17.5.1"
       },
@@ -5201,9 +5201,9 @@
       }
     },
     "node_modules/snarkyjs": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/snarkyjs/-/snarkyjs-0.4.4.tgz",
-      "integrity": "sha512-GaoCZVpO08OKTipIsyIeQoiIRcIg7DVqru//AA05hh/fQ8YSReU4rQiT9LuRpjMO1tjzbc5Rw4A+WfvGDC6/lw==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/snarkyjs/-/snarkyjs-0.5.0.tgz",
+      "integrity": "sha512-c1/W3OAnlo6bXBR63hhayaUUy/aKgHS6IiPg/9Z8Ejduv+P5TG6dZGaOOiM/QgwQJS+yHtfzYRN9GIawCTlC1Q==",
       "dependencies": {
         "env": "^0.0.2",
         "isomorphic-fetch": "^3.0.0",
@@ -9836,9 +9836,9 @@
       }
     },
     "snarkyjs": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/snarkyjs/-/snarkyjs-0.4.4.tgz",
-      "integrity": "sha512-GaoCZVpO08OKTipIsyIeQoiIRcIg7DVqru//AA05hh/fQ8YSReU4rQiT9LuRpjMO1tjzbc5Rw4A+WfvGDC6/lw==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/snarkyjs/-/snarkyjs-0.5.0.tgz",
+      "integrity": "sha512-c1/W3OAnlo6bXBR63hhayaUUy/aKgHS6IiPg/9Z8Ejduv+P5TG6dZGaOOiM/QgwQJS+yHtfzYRN9GIawCTlC1Q==",
       "requires": {
         "env": "^0.0.2",
         "isomorphic-fetch": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "mina-signer": "^1.1.0",
     "ora": "^5.4.1",
     "shelljs": "^0.8.5",
-    "snarkyjs": "^0.4.4",
+    "snarkyjs": "^0.5.0",
     "table": "^6.8.0",
     "yargs": "^17.5.1"
   },

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "@typescript-eslint/eslint-plugin": "^5.26.0",
     "@typescript-eslint/parser": "^5.26.0",
     "eslint": "^8.16.0",
+    "eslint-plugin-snarkyjs": "^0.3.0",
     "husky": "^7.0.2",
     "jest": "^27.2.1",
     "lint-staged": "^11.1.2",

--- a/templates/project-ts/package-lock.json
+++ b/templates/project-ts/package-lock.json
@@ -8,9 +8,6 @@
       "name": "package-name",
       "version": "0.1.5",
       "license": "Apache-2.0",
-      "dependencies": {
-        "snarkyjs": "^0.4.4"
-      },
       "devDependencies": {
         "@babel/preset-env": "^7.16.4",
         "@babel/preset-typescript": "^7.16.0",
@@ -25,6 +22,9 @@
         "prettier": "^2.3.2",
         "ts-jest": "^27.0.7",
         "typescript": "^4.7.2"
+      },
+      "peerDependencies": {
+        "snarkyjs": "^0.5.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2528,9 +2528,9 @@
       }
     },
     "node_modules/@types/json-schema": {
-      "version": "7.0.9",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
-      "integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==",
+      "version": "7.0.11",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
+      "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
       "dev": true
     },
     "node_modules/@types/node": {
@@ -2573,19 +2573,19 @@
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "5.10.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.10.1.tgz",
-      "integrity": "sha512-xN3CYqFlyE/qOcy978/L0xLR2HlcAGIyIK5sMOasxaaAPfQRj/MmMV6OC3I7NZO84oEUdWCOju34Z9W8E0pFDQ==",
+      "version": "5.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.33.0.tgz",
+      "integrity": "sha512-jHvZNSW2WZ31OPJ3enhLrEKvAZNyAFWZ6rx9tUwaessTc4sx9KmgMNhVcqVAl1ETnT5rU5fpXTLmY9YvC1DCNg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.10.1",
-        "@typescript-eslint/type-utils": "5.10.1",
-        "@typescript-eslint/utils": "5.10.1",
-        "debug": "^4.3.2",
+        "@typescript-eslint/scope-manager": "5.33.0",
+        "@typescript-eslint/type-utils": "5.33.0",
+        "@typescript-eslint/utils": "5.33.0",
+        "debug": "^4.3.4",
         "functional-red-black-tree": "^1.0.1",
-        "ignore": "^5.1.8",
+        "ignore": "^5.2.0",
         "regexpp": "^3.2.0",
-        "semver": "^7.3.5",
+        "semver": "^7.3.7",
         "tsutils": "^3.21.0"
       },
       "engines": {
@@ -2606,9 +2606,9 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin/node_modules/semver": {
-      "version": "7.3.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+      "version": "7.3.7",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -2621,15 +2621,15 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "5.10.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.10.1.tgz",
-      "integrity": "sha512-GReo3tjNBwR5RnRO0K2wDIDN31cM3MmDtgyQ85oAxAmC5K3j/g85IjP+cDfcqDsDDBf1HNKQAD0WqOYL8jXqUA==",
+      "version": "5.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.33.0.tgz",
+      "integrity": "sha512-cgM5cJrWmrDV2KpvlcSkelTBASAs1mgqq+IUGKJvFxWrapHpaRy5EXPQz9YaKF3nZ8KY18ILTiVpUtbIac86/w==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.10.1",
-        "@typescript-eslint/types": "5.10.1",
-        "@typescript-eslint/typescript-estree": "5.10.1",
-        "debug": "^4.3.2"
+        "@typescript-eslint/scope-manager": "5.33.0",
+        "@typescript-eslint/types": "5.33.0",
+        "@typescript-eslint/typescript-estree": "5.33.0",
+        "debug": "^4.3.4"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -2648,13 +2648,13 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "5.10.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.10.1.tgz",
-      "integrity": "sha512-Lyvi559Gvpn94k7+ElXNMEnXu/iundV5uFmCUNnftbFrUbAJ1WBoaGgkbOBm07jVZa682oaBU37ao/NGGX4ZDg==",
+      "version": "5.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.33.0.tgz",
+      "integrity": "sha512-/Jta8yMNpXYpRDl8EwF/M8It2A9sFJTubDo0ATZefGXmOqlaBffEw0ZbkbQ7TNDK6q55NPHFshGBPAZvZkE8Pw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.10.1",
-        "@typescript-eslint/visitor-keys": "5.10.1"
+        "@typescript-eslint/types": "5.33.0",
+        "@typescript-eslint/visitor-keys": "5.33.0"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -2665,13 +2665,13 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "5.10.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.10.1.tgz",
-      "integrity": "sha512-AfVJkV8uck/UIoDqhu+ptEdBoQATON9GXnhOpPLzkQRJcSChkvD//qsz9JVffl2goxX+ybs5klvacE9vmrQyCw==",
+      "version": "5.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.33.0.tgz",
+      "integrity": "sha512-2zB8uEn7hEH2pBeyk3NpzX1p3lF9dKrEbnXq1F7YkpZ6hlyqb2yZujqgRGqXgRBTHWIUG3NGx/WeZk224UKlIA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/utils": "5.10.1",
-        "debug": "^4.3.2",
+        "@typescript-eslint/utils": "5.33.0",
+        "debug": "^4.3.4",
         "tsutils": "^3.21.0"
       },
       "engines": {
@@ -2691,9 +2691,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "5.10.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.10.1.tgz",
-      "integrity": "sha512-ZvxQ2QMy49bIIBpTqFiOenucqUyjTQ0WNLhBM6X1fh1NNlYAC6Kxsx8bRTY3jdYsYg44a0Z/uEgQkohbR0H87Q==",
+      "version": "5.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.33.0.tgz",
+      "integrity": "sha512-nIMt96JngB4MYFYXpZ/3ZNU4GWPNdBbcB5w2rDOCpXOVUkhtNlG2mmm8uXhubhidRZdwMaMBap7Uk8SZMU/ppw==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -2704,17 +2704,17 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "5.10.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.10.1.tgz",
-      "integrity": "sha512-PwIGnH7jIueXv4opcwEbVGDATjGPO1dx9RkUl5LlHDSe+FXxPwFL5W/qYd5/NHr7f6lo/vvTrAzd0KlQtRusJQ==",
+      "version": "5.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.33.0.tgz",
+      "integrity": "sha512-tqq3MRLlggkJKJUrzM6wltk8NckKyyorCSGMq4eVkyL5sDYzJJcMgZATqmF8fLdsWrW7OjjIZ1m9v81vKcaqwQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.10.1",
-        "@typescript-eslint/visitor-keys": "5.10.1",
-        "debug": "^4.3.2",
-        "globby": "^11.0.4",
+        "@typescript-eslint/types": "5.33.0",
+        "@typescript-eslint/visitor-keys": "5.33.0",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
         "is-glob": "^4.0.3",
-        "semver": "^7.3.5",
+        "semver": "^7.3.7",
         "tsutils": "^3.21.0"
       },
       "engines": {
@@ -2731,9 +2731,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
-      "version": "7.3.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+      "version": "7.3.7",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -2746,15 +2746,15 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "5.10.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.10.1.tgz",
-      "integrity": "sha512-RRmlITiUbLuTRtn/gcPRi4202niF+q7ylFLCKu4c+O/PcpRvZ/nAUwQ2G00bZgpWkhrNLNnvhZLbDn8Ml0qsQw==",
+      "version": "5.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.33.0.tgz",
+      "integrity": "sha512-JxOAnXt9oZjXLIiXb5ZIcZXiwVHCkqZgof0O8KPgz7C7y0HS42gi75PdPlqh1Tf109M0fyUw45Ao6JLo7S5AHw==",
       "dev": true,
       "dependencies": {
         "@types/json-schema": "^7.0.9",
-        "@typescript-eslint/scope-manager": "5.10.1",
-        "@typescript-eslint/types": "5.10.1",
-        "@typescript-eslint/typescript-estree": "5.10.1",
+        "@typescript-eslint/scope-manager": "5.33.0",
+        "@typescript-eslint/types": "5.33.0",
+        "@typescript-eslint/typescript-estree": "5.33.0",
         "eslint-scope": "^5.1.1",
         "eslint-utils": "^3.0.0"
       },
@@ -2769,32 +2769,14 @@
         "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
-    "node_modules/@typescript-eslint/utils/node_modules/eslint-utils": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
-      "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
-      "dev": true,
-      "dependencies": {
-        "eslint-visitor-keys": "^2.0.0"
-      },
-      "engines": {
-        "node": "^10.0.0 || ^12.0.0 || >= 14.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mysticatea"
-      },
-      "peerDependencies": {
-        "eslint": ">=5"
-      }
-    },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.10.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.10.1.tgz",
-      "integrity": "sha512-NjQ0Xinhy9IL979tpoTRuLKxMc0zJC7QVSdeerXs2/QvOy2yRkzX5dRb10X5woNUdJgU8G3nYRDlI33sq1K4YQ==",
+      "version": "5.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.33.0.tgz",
+      "integrity": "sha512-/XsqCzD4t+Y9p5wd9HZiptuGKBlaZO5showwqODii5C0nZawxWLF+Q6k5wYHBrQv96h6GYKyqqMHCSTqta8Kiw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.10.1",
-        "eslint-visitor-keys": "^3.0.0"
+        "@typescript-eslint/types": "5.33.0",
+        "eslint-visitor-keys": "^3.3.0"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -2802,15 +2784,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.2.0.tgz",
-      "integrity": "sha512-IOzT0X126zn7ALX0dwFiUQEdsfzrm4+ISsQS8nukaJXwEyYKRSnEIIDULYg1mCtGp7UUXgfGl7BIolXREQK+XQ==",
-      "dev": true,
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
     "node_modules/abab": {
@@ -3602,9 +3575,9 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-      "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
       "dev": true,
       "dependencies": {
         "ms": "2.1.2"
@@ -3769,6 +3742,7 @@
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/env/-/env-0.0.2.tgz",
       "integrity": "sha1-UMGfMHsSmkWEW2tobfWzndQNHPA=",
+      "peer": true,
       "engines": {
         "node": ">= 0.5.9"
       }
@@ -3912,13 +3886,40 @@
         "node": ">=4.0"
       }
     },
-    "node_modules/eslint-visitor-keys": {
+    "node_modules/eslint-utils": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
+      "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
+      "dev": true,
+      "dependencies": {
+        "eslint-visitor-keys": "^2.0.0"
+      },
+      "engines": {
+        "node": "^10.0.0 || ^12.0.0 || >= 14.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mysticatea"
+      },
+      "peerDependencies": {
+        "eslint": ">=5"
+      }
+    },
+    "node_modules/eslint-utils/node_modules/eslint-visitor-keys": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
       "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
       "dev": true,
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
+      "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
     "node_modules/eslint/node_modules/ansi-styles": {
@@ -3997,42 +3998,6 @@
         "esrecurse": "^4.3.0",
         "estraverse": "^5.2.0"
       },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      }
-    },
-    "node_modules/eslint/node_modules/eslint-utils": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
-      "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
-      "dev": true,
-      "dependencies": {
-        "eslint-visitor-keys": "^2.0.0"
-      },
-      "engines": {
-        "node": "^10.0.0 || ^12.0.0 || >= 14.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mysticatea"
-      },
-      "peerDependencies": {
-        "eslint": ">=5"
-      }
-    },
-    "node_modules/eslint/node_modules/eslint-utils/node_modules/eslint-visitor-keys": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
-      "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/eslint/node_modules/eslint-visitor-keys": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.2.0.tgz",
-      "integrity": "sha512-IOzT0X126zn7ALX0dwFiUQEdsfzrm4+ISsQS8nukaJXwEyYKRSnEIIDULYg1mCtGp7UUXgfGl7BIolXREQK+XQ==",
-      "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
@@ -4170,15 +4135,6 @@
         "acorn-jsx": "^5.3.1",
         "eslint-visitor-keys": "^3.1.0"
       },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      }
-    },
-    "node_modules/espree/node_modules/eslint-visitor-keys": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.2.0.tgz",
-      "integrity": "sha512-IOzT0X126zn7ALX0dwFiUQEdsfzrm4+ISsQS8nukaJXwEyYKRSnEIIDULYg1mCtGp7UUXgfGl7BIolXREQK+XQ==",
-      "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
@@ -4881,6 +4837,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-3.0.0.tgz",
       "integrity": "sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==",
+      "peer": true,
       "dependencies": {
         "node-fetch": "^2.6.1",
         "whatwg-fetch": "^3.4.1"
@@ -7158,6 +7115,7 @@
       "version": "2.6.7",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
       "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "peer": true,
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -7176,17 +7134,20 @@
     "node_modules/node-fetch/node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
+      "peer": true
     },
     "node_modules/node-fetch/node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
+      "peer": true
     },
     "node_modules/node-fetch/node_modules/whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+      "peer": true,
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
@@ -7581,7 +7542,8 @@
     "node_modules/reflect-metadata": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
-      "integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg=="
+      "integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg==",
+      "peer": true
     },
     "node_modules/regenerate": {
       "version": "1.4.2",
@@ -7929,9 +7891,10 @@
       "dev": true
     },
     "node_modules/snarkyjs": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/snarkyjs/-/snarkyjs-0.4.4.tgz",
-      "integrity": "sha512-GaoCZVpO08OKTipIsyIeQoiIRcIg7DVqru//AA05hh/fQ8YSReU4rQiT9LuRpjMO1tjzbc5Rw4A+WfvGDC6/lw==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/snarkyjs/-/snarkyjs-0.5.0.tgz",
+      "integrity": "sha512-c1/W3OAnlo6bXBR63hhayaUUy/aKgHS6IiPg/9Z8Ejduv+P5TG6dZGaOOiM/QgwQJS+yHtfzYRN9GIawCTlC1Q==",
+      "peer": true,
       "dependencies": {
         "env": "^0.0.2",
         "isomorphic-fetch": "^3.0.0",
@@ -7948,7 +7911,8 @@
     "node_modules/snarkyjs/node_modules/tslib": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+      "peer": true
     },
     "node_modules/source-map": {
       "version": "0.5.7",
@@ -8529,7 +8493,8 @@
     "node_modules/whatwg-fetch": {
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz",
-      "integrity": "sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA=="
+      "integrity": "sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA==",
+      "peer": true
     },
     "node_modules/whatwg-mimetype": {
       "version": "2.3.0",
@@ -10543,9 +10508,9 @@
       }
     },
     "@types/json-schema": {
-      "version": "7.0.9",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
-      "integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==",
+      "version": "7.0.11",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
+      "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
       "dev": true
     },
     "@types/node": {
@@ -10588,26 +10553,26 @@
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "5.10.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.10.1.tgz",
-      "integrity": "sha512-xN3CYqFlyE/qOcy978/L0xLR2HlcAGIyIK5sMOasxaaAPfQRj/MmMV6OC3I7NZO84oEUdWCOju34Z9W8E0pFDQ==",
+      "version": "5.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.33.0.tgz",
+      "integrity": "sha512-jHvZNSW2WZ31OPJ3enhLrEKvAZNyAFWZ6rx9tUwaessTc4sx9KmgMNhVcqVAl1ETnT5rU5fpXTLmY9YvC1DCNg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "5.10.1",
-        "@typescript-eslint/type-utils": "5.10.1",
-        "@typescript-eslint/utils": "5.10.1",
-        "debug": "^4.3.2",
+        "@typescript-eslint/scope-manager": "5.33.0",
+        "@typescript-eslint/type-utils": "5.33.0",
+        "@typescript-eslint/utils": "5.33.0",
+        "debug": "^4.3.4",
         "functional-red-black-tree": "^1.0.1",
-        "ignore": "^5.1.8",
+        "ignore": "^5.2.0",
         "regexpp": "^3.2.0",
-        "semver": "^7.3.5",
+        "semver": "^7.3.7",
         "tsutils": "^3.21.0"
       },
       "dependencies": {
         "semver": {
-          "version": "7.3.5",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "version": "7.3.7",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+          "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
@@ -10616,63 +10581,63 @@
       }
     },
     "@typescript-eslint/parser": {
-      "version": "5.10.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.10.1.tgz",
-      "integrity": "sha512-GReo3tjNBwR5RnRO0K2wDIDN31cM3MmDtgyQ85oAxAmC5K3j/g85IjP+cDfcqDsDDBf1HNKQAD0WqOYL8jXqUA==",
+      "version": "5.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.33.0.tgz",
+      "integrity": "sha512-cgM5cJrWmrDV2KpvlcSkelTBASAs1mgqq+IUGKJvFxWrapHpaRy5EXPQz9YaKF3nZ8KY18ILTiVpUtbIac86/w==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "5.10.1",
-        "@typescript-eslint/types": "5.10.1",
-        "@typescript-eslint/typescript-estree": "5.10.1",
-        "debug": "^4.3.2"
+        "@typescript-eslint/scope-manager": "5.33.0",
+        "@typescript-eslint/types": "5.33.0",
+        "@typescript-eslint/typescript-estree": "5.33.0",
+        "debug": "^4.3.4"
       }
     },
     "@typescript-eslint/scope-manager": {
-      "version": "5.10.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.10.1.tgz",
-      "integrity": "sha512-Lyvi559Gvpn94k7+ElXNMEnXu/iundV5uFmCUNnftbFrUbAJ1WBoaGgkbOBm07jVZa682oaBU37ao/NGGX4ZDg==",
+      "version": "5.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.33.0.tgz",
+      "integrity": "sha512-/Jta8yMNpXYpRDl8EwF/M8It2A9sFJTubDo0ATZefGXmOqlaBffEw0ZbkbQ7TNDK6q55NPHFshGBPAZvZkE8Pw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.10.1",
-        "@typescript-eslint/visitor-keys": "5.10.1"
+        "@typescript-eslint/types": "5.33.0",
+        "@typescript-eslint/visitor-keys": "5.33.0"
       }
     },
     "@typescript-eslint/type-utils": {
-      "version": "5.10.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.10.1.tgz",
-      "integrity": "sha512-AfVJkV8uck/UIoDqhu+ptEdBoQATON9GXnhOpPLzkQRJcSChkvD//qsz9JVffl2goxX+ybs5klvacE9vmrQyCw==",
+      "version": "5.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.33.0.tgz",
+      "integrity": "sha512-2zB8uEn7hEH2pBeyk3NpzX1p3lF9dKrEbnXq1F7YkpZ6hlyqb2yZujqgRGqXgRBTHWIUG3NGx/WeZk224UKlIA==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/utils": "5.10.1",
-        "debug": "^4.3.2",
+        "@typescript-eslint/utils": "5.33.0",
+        "debug": "^4.3.4",
         "tsutils": "^3.21.0"
       }
     },
     "@typescript-eslint/types": {
-      "version": "5.10.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.10.1.tgz",
-      "integrity": "sha512-ZvxQ2QMy49bIIBpTqFiOenucqUyjTQ0WNLhBM6X1fh1NNlYAC6Kxsx8bRTY3jdYsYg44a0Z/uEgQkohbR0H87Q==",
+      "version": "5.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.33.0.tgz",
+      "integrity": "sha512-nIMt96JngB4MYFYXpZ/3ZNU4GWPNdBbcB5w2rDOCpXOVUkhtNlG2mmm8uXhubhidRZdwMaMBap7Uk8SZMU/ppw==",
       "dev": true
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "5.10.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.10.1.tgz",
-      "integrity": "sha512-PwIGnH7jIueXv4opcwEbVGDATjGPO1dx9RkUl5LlHDSe+FXxPwFL5W/qYd5/NHr7f6lo/vvTrAzd0KlQtRusJQ==",
+      "version": "5.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.33.0.tgz",
+      "integrity": "sha512-tqq3MRLlggkJKJUrzM6wltk8NckKyyorCSGMq4eVkyL5sDYzJJcMgZATqmF8fLdsWrW7OjjIZ1m9v81vKcaqwQ==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.10.1",
-        "@typescript-eslint/visitor-keys": "5.10.1",
-        "debug": "^4.3.2",
-        "globby": "^11.0.4",
+        "@typescript-eslint/types": "5.33.0",
+        "@typescript-eslint/visitor-keys": "5.33.0",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
         "is-glob": "^4.0.3",
-        "semver": "^7.3.5",
+        "semver": "^7.3.7",
         "tsutils": "^3.21.0"
       },
       "dependencies": {
         "semver": {
-          "version": "7.3.5",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "version": "7.3.7",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+          "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
@@ -10681,46 +10646,27 @@
       }
     },
     "@typescript-eslint/utils": {
-      "version": "5.10.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.10.1.tgz",
-      "integrity": "sha512-RRmlITiUbLuTRtn/gcPRi4202niF+q7ylFLCKu4c+O/PcpRvZ/nAUwQ2G00bZgpWkhrNLNnvhZLbDn8Ml0qsQw==",
+      "version": "5.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.33.0.tgz",
+      "integrity": "sha512-JxOAnXt9oZjXLIiXb5ZIcZXiwVHCkqZgof0O8KPgz7C7y0HS42gi75PdPlqh1Tf109M0fyUw45Ao6JLo7S5AHw==",
       "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.9",
-        "@typescript-eslint/scope-manager": "5.10.1",
-        "@typescript-eslint/types": "5.10.1",
-        "@typescript-eslint/typescript-estree": "5.10.1",
+        "@typescript-eslint/scope-manager": "5.33.0",
+        "@typescript-eslint/types": "5.33.0",
+        "@typescript-eslint/typescript-estree": "5.33.0",
         "eslint-scope": "^5.1.1",
         "eslint-utils": "^3.0.0"
-      },
-      "dependencies": {
-        "eslint-utils": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
-          "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
-          "dev": true,
-          "requires": {
-            "eslint-visitor-keys": "^2.0.0"
-          }
-        }
       }
     },
     "@typescript-eslint/visitor-keys": {
-      "version": "5.10.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.10.1.tgz",
-      "integrity": "sha512-NjQ0Xinhy9IL979tpoTRuLKxMc0zJC7QVSdeerXs2/QvOy2yRkzX5dRb10X5woNUdJgU8G3nYRDlI33sq1K4YQ==",
+      "version": "5.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.33.0.tgz",
+      "integrity": "sha512-/XsqCzD4t+Y9p5wd9HZiptuGKBlaZO5showwqODii5C0nZawxWLF+Q6k5wYHBrQv96h6GYKyqqMHCSTqta8Kiw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.10.1",
-        "eslint-visitor-keys": "^3.0.0"
-      },
-      "dependencies": {
-        "eslint-visitor-keys": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.2.0.tgz",
-          "integrity": "sha512-IOzT0X126zn7ALX0dwFiUQEdsfzrm4+ISsQS8nukaJXwEyYKRSnEIIDULYg1mCtGp7UUXgfGl7BIolXREQK+XQ==",
-          "dev": true
-        }
+        "@typescript-eslint/types": "5.33.0",
+        "eslint-visitor-keys": "^3.3.0"
       }
     },
     "abab": {
@@ -11341,9 +11287,9 @@
       }
     },
     "debug": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-      "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
       "dev": true,
       "requires": {
         "ms": "2.1.2"
@@ -11465,7 +11411,8 @@
     "env": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/env/-/env-0.0.2.tgz",
-      "integrity": "sha1-UMGfMHsSmkWEW2tobfWzndQNHPA="
+      "integrity": "sha1-UMGfMHsSmkWEW2tobfWzndQNHPA=",
+      "peer": true
     },
     "error-ex": {
       "version": "1.3.2",
@@ -11609,29 +11556,6 @@
             "estraverse": "^5.2.0"
           }
         },
-        "eslint-utils": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
-          "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
-          "dev": true,
-          "requires": {
-            "eslint-visitor-keys": "^2.0.0"
-          },
-          "dependencies": {
-            "eslint-visitor-keys": {
-              "version": "2.1.0",
-              "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
-              "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
-              "dev": true
-            }
-          }
-        },
-        "eslint-visitor-keys": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.2.0.tgz",
-          "integrity": "sha512-IOzT0X126zn7ALX0dwFiUQEdsfzrm4+ISsQS8nukaJXwEyYKRSnEIIDULYg1mCtGp7UUXgfGl7BIolXREQK+XQ==",
-          "dev": true
-        },
         "glob-parent": {
           "version": "6.0.2",
           "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -11745,10 +11669,27 @@
         }
       }
     },
+    "eslint-utils": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
+      "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
+      "dev": true,
+      "requires": {
+        "eslint-visitor-keys": "^2.0.0"
+      },
+      "dependencies": {
+        "eslint-visitor-keys": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+          "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+          "dev": true
+        }
+      }
+    },
     "eslint-visitor-keys": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
-      "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
+      "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
       "dev": true
     },
     "espree": {
@@ -11760,14 +11701,6 @@
         "acorn": "^8.7.0",
         "acorn-jsx": "^5.3.1",
         "eslint-visitor-keys": "^3.1.0"
-      },
-      "dependencies": {
-        "eslint-visitor-keys": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.2.0.tgz",
-          "integrity": "sha512-IOzT0X126zn7ALX0dwFiUQEdsfzrm4+ISsQS8nukaJXwEyYKRSnEIIDULYg1mCtGp7UUXgfGl7BIolXREQK+XQ==",
-          "dev": true
-        }
       }
     },
     "esprima": {
@@ -12291,6 +12224,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-3.0.0.tgz",
       "integrity": "sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==",
+      "peer": true,
       "requires": {
         "node-fetch": "^2.6.1",
         "whatwg-fetch": "^3.4.1"
@@ -14009,6 +13943,7 @@
       "version": "2.6.7",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
       "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "peer": true,
       "requires": {
         "whatwg-url": "^5.0.0"
       },
@@ -14016,17 +13951,20 @@
         "tr46": {
           "version": "0.0.3",
           "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-          "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+          "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
+          "peer": true
         },
         "webidl-conversions": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-          "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+          "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
+          "peer": true
         },
         "whatwg-url": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
           "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+          "peer": true,
           "requires": {
             "tr46": "~0.0.3",
             "webidl-conversions": "^3.0.0"
@@ -14312,7 +14250,8 @@
     "reflect-metadata": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
-      "integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg=="
+      "integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg==",
+      "peer": true
     },
     "regenerate": {
       "version": "1.4.2",
@@ -14577,9 +14516,10 @@
       }
     },
     "snarkyjs": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/snarkyjs/-/snarkyjs-0.4.4.tgz",
-      "integrity": "sha512-GaoCZVpO08OKTipIsyIeQoiIRcIg7DVqru//AA05hh/fQ8YSReU4rQiT9LuRpjMO1tjzbc5Rw4A+WfvGDC6/lw==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/snarkyjs/-/snarkyjs-0.5.0.tgz",
+      "integrity": "sha512-c1/W3OAnlo6bXBR63hhayaUUy/aKgHS6IiPg/9Z8Ejduv+P5TG6dZGaOOiM/QgwQJS+yHtfzYRN9GIawCTlC1Q==",
+      "peer": true,
       "requires": {
         "env": "^0.0.2",
         "isomorphic-fetch": "^3.0.0",
@@ -14590,7 +14530,8 @@
         "tslib": {
           "version": "2.3.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+          "peer": true
         }
       }
     },
@@ -15027,7 +14968,8 @@
     "whatwg-fetch": {
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz",
-      "integrity": "sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA=="
+      "integrity": "sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA==",
+      "peer": true
     },
     "whatwg-mimetype": {
       "version": "2.3.0",

--- a/templates/project-ts/package.json
+++ b/templates/project-ts/package.json
@@ -44,6 +44,6 @@
     "typescript": "^4.7.2"
   },
   "peerDependencies": {
-    "snarkyjs": "^0.4.4"
+    "snarkyjs": "^0.5.0"
   }
 }

--- a/templates/project-ts/src/Add.ts
+++ b/templates/project-ts/src/Add.ts
@@ -34,7 +34,7 @@ export class Add extends SmartContract {
 
   @method update() {
     const currentState = this.num.get();
-    this.num.assertEquals(currentState);
+    this.num.assertEquals(currentState); // precondition that links this.num.get() to the actual on-chain state
     const newState = currentState.add(2);
     newState.assertEquals(currentState.add(2));
     this.num.set(newState);

--- a/templates/project-ts/src/Add.ts
+++ b/templates/project-ts/src/Add.ts
@@ -34,6 +34,7 @@ export class Add extends SmartContract {
 
   @method update() {
     const currentState = this.num.get();
+    this.num.assertEquals(currentState);
     const newState = currentState.add(2);
     newState.assertEquals(currentState.add(2));
     this.num.set(newState);


### PR DESCRIPTION
**Description** 
Addresses #227 & #229

This PR adds preconditions to the template and example contracts that links accessing contract state via `.get` to actual on-chain state. A static `from` method was also added to the sudoku smart contract to invoke the original constructor instead of overriding it. This is a necessary refactor after the new SnarkyJS CircuitValue improvements. See [this discussion](https://github.com/o1-labs/snarkyjs/pull/269) for more details. 