### PR TITLE
Bump version of zkapp-cli to 0.5.0 and snarkyjs to 0.7.0

### DIFF
--- a/examples/sudoku/ts/src/sudoku.ts
+++ b/examples/sudoku/ts/src/sudoku.ts
@@ -128,7 +128,7 @@ async function deploy(
     zkAppInstance.init(sudokuInstance);
     zkAppInstance.sign(zkAppPrivateKey);
   });
-  await tx.send().wait();
+  await tx.send();
 }
 
 async function submitSolution(
@@ -144,7 +144,7 @@ async function submitSolution(
     zkApp.sign(zkAppPrivateKey);
   });
   try {
-    await tx.send().wait();
+    await tx.send();
     return true;
   } catch (err) {
     return false;

--- a/examples/tictactoe/ts/src/tictactoe-lib.ts
+++ b/examples/tictactoe/ts/src/tictactoe-lib.ts
@@ -25,7 +25,7 @@ export async function deploy(
     zkAppInstance.init();
     zkAppInstance.sign(zkAppPrivatekey);
   });
-  await txn.send().wait();
+  await txn.send();
 }
 
 export async function makeMove(
@@ -49,5 +49,5 @@ export async function makeMove(
     );
     zkAppInstance.sign(zkAppPrivatekey);
   });
-  await txn.send().wait();
+  await txn.send();
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "mina-signer": "^1.1.0",
         "ora": "^5.4.1",
         "shelljs": "^0.8.5",
-        "snarkyjs": "^0.6.0",
+        "snarkyjs": "^0.7.0",
         "table": "^6.8.0",
         "yargs": "^17.5.1"
       },
@@ -5292,9 +5292,9 @@
       }
     },
     "node_modules/snarkyjs": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/snarkyjs/-/snarkyjs-0.6.0.tgz",
-      "integrity": "sha512-JcPlGrG3Ixi3o76m4nlEKyMxbelh7ZVxThdbWH7CmW81jSid89VGwVuBzVWcnrMElCl8PBV5LOONTO34VsWY8A==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/snarkyjs/-/snarkyjs-0.7.0.tgz",
+      "integrity": "sha512-w0Ogun34bgrpQ7IVfN8//IezJkax9d02OBog9eiTDuzYtw50AVQY8et5j+K4kSNQhnEYkT8JpXtPFdojJhcD3A==",
       "dependencies": {
         "env": "^0.0.2",
         "isomorphic-fetch": "^3.0.0",
@@ -9998,9 +9998,9 @@
       }
     },
     "snarkyjs": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/snarkyjs/-/snarkyjs-0.6.0.tgz",
-      "integrity": "sha512-JcPlGrG3Ixi3o76m4nlEKyMxbelh7ZVxThdbWH7CmW81jSid89VGwVuBzVWcnrMElCl8PBV5LOONTO34VsWY8A==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/snarkyjs/-/snarkyjs-0.7.0.tgz",
+      "integrity": "sha512-w0Ogun34bgrpQ7IVfN8//IezJkax9d02OBog9eiTDuzYtw50AVQY8et5j+K4kSNQhnEYkT8JpXtPFdojJhcD3A==",
       "requires": {
         "env": "^0.0.2",
         "isomorphic-fetch": "^3.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zkapp-cli",
-  "version": "0.4.20",
+  "version": "0.5.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "zkapp-cli",
-      "version": "0.4.20",
+      "version": "0.5.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zkapp-cli",
-  "version": "0.4.20",
+  "version": "0.5.0",
   "description": "CLI to create a zkApp (\"zero-knowledge app\") for Mina Protocol.",
   "keywords": [
     "cli",
@@ -45,7 +45,7 @@
     "mina-signer": "^1.1.0",
     "ora": "^5.4.1",
     "shelljs": "^0.8.5",
-    "snarkyjs": "^0.6.0",
+    "snarkyjs": "^0.7.0",
     "table": "^6.8.0",
     "yargs": "^17.5.1"
   },

--- a/templates/project-ts/package-lock.json
+++ b/templates/project-ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "package-name",
-  "version": "0.1.5",
+  "version": "0.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "package-name",
-      "version": "0.1.5",
+      "version": "0.1.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/preset-env": "^7.16.4",
@@ -24,7 +24,7 @@
         "typescript": "^4.7.2"
       },
       "peerDependencies": {
-        "snarkyjs": "^0.6.0"
+        "snarkyjs": "^0.7.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -7891,9 +7891,9 @@
       "dev": true
     },
     "node_modules/snarkyjs": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/snarkyjs/-/snarkyjs-0.6.0.tgz",
-      "integrity": "sha512-JcPlGrG3Ixi3o76m4nlEKyMxbelh7ZVxThdbWH7CmW81jSid89VGwVuBzVWcnrMElCl8PBV5LOONTO34VsWY8A==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/snarkyjs/-/snarkyjs-0.7.0.tgz",
+      "integrity": "sha512-w0Ogun34bgrpQ7IVfN8//IezJkax9d02OBog9eiTDuzYtw50AVQY8et5j+K4kSNQhnEYkT8JpXtPFdojJhcD3A==",
       "peer": true,
       "dependencies": {
         "env": "^0.0.2",
@@ -14516,9 +14516,9 @@
       }
     },
     "snarkyjs": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/snarkyjs/-/snarkyjs-0.6.0.tgz",
-      "integrity": "sha512-JcPlGrG3Ixi3o76m4nlEKyMxbelh7ZVxThdbWH7CmW81jSid89VGwVuBzVWcnrMElCl8PBV5LOONTO34VsWY8A==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/snarkyjs/-/snarkyjs-0.7.0.tgz",
+      "integrity": "sha512-w0Ogun34bgrpQ7IVfN8//IezJkax9d02OBog9eiTDuzYtw50AVQY8et5j+K4kSNQhnEYkT8JpXtPFdojJhcD3A==",
       "peer": true,
       "requires": {
         "env": "^0.0.2",

--- a/templates/project-ts/package.json
+++ b/templates/project-ts/package.json
@@ -44,6 +44,6 @@
     "typescript": "^4.7.2"
   },
   "peerDependencies": {
-    "snarkyjs": "^0.6.0"
+    "snarkyjs": "^0.7.0"
   }
 }

--- a/templates/project-ts/src/Add.test.ts
+++ b/templates/project-ts/src/Add.test.ts
@@ -33,7 +33,7 @@ async function localDeploy(
     zkAppInstance.init();
     zkAppInstance.sign(zkAppPrivatekey);
   });
-  await txn.send().wait();
+  await txn.send();
 }
 
 describe('Add', () => {
@@ -69,7 +69,7 @@ describe('Add', () => {
       zkAppInstance.update();
       zkAppInstance.sign(zkAppPrivateKey);
     });
-    await txn.send().wait();
+    await txn.send();
 
     const updatedNum = zkAppInstance.num.get();
     expect(updatedNum).toEqual(Field(3));

--- a/templates/project-ts/src/Add.ts
+++ b/templates/project-ts/src/Add.ts
@@ -6,6 +6,7 @@ import {
   method,
   DeployArgs,
   Permissions,
+  PrivateKey,
 } from 'snarkyjs';
 
 /**
@@ -14,7 +15,7 @@ import {
  *
  * The Add contract initializes the state variable 'num' to be a Field(1) value by default when deployed.
  * When the 'update' method is called, the Add contract adds Field(2) to its 'num' contract state.
- * 
+ *
  * This file is safe to delete and replace with your own contract.
  */
 export class Add extends SmartContract {
@@ -28,8 +29,10 @@ export class Add extends SmartContract {
     });
   }
 
-  @method init() {
+  @method init(zkappKey: PrivateKey) {
+    super.init(zkappKey);
     this.num.set(Field(1));
+    this.requireSignature();
   }
 
   @method update() {
@@ -38,5 +41,6 @@ export class Add extends SmartContract {
     const newState = currentState.add(2);
     newState.assertEquals(currentState.add(2));
     this.num.set(newState);
+    this.requireSignature();
   }
 }


### PR DESCRIPTION
For Berkeley redeployment. 

Still needs `npm install` run in this project's root directory and `project-ts` directory, and to commit `package-lock.json`. it's not possible to do that successfully until SnarkyJS is available on NPM at `0.7.0`.