### PR TITLE
Provide a better error message when an unknown error occurs in deployment

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zkapp-cli",
-  "version": "0.4.19",
+  "version": "0.4.20",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "zkapp-cli",
-      "version": "0.4.19",
+      "version": "0.4.20",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zkapp-cli",
-  "version": "0.4.19",
+  "version": "0.4.20",
   "description": "CLI to create a zkApp (\"zero-knowledge app\") for Mina Protocol.",
   "keywords": [
     "cli",

--- a/src/lib/deploy.js
+++ b/src/lib/deploy.js
@@ -7,6 +7,7 @@ const { table, getBorderCharacters } = require('table');
 const glob = require('fast-glob');
 const { step } = require('./helpers');
 const fetch = require('node-fetch');
+const util = require('util');
 
 const { red, green, bold, reset } = require('chalk');
 const log = console.log;
@@ -419,7 +420,7 @@ async function deploy({ alias, yes }) {
 
   if (!txn || txn?.kind === 'error') {
     // Note that the thrown error object is already console logged via step().
-    log(red(getErrorMessage(txn?.message ?? [])));
+    log(red(getErrorMessage(txn)));
     await shutdown();
     return;
   }
@@ -563,9 +564,10 @@ function getAccountQuery(publicKey) {
   }`;
 }
 
-function getErrorMessage(errors) {
+function getErrorMessage(error) {
+  let errors = error?.message ?? [];
   if (errors.length === 0) {
-    return 'Failed to send transaction. Unknown error.';
+    return `Failed to send transaction. Unknown error: ${util.format(error)}`;
   }
   let errorMessage =
     '  Failed to send transaction to relayer. Errors: ' +

--- a/src/lib/deploy.js
+++ b/src/lib/deploy.js
@@ -419,7 +419,7 @@ async function deploy({ alias, yes }) {
 
   if (!txn || txn?.kind === 'error') {
     // Note that the thrown error object is already console logged via step().
-    log(red(getErrorMessage(txn.message ?? [])));
+    log(red(getErrorMessage(txn?.message ?? [])));
     await shutdown();
     return;
   }
@@ -564,6 +564,9 @@ function getAccountQuery(publicKey) {
 }
 
 function getErrorMessage(errors) {
+  if (errors.length === 0) {
+    return 'Failed to send transaction. Unknown error.';
+  }
   let errorMessage =
     '  Failed to send transaction to relayer. Errors: ' +
     errors.map((e) => e.message);


### PR DESCRIPTION
## Description
Addresses #255 when a deployment fails with an error response that is not in the form we expect. When a GraphQL error occurs, we expect an array of errors to be returned from the endpoint we are issuing. When an error returns that's not an array, an unhelpful message is shown along the lines of:

```sh
zk deploy 
✔ Build project
✔ Generate build.json
✔ Choose smart contract
  The 'Square' smart contract will be used
  for this network as specified in config.json.
✔ Generate verification key (takes 10-30 sec)
  Using the cached verification key
✔ Build transaction
✔ Send to network
zk deploy [alias]

Deploy or redeploy a zkApp

Options:
  -y, --yes      Respond `yes` to all confirmation prompts.
                 Allows running non-interactively within a script.     [boolean]
  -h, --help     Show help                                             [boolean]
  -v, --version  Show version number                                   [boolean]

TypeError: errors.map is not a function
    at getErrorMessage (/usr/lib/node_modules/zkapp-cli/src/lib/deploy.js:569:12)
    at deploy (/usr/lib/node_modules/zkapp-cli/src/lib/deploy.js:422:13)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async Object.handler (/usr/lib/node_modules/zkapp-cli/src/bin/index.js:80:21)
```

This PR makes a change to log `Failed to send transaction. Unknown error` if such an error occurs instead.