### PR TITLE
Constrain examples names to valid names

### DIFF
--- a/src/bin/index.js
+++ b/src/bin/index.js
@@ -32,6 +32,10 @@ yargs(hideBin(process.argv))
     'Unknown command: %s': {
       one: _red('Unknown command: %s'),
     },
+    'Invalid values:': _red('Invalid values:'),
+    'Argument: %s, Given: %s, Choices: %s': _red(
+      `%s was %s. Must be one of: %s.`
+    ),
   })
   .demandCommand(1, _red('Please provide a command.'))
 
@@ -67,7 +71,14 @@ yargs(hideBin(process.argv))
   .command(
     ['example [name]', 'e [name]'],
     'Create an example project',
-    { name: { demand: true, string: true, hidden: true } },
+    {
+      name: {
+        demand: true,
+        string: true,
+        hidden: false,
+        choices: ['sudoku', 'tictactoe'],
+      },
+    },
     async (argv) => await example(argv.name)
   )
   .command(['system', 'sys', 's'], 'Show system info', {}, () => system())


### PR DESCRIPTION
Example error output if user uses an invalid example name:

> ❯ zk example foo
> zk example [name]
> 
> Create an example project
> 
> Options:
>       --name  [string] [required] [choices: "sudoku", "tictactoe"]
>   -h, --help     Show help                               [boolean]
>   -v, --version  Show version number                     [boolean]
> 
> Invalid values:
>   name was "foo". Must be one of: "sudoku", "tictactoe".

(We don't have a lot of flexibility in the formatting of that error message because it must accept three string replacements. But I made it more readable than the default error message provided by yargs.)