### PR TITLE
fix for non page files in nextjs projects

### DIFF
--- a/src/lib/project.js
+++ b/src/lib/project.js
@@ -311,6 +311,7 @@ async function scaffoldNext() {
   let newNextConfig = nextConfig.replace(
     /^}(.*?)$/gm, // Search for the last '}' in the file.
     `
+  pageExtensions: ['page.tsx', 'page.ts', 'page.jsx', 'page.js'],
   webpack(config) {
     config.resolve.alias = {
       ...config.resolve.alias,
@@ -344,6 +345,15 @@ async function scaffoldNext() {
     'reactStrictMode: false'
   );
   fs.writeFileSync(path.join('ui', 'next.config.js'), newNextConfig);
+
+  sh.mv(
+    path.join('ui', 'pages', '_app.tsx'),
+    path.join('ui', 'pages', '_app.page.tsx')
+  );
+  sh.mv(
+    path.join('ui', 'index', '_app.tsx'),
+    path.join('ui', 'pages', 'index.page.tsx')
+  );
 
   const tsconfig = `
     {


### PR DESCRIPTION
Includes the change from [here](https://nextjs.org/docs/api-reference/next.config.js/custom-page-extensions#including-non-page-files-in-the-pages-directory) to better support helper files that aren't react components