### PR TITLE
Fix Sudoku and enable CLI to create init() proofs

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -11,6 +11,8 @@ module.exports = {
     ecmaVersion: 'latest',
   },
   plugins: ['@typescript-eslint'],
-  rules: {},
+  rules: {
+    'no-constant-condition': 'off',
+  },
   ignorePatterns: ['*.md'],
 };

--- a/examples/sudoku/ts/src/run.ts
+++ b/examples/sudoku/ts/src/run.ts
@@ -32,6 +32,13 @@ let tx = await Mina.transaction(account, () => {
   zkApp.update(Sudoku.from(sudoku));
 });
 await tx.prove();
+/**
+ * note: this tx needs to be signed with `tx.sign()`, because `deploy` uses `requireSignature()` under the hood,
+ * so one of the account updates in this tx has to be authorized with a signature (vs proof).
+ * this is necessary for the deploy tx because the initial permissions for all account fields are "signature".
+ * (but `deploy()` changes some of those permissions to "proof" and adds the verification key that enables proofs.
+ * that's why we don't need `tx.sign()` for the later transactions.)
+ */
 await tx.sign([zkAppPrivateKey]).send();
 
 console.log('Is the sudoku solved?', zkApp.isSolved.get().toBoolean());

--- a/examples/sudoku/ts/src/sudoku-lib.js
+++ b/examples/sudoku/ts/src/sudoku-lib.js
@@ -62,7 +62,6 @@ function solveSudokuInternal(sudoku, deterministic, possible) {
       // no values possible! we failed to get a solution
       if (x === 0) return;
 
-      // console.log('chose', x, 'at', i, j);
       let sudoku_ = cloneSudoku(sudoku);
       let possible_ = cloneSudoku(possible);
       sudoku_[i][j] = x;
@@ -75,7 +74,6 @@ function solveSudokuInternal(sudoku, deterministic, possible) {
 
       // there is no solution with x at i, j!
       // mark this value as impossible and try again
-      // console.log('backtracking...');
       possible[i][j][x - 1] = 0;
     }
   }
@@ -117,8 +115,6 @@ function chooseRandomPossible(i, j, possible) {
     .filter((b) => b);
   let n = possibleValues.length;
   if (n === 0) return 0;
-  // if (j === 0) console.log();
-  // console.log('possible at', i, j, ':', possibleValues.join(','));
   let k = Math.floor(Math.random() * n);
   return possibleValues[k];
 }

--- a/examples/sudoku/ts/src/sudoku.test.ts
+++ b/examples/sudoku/ts/src/sudoku.test.ts
@@ -18,7 +18,7 @@ describe('sudoku', () => {
 
   beforeEach(async () => {
     await isReady;
-    let Local = Mina.LocalBlockchain();
+    let Local = Mina.LocalBlockchain({ proofsEnabled: false });
     Mina.setActiveInstance(Local);
     account = Local.testAccounts[0].privateKey;
     zkAppPrivateKey = PrivateKey.random();
@@ -69,7 +69,6 @@ async function deploy(
   sudoku: number[][],
   account: PrivateKey
 ) {
-  await SudokuZkApp.compile();
   let tx = await Mina.transaction(account, () => {
     AccountUpdate.fundNewAccount(account);
     let sudokuInstance = Sudoku.from(sudoku);

--- a/examples/sudoku/ts/src/sudoku.ts
+++ b/examples/sudoku/ts/src/sudoku.ts
@@ -1,6 +1,4 @@
 import {
-  matrixProp,
-  CircuitValue,
   Field,
   SmartContract,
   method,
@@ -9,23 +7,19 @@ import {
   State,
   isReady,
   Poseidon,
-  Permissions,
-  Mina,
-  AccountUpdate,
-  PrivateKey,
-  PublicKey,
+  Struct,
+  Circuit,
 } from 'snarkyjs';
 
-export { deploy, submitSolution, getZkAppState, createLocalBlockchain };
+export { Sudoku, SudokuZkApp };
 
 await isReady;
 
-class Sudoku extends CircuitValue {
-  @matrixProp(Field, 9, 9) value: Field[][];
-
-  constructor(value: number[][]) {
-    super();
-    this.value = value.map((row) => row.map(Field));
+class Sudoku extends Struct({
+  value: Circuit.array(Circuit.array(Field, 9), 9),
+}) {
+  static from(value: number[][]) {
+    return new Sudoku({ value: value.map((row) => row.map(Field)) });
   }
 
   hash() {
@@ -33,11 +27,16 @@ class Sudoku extends CircuitValue {
   }
 }
 
-export class SudokuZkApp extends SmartContract {
+class SudokuZkApp extends SmartContract {
   @state(Field) sudokuHash = State<Field>();
   @state(Bool) isSolved = State<Bool>();
 
-  @method init(sudokuInstance: Sudoku) {
+  // by making this a `@method`, we ensure that a proof is created for the state initialization
+  @method init() {
+    super.init();
+  }
+
+  @method update(sudokuInstance: Sudoku) {
     this.sudokuHash.set(sudokuInstance.hash());
     this.isSolved.set(Bool(false));
   }
@@ -56,7 +55,7 @@ export class SudokuZkApp extends SmartContract {
       oneTo9
         .map((k) => range9.map((i) => array[i].equals(k)).reduce(Bool.or))
         .reduce(Bool.and)
-        .assertEquals(true);
+        .assertTrue('array contains the numbers 1...9');
     }
 
     // check all rows
@@ -100,68 +99,7 @@ export class SudokuZkApp extends SmartContract {
   }
 }
 
-// helpers
-function createLocalBlockchain(): PrivateKey {
-  let Local = Mina.LocalBlockchain();
-  Mina.setActiveInstance(Local);
-
-  const account = Local.testAccounts[0].privateKey;
-  return account;
-}
-
-async function deploy(
-  zkAppInstance: SudokuZkApp,
-  zkAppPrivateKey: PrivateKey,
-  sudoku: number[][],
-  account: PrivateKey
-) {
-  let tx = await Mina.transaction(account, () => {
-    AccountUpdate.fundNewAccount(account);
-
-    let sudokuInstance = new Sudoku(sudoku);
-    zkAppInstance.deploy({ zkappKey: zkAppPrivateKey });
-    zkAppInstance.setPermissions({
-      ...Permissions.default(),
-      editState: Permissions.proofOrSignature(),
-    });
-
-    zkAppInstance.init(sudokuInstance);
-    zkAppInstance.sign(zkAppPrivateKey);
-  });
-  await tx.send();
-}
-
-async function submitSolution(
-  sudoku: number[][],
-  solution: number[][],
-  account: PrivateKey,
-  zkAppAddress: PublicKey,
-  zkAppPrivateKey: PrivateKey
-) {
-  let tx = await Mina.transaction(account, () => {
-    let zkApp = new SudokuZkApp(zkAppAddress);
-    zkApp.submitSolution(new Sudoku(sudoku), new Sudoku(solution));
-    zkApp.sign(zkAppPrivateKey);
-  });
-  try {
-    await tx.send();
-    return true;
-  } catch (err) {
-    return false;
-  }
-}
-
-function getZkAppState(zkAppInstance: SudokuZkApp) {
-  let sudokuHash = fieldToHex(zkAppInstance.sudokuHash.get());
-  let isSolved = zkAppInstance.isSolved.get().toBoolean();
-  return { sudokuHash, isSolved };
-}
-
 function divmod(k: number, n: number) {
   let q = Math.floor(k / n);
   return [q, k - q * n];
-}
-
-function fieldToHex(field: Field) {
-  return BigInt(field.toString()).toString(16);
 }

--- a/templates/project-ts/.eslintrc.cjs
+++ b/templates/project-ts/.eslintrc.cjs
@@ -11,5 +11,7 @@ module.exports = {
     ecmaVersion: 'latest',
   },
   plugins: ['@typescript-eslint', 'snarkyjs'],
-  rules: {},
+  rules: {
+    'no-constant-condition': 'off',
+  },
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "es2020",
+    "module": "es2022",
+    "lib": ["dom", "esnext"],
+    "outDir": "./build",
+    "rootDir": ".",
+    "strict": true,
+    "strictPropertyInitialization": false, // to enable generic constructors, e.g. on CircuitValue
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "esModuleInterop": true,
+    "moduleResolution": "node",
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+    "allowJs": true,
+    "declaration": true,
+    "sourceMap": true,
+    "noFallthroughCasesInSwitch": true,
+    "allowSyntheticDefaultImports": true,
+    "isolatedModules": true
+  },
+  "include": ["./templates", "./examples"]
+}


### PR DESCRIPTION
This PR
- fixes the sudoku example
- does a fairly large refactor of the sudoku example, so that it doesn't rely on `this.sign()`, uses Struct instead of CircuitValue, uses snarkyjs APIs directly instead of custom helper functions, and makes `run.ts` script use proofs (the tests use `proofsEnabled: false`)
- during deployment, checks if the smart contract has `init()` decorated with `@method`. If yes, then we have to create a proof to deploy successfully; this is done in a separate step that's shown to the user, after building the transaction

Other small changes:
- Add TS config at the top level so we have proper type feedback in the examples
- Tweak eslint config to not show an error for the sudoku code