### PR TITLE
Make Ora discard stdin

### DIFF
--- a/src/lib/helpers.js
+++ b/src/lib/helpers.js
@@ -9,7 +9,9 @@ const { green, red } = require('chalk');
  * @returns {Promise<T>}
  */
 async function step(str, fn) {
-  const spin = ora(`${str}...`).start();
+  // discardStdin prevents Ora from accepting input that would be passed to a
+  // subsequent command, like a y/n confirmation step, which would be dangerous.
+  const spin = ora({ text: `${str}...`, discardStdin: true }).start();
   try {
     const result = await fn();
     spin.succeed(green(str));

--- a/src/lib/project.js
+++ b/src/lib/project.js
@@ -78,7 +78,7 @@ async function project(name) {
 async function fetchProjectTemplate(name, lang) {
   const projectName = lang === 'ts' ? 'project-ts' : 'project';
   const step = 'Fetch project template';
-  const spin = ora(`${step}...`).start();
+  const spin = ora({ text: `${step}...`, discardStdin: true }).start();
 
   try {
     const src = 'github:o1-labs/zkapp-cli#main';
@@ -116,7 +116,7 @@ async function fetchProjectTemplate(name, lang) {
  * @returns {Promise<void>}
  */
 async function step(step, cmd) {
-  const spin = ora(`${step}...`).start();
+  const spin = ora({ text: `${step}...`, discardStdin: true }).start();
   try {
     await shExec(cmd);
     spin.succeed(_green(step));


### PR DESCRIPTION
This way it is not automatically consumed by the next step, such as the yes/no confirmation step.

Fixes https://github.com/o1-labs/zkapp-cli/issues/194 


Tested on deployment. Works. The Ora steps aren't messed up if typing during them, and the input isn't invisibly passed to the yes/no prompt, as was the case previously. Now it will show all the junk text, if a user entered any, allowing them to clear it out and proceed in a predictable manner.