### PR TITLE
feat: add SnarkyJS to the ui project package.json dependencies

### DIFF
--- a/src/lib/project.js
+++ b/src/lib/project.js
@@ -85,6 +85,12 @@ async function project({ name, ui }) {
         ui = false;
         break;
     }
+
+    // Add SnarkyJS as a dependency in the UI project.
+    let x = fs.readJSONSync(`ui/package.json`);
+    x.dependencies.snarkyjs = '0.*';
+    fs.writeJSONSync(`ui/package.json`, x, { spaces: 2 });
+
     ora(green(`UI: Set up project`)).succeed();
 
     if (ui && ui !== 'empty') {


### PR DESCRIPTION
Closes https://github.com/o1-labs/zkapp-cli/issues/280

To discuss: if we should use `0.*` or `0.6.*` as the version. The latter takes more work to maintain manually or code to get working to stay in sync with the contracts project dir, which isn't yet created at this point in the script.