### PR TITLE
Rename references to party and bump SnarkyJS to 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/o1-labs/zkapp-cli/compare/feature/deploy-alias...HEAD)
 
+## [0.4.15] - 2021-09-015
+
+### Changed
+
+- Upgraded SnarkyJS to `0.6.0`. [#249](https://github.com/o1-labs/zkapp-cli/pull/249)
+- Renamed the references of Party to AccountUpdate and parties to zkappCommand in CLI and template/examples to match changes in Mina Protocol and SnarkyJS.
+
 ## [0.4.7] - 2021-06-14
 
 ### Added

--- a/examples/sudoku/ts/src/sudoku.ts
+++ b/examples/sudoku/ts/src/sudoku.ts
@@ -11,7 +11,7 @@ import {
   Poseidon,
   Permissions,
   Mina,
-  Party,
+  AccountUpdate,
   PrivateKey,
   PublicKey,
 } from 'snarkyjs';
@@ -116,7 +116,7 @@ async function deploy(
   account: PrivateKey
 ) {
   let tx = await Mina.transaction(account, () => {
-    Party.fundNewAccount(account);
+    AccountUpdate.fundNewAccount(account);
 
     let sudokuInstance = new Sudoku(sudoku);
     zkAppInstance.deploy({ zkappKey: zkAppPrivateKey });

--- a/examples/sudoku/ts/src/sudoku.ts
+++ b/examples/sudoku/ts/src/sudoku.ts
@@ -126,6 +126,7 @@ async function deploy(
     });
 
     zkAppInstance.init(sudokuInstance);
+    zkAppInstance.sign(zkAppPrivateKey);
   });
   await tx.send().wait();
 }

--- a/examples/tictactoe/ts/src/run.ts
+++ b/examples/tictactoe/ts/src/run.ts
@@ -33,7 +33,7 @@ async function playTicTacToe() {
 
   // initial state
   let b = await Mina.getAccount(zkAppPubkey);
-  console.log('b', b);
+
   console.log('initial state of the zkApp');
   for (const i in [0, 1, 2, 3, 4, 5, 6, 7]) {
     console.log('state', i, ':', b.appState?.[i].toString());

--- a/examples/tictactoe/ts/src/tictactoe-lib.ts
+++ b/examples/tictactoe/ts/src/tictactoe-lib.ts
@@ -1,4 +1,11 @@
-import { Field, PrivateKey, PublicKey, Mina, AccountUpdate, Signature } from 'snarkyjs';
+import {
+  Field,
+  PrivateKey,
+  PublicKey,
+  Mina,
+  AccountUpdate,
+  Signature,
+} from 'snarkyjs';
 import { TicTacToe } from './tictactoe.js';
 
 export function createLocalBlockchain(): PrivateKey[] {
@@ -9,20 +16,21 @@ export function createLocalBlockchain(): PrivateKey[] {
 
 export async function deploy(
   zkAppInstance: TicTacToe,
-  zkAppPrivkey: PrivateKey,
+  zkAppPrivatekey: PrivateKey,
   deployer: PrivateKey
 ) {
   const txn = await Mina.transaction(deployer, () => {
     AccountUpdate.fundNewAccount(deployer);
-    zkAppInstance.deploy({ zkappKey: zkAppPrivkey });
+    zkAppInstance.deploy({ zkappKey: zkAppPrivatekey });
     zkAppInstance.init();
+    zkAppInstance.sign(zkAppPrivatekey);
   });
   await txn.send().wait();
 }
 
 export async function makeMove(
   zkAppInstance: TicTacToe,
-  zkAppPrivkey: PrivateKey,
+  zkAppPrivatekey: PrivateKey,
   currentPlayer: PrivateKey,
   player1Public: PublicKey,
   player2Public: PublicKey,
@@ -39,7 +47,7 @@ export async function makeMove(
       player1Public,
       player2Public
     );
-    zkAppInstance.sign(zkAppPrivkey);
+    zkAppInstance.sign(zkAppPrivatekey);
   });
   await txn.send().wait();
 }

--- a/examples/tictactoe/ts/src/tictactoe-lib.ts
+++ b/examples/tictactoe/ts/src/tictactoe-lib.ts
@@ -1,4 +1,4 @@
-import { Field, PrivateKey, PublicKey, Mina, Party, Signature } from 'snarkyjs';
+import { Field, PrivateKey, PublicKey, Mina, AccountUpdate, Signature } from 'snarkyjs';
 import { TicTacToe } from './tictactoe.js';
 
 export function createLocalBlockchain(): PrivateKey[] {
@@ -13,7 +13,7 @@ export async function deploy(
   deployer: PrivateKey
 ) {
   const txn = await Mina.transaction(deployer, () => {
-    Party.fundNewAccount(deployer);
+    AccountUpdate.fundNewAccount(deployer);
     zkAppInstance.deploy({ zkappKey: zkAppPrivkey });
     zkAppInstance.init();
   });

--- a/package-lock.json
+++ b/package-lock.json
@@ -5292,9 +5292,9 @@
       }
     },
     "node_modules/snarkyjs": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/snarkyjs/-/snarkyjs-0.5.0.tgz",
-      "integrity": "sha512-c1/W3OAnlo6bXBR63hhayaUUy/aKgHS6IiPg/9Z8Ejduv+P5TG6dZGaOOiM/QgwQJS+yHtfzYRN9GIawCTlC1Q==",
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/snarkyjs/-/snarkyjs-0.5.4.tgz",
+      "integrity": "sha512-r9Q3t4dfYxLUVOofQLNJXQevxVh7kCr74fD92vaP+WZ5eccvJ7a7iJGxH6dGWN66079694bq9Td1x38fyXZObg==",
       "dependencies": {
         "env": "^0.0.2",
         "isomorphic-fetch": "^3.0.0",
@@ -9998,9 +9998,9 @@
       }
     },
     "snarkyjs": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/snarkyjs/-/snarkyjs-0.5.0.tgz",
-      "integrity": "sha512-c1/W3OAnlo6bXBR63hhayaUUy/aKgHS6IiPg/9Z8Ejduv+P5TG6dZGaOOiM/QgwQJS+yHtfzYRN9GIawCTlC1Q==",
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/snarkyjs/-/snarkyjs-0.5.4.tgz",
+      "integrity": "sha512-r9Q3t4dfYxLUVOofQLNJXQevxVh7kCr74fD92vaP+WZ5eccvJ7a7iJGxH6dGWN66079694bq9Td1x38fyXZObg==",
       "requires": {
         "env": "^0.0.2",
         "isomorphic-fetch": "^3.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "mina-signer": "^1.1.0",
         "ora": "^5.4.1",
         "shelljs": "^0.8.5",
-        "snarkyjs": "^0.5.0",
+        "snarkyjs": "^0.6.0",
         "table": "^6.8.0",
         "yargs": "^17.5.1"
       },
@@ -5292,9 +5292,9 @@
       }
     },
     "node_modules/snarkyjs": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/snarkyjs/-/snarkyjs-0.5.4.tgz",
-      "integrity": "sha512-r9Q3t4dfYxLUVOofQLNJXQevxVh7kCr74fD92vaP+WZ5eccvJ7a7iJGxH6dGWN66079694bq9Td1x38fyXZObg==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/snarkyjs/-/snarkyjs-0.6.0.tgz",
+      "integrity": "sha512-JcPlGrG3Ixi3o76m4nlEKyMxbelh7ZVxThdbWH7CmW81jSid89VGwVuBzVWcnrMElCl8PBV5LOONTO34VsWY8A==",
       "dependencies": {
         "env": "^0.0.2",
         "isomorphic-fetch": "^3.0.0",
@@ -5302,7 +5302,7 @@
         "tslib": "^2.3.0"
       },
       "bin": {
-        "snarky-run": "src/build/run.mjs"
+        "snarky-run": "src/build/run.js"
       },
       "engines": {
         "node": ">=16.4.0"
@@ -9998,9 +9998,9 @@
       }
     },
     "snarkyjs": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/snarkyjs/-/snarkyjs-0.5.4.tgz",
-      "integrity": "sha512-r9Q3t4dfYxLUVOofQLNJXQevxVh7kCr74fD92vaP+WZ5eccvJ7a7iJGxH6dGWN66079694bq9Td1x38fyXZObg==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/snarkyjs/-/snarkyjs-0.6.0.tgz",
+      "integrity": "sha512-JcPlGrG3Ixi3o76m4nlEKyMxbelh7ZVxThdbWH7CmW81jSid89VGwVuBzVWcnrMElCl8PBV5LOONTO34VsWY8A==",
       "requires": {
         "env": "^0.0.2",
         "isomorphic-fetch": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zkapp-cli",
-  "version": "0.4.14",
+  "version": "0.4.15",
   "description": "CLI to create a zkApp (\"zero-knowledge app\") for Mina Protocol.",
   "keywords": [
     "cli",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "mina-signer": "^1.1.0",
     "ora": "^5.4.1",
     "shelljs": "^0.8.5",
-    "snarkyjs": "^0.5.0",
+    "snarkyjs": "^0.6.0",
     "table": "^6.8.0",
     "yargs": "^17.5.1"
   },

--- a/src/lib/deploy.js
+++ b/src/lib/deploy.js
@@ -173,7 +173,7 @@ async function deploy({ alias, yes }) {
 
   // import snarkyjs from the user directory
   let { isReady, shutdown, PrivateKey, addCachedAccount, Mina, Bool } =
-    await import(`${DIR}/node_modules/snarkyjs/dist/server/index.mjs`);
+    await import(`${DIR}/node_modules/snarkyjs/dist/node/index.js`);
 
   const graphQLEndpoint = config?.networks[alias]?.url ?? DEFAULT_GRAPHQL;
   const { data: nodeStatus } = await sendGraphQL(

--- a/src/lib/deploy.js
+++ b/src/lib/deploy.js
@@ -528,7 +528,7 @@ function sendZkAppQuery(partiesJson) {
   return `
   mutation {
     sendZkapp(input: {
-      parties: ${removeJsonQuotes(partiesJson)}
+      accountUpdates: ${removeJsonQuotes(partiesJson)}
     }) { zkapp
       {
         id

--- a/src/lib/deploy.js
+++ b/src/lib/deploy.js
@@ -528,7 +528,7 @@ function sendZkAppQuery(acountUpdatesJson) {
   return `
   mutation {
     sendZkapp(input: {
-      accountUpdates: ${removeJsonQuotes(acountUpdatesJson)}
+      zkappCommand: ${removeJsonQuotes(acountUpdatesJson)}
     }) { zkapp
       {
         id

--- a/src/lib/deploy.js
+++ b/src/lib/deploy.js
@@ -524,11 +524,11 @@ async function sendGraphQL(graphQLEndpoint, query) {
   }
 }
 
-function sendZkAppQuery(partiesJson) {
+function sendZkAppQuery(acountUpdatesJson) {
   return `
   mutation {
     sendZkapp(input: {
-      accountUpdates: ${removeJsonQuotes(partiesJson)}
+      accountUpdates: ${removeJsonQuotes(acountUpdatesJson)}
     }) { zkapp
       {
         id

--- a/templates/project-ts/package-lock.json
+++ b/templates/project-ts/package-lock.json
@@ -24,7 +24,7 @@
         "typescript": "^4.7.2"
       },
       "peerDependencies": {
-        "snarkyjs": "^0.5.0"
+        "snarkyjs": "^0.6.0"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/templates/project-ts/package-lock.json
+++ b/templates/project-ts/package-lock.json
@@ -7891,9 +7891,9 @@
       "dev": true
     },
     "node_modules/snarkyjs": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/snarkyjs/-/snarkyjs-0.5.0.tgz",
-      "integrity": "sha512-c1/W3OAnlo6bXBR63hhayaUUy/aKgHS6IiPg/9Z8Ejduv+P5TG6dZGaOOiM/QgwQJS+yHtfzYRN9GIawCTlC1Q==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/snarkyjs/-/snarkyjs-0.6.0.tgz",
+      "integrity": "sha512-JcPlGrG3Ixi3o76m4nlEKyMxbelh7ZVxThdbWH7CmW81jSid89VGwVuBzVWcnrMElCl8PBV5LOONTO34VsWY8A==",
       "peer": true,
       "dependencies": {
         "env": "^0.0.2",
@@ -7902,7 +7902,7 @@
         "tslib": "^2.3.0"
       },
       "bin": {
-        "snarky-run": "src/build/run.mjs"
+        "snarky-run": "src/build/run.js"
       },
       "engines": {
         "node": ">=16.4.0"
@@ -14516,9 +14516,9 @@
       }
     },
     "snarkyjs": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/snarkyjs/-/snarkyjs-0.5.0.tgz",
-      "integrity": "sha512-c1/W3OAnlo6bXBR63hhayaUUy/aKgHS6IiPg/9Z8Ejduv+P5TG6dZGaOOiM/QgwQJS+yHtfzYRN9GIawCTlC1Q==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/snarkyjs/-/snarkyjs-0.6.0.tgz",
+      "integrity": "sha512-JcPlGrG3Ixi3o76m4nlEKyMxbelh7ZVxThdbWH7CmW81jSid89VGwVuBzVWcnrMElCl8PBV5LOONTO34VsWY8A==",
       "peer": true,
       "requires": {
         "env": "^0.0.2",

--- a/templates/project-ts/package.json
+++ b/templates/project-ts/package.json
@@ -44,6 +44,6 @@
     "typescript": "^4.7.2"
   },
   "peerDependencies": {
-    "snarkyjs": "^0.5.0"
+    "snarkyjs": "^0.6.0"
   }
 }

--- a/templates/project-ts/src/Add.test.ts
+++ b/templates/project-ts/src/Add.test.ts
@@ -6,7 +6,7 @@ import {
   Mina,
   PrivateKey,
   PublicKey,
-  Party,
+  AccountUpdate,
 } from 'snarkyjs';
 
 /*
@@ -28,7 +28,7 @@ async function localDeploy(
   deployerAccount: PrivateKey
 ) {
   const txn = await Mina.transaction(deployerAccount, () => {
-    Party.fundNewAccount(deployerAccount);
+    AccountUpdate.fundNewAccount(deployerAccount);
     zkAppInstance.deploy({ zkappKey: zkAppPrivkey });
     zkAppInstance.init();
   });

--- a/templates/project-ts/src/Add.test.ts
+++ b/templates/project-ts/src/Add.test.ts
@@ -10,9 +10,9 @@ import {
 } from 'snarkyjs';
 
 /*
- * This file specifies how to test the `Add` example smart contract. It is safe to delete this file and replace 
- * with your own tests. 
- * 
+ * This file specifies how to test the `Add` example smart contract. It is safe to delete this file and replace
+ * with your own tests.
+ *
  * See https://docs.minaprotocol.com/zkapps for more info.
  */
 
@@ -24,13 +24,14 @@ function createLocalBlockchain() {
 
 async function localDeploy(
   zkAppInstance: Add,
-  zkAppPrivkey: PrivateKey,
+  zkAppPrivatekey: PrivateKey,
   deployerAccount: PrivateKey
 ) {
   const txn = await Mina.transaction(deployerAccount, () => {
     AccountUpdate.fundNewAccount(deployerAccount);
-    zkAppInstance.deploy({ zkappKey: zkAppPrivkey });
+    zkAppInstance.deploy({ zkappKey: zkAppPrivatekey });
     zkAppInstance.init();
+    zkAppInstance.sign(zkAppPrivatekey);
   });
   await txn.send().wait();
 }


### PR DESCRIPTION
**Description**
Addresses 
#248 

This PR renames all references of party to accountUpdate, and parties to zkappCommand. Fixes were also made to make the CLI compatible with SnarkyJS 0.6.0. The CLI version was bumped to 0.4.15. 

Renames
  -CLI: graphql mutations
  -Template: tests
  -Examples: tests/lib

Fixes
  -CLI : snarkyJS local file path
  -Template/Examples: tests
  
**Tested**

The CLI was used to generate, run and deploy example projects. A project was successfully deployed to QAnet here https://berkeley.minaexplorer.com/transaction/CkpZToB1KNYg5M79bivvE557BP1W8e9p7vp1WZCVycJ3yHmS4noo5 .
  