### PR TITLE
Cannot find name '...' Jest TS error fix

### DIFF
--- a/templates/project-ts/tsconfig.json
+++ b/templates/project-ts/tsconfig.json
@@ -20,6 +20,5 @@
     "allowSyntheticDefaultImports": true,
     "isolatedModules": true
   },
-  "include": ["./src"],
-  "exclude": ["./src/**/*.test.ts"]
+  "include": ["./src", "./src/**/*.test.ts"]
 }


### PR DESCRIPTION
Otherwise test sources will highlight the `Cannot find name '...'` (Jest methods) errors within generated projects.