### PR TITLE
Working mvp of UI monorepo

### DIFF
--- a/src/bin/index.js
+++ b/src/bin/index.js
@@ -48,7 +48,7 @@ yargs(hideBin(process.argv))
         demand: false,
         string: true,
         hidden: false,
-        choices: ['svelte', 'next', 'vue', 'empty', 'none'],
+        choices: ['svelte', 'next', 'nuxt', 'empty', 'none'],
         description: 'Creates an accompanying UI',
       },
     },

--- a/src/bin/index.js
+++ b/src/bin/index.js
@@ -44,7 +44,7 @@ yargs(hideBin(process.argv))
         demand: false,
         string: true,
         hidden: false,
-        choices: ['svelte', 'next', 'vue', 'empty'],
+        choices: ['svelte', 'next', 'vue', 'empty', 'none'],
         description: 'Creates an accompanying UI',
       },
     },

--- a/src/bin/index.js
+++ b/src/bin/index.js
@@ -38,8 +38,17 @@ yargs(hideBin(process.argv))
   .command(
     ['project [name]', 'proj [name]', 'p [name]'],
     'Create a new project',
-    { name: { demand: true, string: true, hidden: true } },
-    async (argv) => await project(argv.name)
+    {
+      name: { demand: true, string: true, hidden: true },
+      ui: {
+        demand: false,
+        string: true,
+        hidden: false,
+        choices: ['svelte', 'next', 'vue', 'empty'],
+        description: 'Creates an accompanying UI',
+      },
+    },
+    async (argv) => await project(argv)
   )
   .command(
     ['file [name]', 'f [name]'],

--- a/src/lib/helpers.js
+++ b/src/lib/helpers.js
@@ -1,5 +1,6 @@
 const ora = require('ora');
 const { green, red } = require('chalk');
+const { spawnSync } = require('child_process');
 
 /**
  * Helper for any steps for a consistent UX.
@@ -21,6 +22,41 @@ async function step(str, fn) {
   }
 }
 
+async function stepInteractive(str, fn) {
+  console.log(`${str}...`);
+
+  const ls = spawnSync('npm', ['create', 'svelte@latest', 'ui'], {
+    // const ls = spawn('npm', ['create', 'svelte@latest', 'ui'], {
+    stdio: 'inherit',
+  });
+
+  // ls.stdout.on('data', (data) => {
+  //   console.log(`stdout: ${data}`);
+  // });
+
+  // ls.on('close', (code) => {
+  //   console.log(`child process close all stdio with code ${code}`);
+  // });
+
+  ls.on('exit', (code) => {
+    console.log(`child process exited with code ${code}`);
+    fn();
+  });
+
+  // console.log(`${str}...`);
+  // try {
+  //   const result = await fn();
+  //   green(str);
+  //   // ora(`${str}...`).succeed();
+  //   return result;
+  // } catch (err) {
+  //   // ora.fail(str);
+  //   console.error('  ' + red(err)); // maintain expected indentation
+  //   process.exit();
+  // }
+}
+
 module.exports = {
   step,
+  stepInteractive,
 };

--- a/src/lib/helpers.js
+++ b/src/lib/helpers.js
@@ -1,6 +1,5 @@
 const ora = require('ora');
 const { green, red } = require('chalk');
-const { spawnSync } = require('child_process');
 
 /**
  * Helper for any steps for a consistent UX.
@@ -24,41 +23,6 @@ async function step(str, fn) {
   }
 }
 
-async function stepInteractive(str, fn) {
-  console.log(`${str}...`);
-
-  const ls = spawnSync('npm', ['create', 'svelte@latest', 'ui'], {
-    // const ls = spawn('npm', ['create', 'svelte@latest', 'ui'], {
-    stdio: 'inherit',
-  });
-
-  // ls.stdout.on('data', (data) => {
-  //   console.log(`stdout: ${data}`);
-  // });
-
-  // ls.on('close', (code) => {
-  //   console.log(`child process close all stdio with code ${code}`);
-  // });
-
-  ls.on('exit', (code) => {
-    console.log(`child process exited with code ${code}`);
-    fn();
-  });
-
-  // console.log(`${str}...`);
-  // try {
-  //   const result = await fn();
-  //   green(str);
-  //   // ora(`${str}...`).succeed();
-  //   return result;
-  // } catch (err) {
-  //   // ora.fail(str);
-  //   console.error('  ' + red(err)); // maintain expected indentation
-  //   process.exit();
-  // }
-}
-
 module.exports = {
   step,
-  stepInteractive,
 };

--- a/src/lib/project.js
+++ b/src/lib/project.js
@@ -79,7 +79,8 @@ async function project({ name, ui }) {
   if (ui) {
     switch (ui) {
       case 'svelte':
-        spawnSync('npm', ['create', 'svelte@latest', 'ui'], {
+        // `-y` installs the latest version of create-svelte without prompting.
+        spawnSync('npm', ['create', 'svelte@latest', '-y', 'ui'], {
           stdio: 'inherit',
           shell: true,
         });

--- a/src/lib/project.js
+++ b/src/lib/project.js
@@ -44,7 +44,7 @@ async function project({ name, ui }) {
           // Make the step text green upon success, else use the reset color.
           const style =
             state.submitted && !state.cancelled ? state.styles.success : reset;
-          return style('Create an accompanying UI project?');
+          return style('Create a UI for your smart contract too?');
         },
         prefix: (state) => {
           // Show a cyan question mark when not submitted.

--- a/src/lib/project.js
+++ b/src/lib/project.js
@@ -115,9 +115,7 @@ async function project({ name, ui }) {
       sh.cd('ui');
       await step(
         'UI: NPM install',
-        `npm install --prefix=ui --silent > ${
-          isWindows ? 'NUL' : '"/dev/null" 2>&1'
-        }`
+        `npm install --silent > ${isWindows ? 'NUL' : '"/dev/null" 2>&1'}`
       );
       sh.cd('..');
     }

--- a/src/lib/project.js
+++ b/src/lib/project.js
@@ -40,7 +40,7 @@ async function project({ name, ui }) {
       res = await prompt({
         type: 'select',
         name: 'ui',
-        choices: ['svelte', 'next', 'vue', 'empty', 'none'],
+        choices: ['svelte', 'next', 'nuxt', 'empty', 'none'],
         message: (state) => {
           // Make the step text green upon success, else use the reset color.
           const style =
@@ -93,8 +93,9 @@ async function project({ name, ui }) {
         });
         sh.rm('-rf', path.join('ui', 'git')); // Remove NextJS' .git; we will init .git in our monorepo's root.
         break;
-      case 'vue':
-        spawnSync('npm', ['init', 'vue@latest', 'ui'], {
+      case 'nuxt':
+        console.log("  Choose 'no version control' when prompted.");
+        spawnSync('npx', ['create-nuxt-app', 'ui'], {
           stdio: 'inherit',
           shell: true,
         });

--- a/src/lib/project.js
+++ b/src/lib/project.js
@@ -5,6 +5,7 @@ const ora = require('ora');
 const sh = require('shelljs');
 const util = require('util');
 const gittar = require('gittar');
+const { spawnSync } = require('child_process');
 
 const _green = chalk.green;
 const _red = chalk.red;
@@ -15,10 +16,9 @@ const shExec = util.promisify(sh.exec);
  * testing lib, etc. Warns if already exists and does NOT overwrite.
  * @param {string} name  Desired dir name or path. Will recursively create
  *                       dirs without overwriting existing content, if needed.
- * @return {Promise<void>}
+ * @return {promise<void>}
  */
-async function project(name) {
-  const lang = 'ts';
+async function project({ name, ui }) {
   const isWindows = process.platform === 'win32';
 
   if (fs.existsSync(name)) {
@@ -34,24 +34,90 @@ async function project(name) {
     return;
   }
 
-  if (!(await fetchProjectTemplate(name, lang))) return;
+  sh.mkdir('-p', name); // Create path/to/dir with their desired name
+  sh.cd(name); // Set dir for shell commands. Doesn't change user's dir in their CLI.
 
-  // Create a keys dir because we excluded it from Git
-  fs.ensureDirSync(`${name}/keys`);
+  // If user wants a UI framework installed alongside their smart contract,
+  // we'll create this dir structure:
+  //   /<name>     (with .git)
+  //     ui/
+  //     contracts/
+  // - We use NPM for the UI projects for consistency with our smart contract
+  //   project, as opposed to Yarn or PNPM.
+  // - spawnSync with stdio:inherit allows the child process to be interactive.
+  if (ui) {
+    switch (ui) {
+      case 'svelte':
+        spawnSync('npm', ['create', 'svelte@latest', 'ui'], {
+          stdio: 'inherit',
+        });
+        break;
+      case 'next':
+        // https://nextjs.org/docs/api-reference/create-next-app#options
+        spawnSync('npx', ['create-next-app@latest', 'ui', '--use-npm'], {
+          stdio: 'inherit',
+        });
+        shExec('rm -rf ui/.git'); // Remove NextJS' .git; we will init .git in our monorepo's root.
+        break;
+      case 'vue':
+        spawnSync('npm', ['init', 'vue@latest', 'ui'], { stdio: 'inherit' });
+        break;
+      case 'empty':
+        sh.mkdir('ui');
+        break;
+    }
+    ora(_green(`UI: Set up project`)).succeed();
 
-  // Set dir for shell commands. Doesn't change user's dir in their CLI.
-  sh.cd(name);
+    if (ui !== 'empty') {
+      // Use `install`, not `ci`, b/c these won't have package-lock.json yet.
+      await step(
+        'UI: NPM install',
+        `npm install --prefix=ui --silent > ${
+          isWindows ? 'NUL' : '"/dev/null" 2>&1'
+        }`
+      );
+    }
+  }
 
+  // Initialize .git in the root, whether monorepo or not.
   await step('Initialize Git repo', 'git init -q');
 
-  // `/dev/null` on linux or 'NUL' on windows is the only way to silence Husky's install log msg.
+  // Scaffold smart contract project
+  if (ui) {
+    sh.mkdir('contracts');
+    sh.cd('contracts');
+  }
+  if (!(await fetchProjectTemplate())) return;
+
+  // Make Husky work if using a monorepo. It needs some changes to work when
+  // .git lives one dir level above package.json. Note that Husky's pre-commit
+  // checks only apply to the contracts project, not to the UI, unless the dev
+  // set that up themselves. It's more valuable for the smart contract.
+  // Source: https://github.com/typicode/husky/issues/348#issuecomment-899344732
+  if (ui) {
+    // https://github.com/o1-labs/zkapp-cli/blob/main/templates/project-ts/package.json#L20
+    let x = fs.readJSONSync(`package.json`);
+    x.scripts.prepare = 'cd .. && husky install contracts/.husky';
+    fs.writeJSONSync(`package.json`, x, { spaces: 2 });
+
+    // https://github.com/o1-labs/zkapp-cli/blob/main/templates/project-ts/.husky/pre-commit#L3
+    let y = fs.readFileSync(`.husky/pre-commit`, 'utf-8');
+    const targetStr = 'husky.sh"\n';
+    y = y.replace(targetStr, targetStr + '\ncd contracts');
+    fs.writeFileSync(`.husky/pre-commit`, y, 'utf-8');
+  }
+
+  // `/dev/null` on Mac or Linux and 'NUL' on Windows is the only way to silence
+  // Husky's install log msg. (Note: The contract project template commits
+  // package-lock.json so we can use `npm ci` for faster installation.)
   await step(
     'NPM install',
     `npm ci --silent > ${isWindows ? 'NUL' : '"/dev/null" 2>&1'}`
   );
 
-  // process.cwd() is full path to user's terminal + path/to/name.
-  await setProjectName(process.cwd());
+  await setProjectName(name.split(path.sep).pop());
+
+  if (ui) sh.cd('..'); // back to project root
 
   // `-n` (no verify) skips Husky's pre-commit hooks.
   await step(
@@ -71,13 +137,12 @@ async function project(name) {
 
 /**
  * Fetch project template.
- * @param {string} example     Name of the destination dir.
- * @param {string} lang        ts or js
- * @returns {Promise<boolean>} True if successful; false if not.
+ * @returns {promise<boolean>} True if successful; false if not.
  */
-async function fetchProjectTemplate(name, lang) {
-  const projectName = lang === 'ts' ? 'project-ts' : 'project';
-  const step = 'Fetch project template';
+async function fetchProjectTemplate() {
+  const projectName = 'project-ts';
+
+  const step = 'Set up project';
   const spin = ora(`${step}...`).start();
 
   try {
@@ -93,13 +158,18 @@ async function fetchProjectTemplate(name, lang) {
       },
     });
 
-    sh.mkdir('-p', name); // create path/to/dir if needed.
+    // Copy files into current working dir
     sh.cp(
       '-r',
       `${path.join(TEMP, 'templates', projectName)}${path.sep}.`,
-      name
+      '.'
     );
     sh.rm('-r', TEMP);
+
+    // Create a keys dir because it's not part of the project scaffolding given
+    // we have `keys` in our .gitignore.
+    sh.mkdir('keys');
+
     spin.succeed(_green(step));
     return true;
   } catch (err) {
@@ -113,7 +183,7 @@ async function fetchProjectTemplate(name, lang) {
  * Helper for any steps that need to call a shell command.
  * @param {string} step Name of step to show user
  * @param {string} cmd  Shell command to execute.
- * @returns {Promise<void>}
+ * @returns {promise<void>}
  */
 async function step(step, cmd) {
   const spin = ora(`${step}...`).start();
@@ -128,24 +198,15 @@ async function step(step, cmd) {
 /**
  * Step to replace placeholder names in the project with the properly-formatted
  * version of the user-supplied name as specified via `zk project <name>`
- * @param {string} projDir Full path to terminal dir + path/to/name
- * @returns {Promise<void>}
+ * @param {string} name User-provided project name.
+ * @returns {promise<void>}
  */
-async function setProjectName(projDir) {
+async function setProjectName(name) {
   const step = 'Set project name';
   const spin = ora(`${step}...`).start();
 
-  const name = projDir.split(path.sep).pop();
-  replaceInFile(
-    path.join(projDir, 'README.md'),
-    'PROJECT_NAME',
-    titleCase(name)
-  );
-  replaceInFile(
-    path.join(projDir, 'package.json'),
-    'package-name',
-    kebabCase(name)
-  );
+  replaceInFile('README.md', 'PROJECT_NAME', titleCase(name));
+  replaceInFile('package.json', 'package-name', kebabCase(name));
 
   spin.succeed(_green(step));
 }

--- a/src/lib/project.js
+++ b/src/lib/project.js
@@ -44,7 +44,7 @@ async function project({ name, ui }) {
           // Make the step text green upon success, else use the reset color.
           const style =
             state.submitted && !state.cancelled ? state.styles.success : reset;
-          return style('Create a UI for your smart contract too?');
+          return style('Create an accompanying UI project too?');
         },
         prefix: (state) => {
           // Show a cyan question mark when not submitted.

--- a/src/lib/project.js
+++ b/src/lib/project.js
@@ -13,9 +13,10 @@ const shExec = util.promisify(sh.exec);
 /**
  * Create a new zkApp project with recommended dir structure, Prettier config,
  * testing lib, etc. Warns if already exists and does NOT overwrite.
- * @param {string} name  Desired dir name or path. Will recursively create
- *                       dirs without overwriting existing content, if needed.
- * @return {promise<void>}
+ * @param {object} argv - The arguments object provided by yargs.
+ * @param {string} argv.name - The user's desired project name.
+ * @param {string} argv.ui - The name of the UI framework to use.
+ * @return {Promise<void>}
  */
 async function project({ name, ui }) {
   const isWindows = process.platform === 'win32';
@@ -173,7 +174,7 @@ async function project({ name, ui }) {
 
 /**
  * Fetch project template.
- * @returns {promise<boolean>} True if successful; false if not.
+ * @returns {Promise<boolean>} - True if successful; false if not.
  */
 async function fetchProjectTemplate() {
   const projectName = 'project-ts';
@@ -217,9 +218,9 @@ async function fetchProjectTemplate() {
 
 /**
  * Helper for any steps that need to call a shell command.
- * @param {string} step Name of step to show user
- * @param {string} cmd  Shell command to execute.
- * @returns {promise<void>}
+ * @param {string} step - Name of step to show user
+ * @param {string} cmd - Shell command to execute.
+ * @returns {Promise<void>}
  */
 async function step(step, cmd) {
   const spin = ora({ text: `${step}...`, discardStdin: true }).start();
@@ -234,9 +235,9 @@ async function step(step, cmd) {
 /**
  * Step to replace placeholder names in the project with the properly-formatted
  * version of the user-supplied name as specified via `zk project <name>`
- * @param {string} dir Path to the dir containing target files to be changed.
- * @param {string} name User-provided project name.
- * @returns {promise<void>}
+ * @param {string} dir - Path to the dir containing target files to be changed.
+ * @param {string} name - User-provided project name.
+ * @returns {Promise<void>}
  */
 async function setProjectName(dir, name) {
   const step = 'Set project name';
@@ -254,9 +255,9 @@ async function setProjectName(dir, name) {
 
 /**
  * Helper to replace text in a file.
- * @param {string} file Path to file
- * @param {string} a    Old text.
- * @param {string} b    New text.
+ * @param {string} file - Path to file
+ * @param {string} a - Old text.
+ * @param {string} b - New text.
  */
 function replaceInFile(file, a, b) {
   let content = fs.readFileSync(file, 'utf8');

--- a/src/lib/project.js
+++ b/src/lib/project.js
@@ -151,7 +151,7 @@ async function project({ name, ui }) {
     `npm ci --silent > ${isWindows ? 'NUL' : '"/dev/null" 2>&1'}`
   );
 
-  await setProjectName(name.split(path.sep).pop());
+  await setProjectName('.', name.split(path.sep).pop());
 
   if (ui) sh.cd('..'); // back to project root
 
@@ -234,15 +234,20 @@ async function step(step, cmd) {
 /**
  * Step to replace placeholder names in the project with the properly-formatted
  * version of the user-supplied name as specified via `zk project <name>`
+ * @param {string} dir Path to the dir containing target files to be changed.
  * @param {string} name User-provided project name.
  * @returns {promise<void>}
  */
-async function setProjectName(name) {
+async function setProjectName(dir, name) {
   const step = 'Set project name';
   const spin = ora(`${step}...`).start();
 
-  replaceInFile('README.md', 'PROJECT_NAME', titleCase(name));
-  replaceInFile('package.json', 'package-name', kebabCase(name));
+  replaceInFile(path.join(dir, 'README.md'), 'PROJECT_NAME', titleCase(name));
+  replaceInFile(
+    path.join(dir, 'package.json'),
+    'package-name',
+    kebabCase(name)
+  );
 
   spin.succeed(green(step));
 }

--- a/src/lib/project.test.js
+++ b/src/lib/project.test.js
@@ -1,8 +1,6 @@
 const fs = require('fs');
 const path = require('path');
 let {
-  project,
-  step,
   setProjectName,
   replaceInFile,
   titleCase,
@@ -35,20 +33,24 @@ describe('project.js', () => {
 
     it('should replace text in README.md & package.json', () => {
       const DIR = 'temp-fixture-proj';
+      const NAME = 'my-cool-zkapp';
+
       const README = '# Mina zkApp: PROJECT_NAME\n more stuff\n and more';
       const PKG = `{"name": "package-name","version": "0.1.0"}`;
       fs.mkdirSync('temp-fixture-proj', { recursive: true });
       fs.writeFileSync(DIR + '/README.md', README);
       fs.writeFileSync(DIR + '/package.json', PKG);
-      setProjectName(DIR);
+
+      setProjectName(DIR, NAME);
+
       const readmeAfter = fs.readFileSync(path.join(DIR, 'README.md'), 'utf8');
-      expect(readmeAfter.includes('Temp Fixture Proj')).toBeTruthy();
+      expect(readmeAfter.includes('My Cool Zkapp')).toBeTruthy();
       expect(readmeAfter.includes('PROJECT_NAME')).toBeFalsy();
       const packageAfter = fs.readFileSync(
         path.join(DIR, 'package.json'),
         'utf8'
       );
-      expect(packageAfter.includes('temp-fixture-proj')).toBeTruthy();
+      expect(packageAfter.includes('my-cool-zkapp')).toBeTruthy();
       expect(packageAfter.includes('package-name')).toBeFalsy();
       fs.rmSync(DIR, { recursive: true });
     });


### PR DESCRIPTION
Adds ability for a dev to create a UI project that lives alongside their smart contract, in the same directory and git repo.

A dev can do this by providing a `--ui` arg to the `zk project <name>` command:
```
zk project foo --ui svelte     // SvelteKit
zk project foo --ui next       // NextJS
zk project foo --ui vue        // VueJS
zk project foo --ui empty      // empty ui directory
zk project foo --ui none       // no ui directory; only the smart contract (similar to old behavior of `zk project foo`)
zk project foo --ui unsupported // example invalid value; shows an error and tells user to choose one of the supported choices a, b, c.
```
This also allow this method to be called non-interactively inside a shell script.

If no parameter is provided, a dropdown is shown:
```
❯ zk project foo
? Create an accompanying UI project? …
❯ svelte
  next
  vue
  empty
  none
```

Closes https://github.com/o1-labs/zkapp-cli/issues/259 and closes https://github.com/o1-labs/zkapp-cli/issues/269 

_Update: We've decided to use NuxtJS (a Vue metaframework) instead of Vue, since we use NextJS instead of React. See comment below for details._