### PR TITLE
Exit the CLI when a project step fails

### DIFF
--- a/src/lib/project.js
+++ b/src/lib/project.js
@@ -239,7 +239,7 @@ async function step(step, cmd) {
     spin.succeed(green(step));
   } catch (err) {
     spin.fail(step);
-    process.exit();
+    process.exit(1);
   }
 }
 

--- a/src/lib/project.js
+++ b/src/lib/project.js
@@ -239,6 +239,7 @@ async function step(step, cmd) {
     spin.succeed(green(step));
   } catch (err) {
     spin.fail(step);
+    process.exit();
   }
 }
 


### PR DESCRIPTION
Fixes #272 

The CLI now exits when there is a failure in any step during project creation.  We can wait to bump the CLI version until we finish the remaining tasks surrounding the UI scaffold features. 