### PR TITLE
Fix Add, add interaction script and release 0.5.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zkapp-cli",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "zkapp-cli",
-      "version": "0.5.2",
+      "version": "0.5.3",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "mina-signer": "^1.1.0",
         "ora": "^5.4.1",
         "shelljs": "^0.8.5",
-        "snarkyjs": "^0.7.2",
+        "snarkyjs": "^0.7.3",
         "table": "^6.8.0",
         "yargs": "^17.5.1"
       },
@@ -5292,9 +5292,9 @@
       }
     },
     "node_modules/snarkyjs": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/snarkyjs/-/snarkyjs-0.7.2.tgz",
-      "integrity": "sha512-nCbzxsAkqAz9bZKi8YAq3bz9TGPKhvNhQIN6pX2FyWSs+idGCs5YN/veXBH00cso6in2vmLENULXkCdxyAe/RA==",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/snarkyjs/-/snarkyjs-0.7.3.tgz",
+      "integrity": "sha512-PA+UMugISjBOq/iAiQugdoJg3jFJkqdNMige/BWm9TE8HfBYDxjoh7Aj6YIm4+RO/vHwzOcTtkfKR9OrKY+c+A==",
       "dependencies": {
         "env": "^0.0.2",
         "isomorphic-fetch": "^3.0.0",
@@ -9998,9 +9998,9 @@
       }
     },
     "snarkyjs": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/snarkyjs/-/snarkyjs-0.7.2.tgz",
-      "integrity": "sha512-nCbzxsAkqAz9bZKi8YAq3bz9TGPKhvNhQIN6pX2FyWSs+idGCs5YN/veXBH00cso6in2vmLENULXkCdxyAe/RA==",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/snarkyjs/-/snarkyjs-0.7.3.tgz",
+      "integrity": "sha512-PA+UMugISjBOq/iAiQugdoJg3jFJkqdNMige/BWm9TE8HfBYDxjoh7Aj6YIm4+RO/vHwzOcTtkfKR9OrKY+c+A==",
       "requires": {
         "env": "^0.0.2",
         "isomorphic-fetch": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zkapp-cli",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "CLI to create a zkApp (\"zero-knowledge app\") for Mina Protocol.",
   "keywords": [
     "cli",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "mina-signer": "^1.1.0",
     "ora": "^5.4.1",
     "shelljs": "^0.8.5",
-    "snarkyjs": "^0.7.2",
+    "snarkyjs": "^0.7.3",
     "table": "^6.8.0",
     "yargs": "^17.5.1"
   },

--- a/src/lib/deploy.js
+++ b/src/lib/deploy.js
@@ -332,8 +332,8 @@ async function deploy({ alias, yes }) {
   }
 
   let transaction = await step('Build transaction', async () => {
-    let Berkeley = Mina.BerkeleyQANet(graphQLEndpoint);
-    Mina.setActiveInstance(Berkeley);
+    let Network = Mina.Network(graphQLEndpoint);
+    Mina.setActiveInstance(Network);
     let tx = await Mina.transaction(
       { feePayerKey: zkAppPrivateKey, fee },
       () => {

--- a/src/lib/deploy.js
+++ b/src/lib/deploy.js
@@ -177,8 +177,9 @@ async function deploy({ alias, yes }) {
   if (process.platform === 'win32') {
     snarkyjsImportPath = 'file://' + snarkyjsImportPath;
   }
-  let { isReady, shutdown, PrivateKey, addCachedAccount, Mina, Bool } =
-    await import(snarkyjsImportPath);
+  let { isReady, shutdown, PrivateKey, Mina, Bool } = await import(
+    snarkyjsImportPath
+  );
 
   const graphQLEndpoint = config?.networks[alias]?.url ?? DEFAULT_GRAPHQL;
   const { data: nodeStatus } = await sendGraphQL(
@@ -319,7 +320,6 @@ async function deploy({ alias, yes }) {
   const accountQuery = getAccountQuery(zkAppAddressBase58);
   const accountResponse = await sendGraphQL(graphQLEndpoint, accountQuery);
 
-  let nonce = 0;
   if (!accountResponse?.data?.account) {
     // No account is found, show an error message and return early
     log(
@@ -329,13 +329,11 @@ async function deploy({ alias, yes }) {
     );
     await shutdown();
     return;
-  } else {
-    // Account nonce value is found from the network
-    nonce = Number(accountResponse.data.account.nonce);
   }
 
   let transaction = await step('Build transaction', async () => {
-    addCachedAccount({ publicKey: zkAppAddressBase58, nonce });
+    let Berkeley = Mina.BerkeleyQANet(graphQLEndpoint);
+    Mina.setActiveInstance(Berkeley);
     let tx = await Mina.transaction(
       { feePayerKey: zkAppPrivateKey, fee },
       () => {

--- a/templates/project-ts/package-lock.json
+++ b/templates/project-ts/package-lock.json
@@ -24,7 +24,7 @@
         "typescript": "^4.7.2"
       },
       "peerDependencies": {
-        "snarkyjs": "^0.7.2"
+        "snarkyjs": "^0.7.3"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -7891,9 +7891,9 @@
       "dev": true
     },
     "node_modules/snarkyjs": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/snarkyjs/-/snarkyjs-0.7.2.tgz",
-      "integrity": "sha512-nCbzxsAkqAz9bZKi8YAq3bz9TGPKhvNhQIN6pX2FyWSs+idGCs5YN/veXBH00cso6in2vmLENULXkCdxyAe/RA==",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/snarkyjs/-/snarkyjs-0.7.3.tgz",
+      "integrity": "sha512-PA+UMugISjBOq/iAiQugdoJg3jFJkqdNMige/BWm9TE8HfBYDxjoh7Aj6YIm4+RO/vHwzOcTtkfKR9OrKY+c+A==",
       "peer": true,
       "dependencies": {
         "env": "^0.0.2",
@@ -14516,9 +14516,9 @@
       }
     },
     "snarkyjs": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/snarkyjs/-/snarkyjs-0.7.2.tgz",
-      "integrity": "sha512-nCbzxsAkqAz9bZKi8YAq3bz9TGPKhvNhQIN6pX2FyWSs+idGCs5YN/veXBH00cso6in2vmLENULXkCdxyAe/RA==",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/snarkyjs/-/snarkyjs-0.7.3.tgz",
+      "integrity": "sha512-PA+UMugISjBOq/iAiQugdoJg3jFJkqdNMige/BWm9TE8HfBYDxjoh7Aj6YIm4+RO/vHwzOcTtkfKR9OrKY+c+A==",
       "peer": true,
       "requires": {
         "env": "^0.0.2",

--- a/templates/project-ts/package.json
+++ b/templates/project-ts/package.json
@@ -44,6 +44,6 @@
     "typescript": "^4.7.2"
   },
   "peerDependencies": {
-    "snarkyjs": "^0.7.2"
+    "snarkyjs": "^0.7.3"
   }
 }

--- a/templates/project-ts/src/Add.ts
+++ b/templates/project-ts/src/Add.ts
@@ -1,13 +1,4 @@
-import {
-  Field,
-  SmartContract,
-  state,
-  State,
-  method,
-  DeployArgs,
-  Permissions,
-  PrivateKey,
-} from 'snarkyjs';
+import { Field, SmartContract, state, State, method } from 'snarkyjs';
 
 /**
  * Basic Example
@@ -21,26 +12,15 @@ import {
 export class Add extends SmartContract {
   @state(Field) num = State<Field>();
 
-  deploy(args: DeployArgs) {
-    super.deploy(args);
-    this.setPermissions({
-      ...Permissions.default(),
-      editState: Permissions.proofOrSignature(),
-    });
-  }
-
-  @method init(zkappKey: PrivateKey) {
-    super.init(zkappKey);
+  init() {
+    super.init();
     this.num.set(Field(1));
-    this.requireSignature();
   }
 
   @method update() {
     const currentState = this.num.get();
     this.num.assertEquals(currentState); // precondition that links this.num.get() to the actual on-chain state
     const newState = currentState.add(2);
-    newState.assertEquals(currentState.add(2));
     this.num.set(newState);
-    this.requireSignature();
   }
 }

--- a/templates/project-ts/src/interact.ts
+++ b/templates/project-ts/src/interact.ts
@@ -39,8 +39,8 @@ let key: { privateKey: string } = JSON.parse(
 let zkAppKey = PrivateKey.fromBase58(key.privateKey);
 
 // set up Mina instance and contract we interact with
-const Berkeley = Mina.Network(config.url);
-Mina.setActiveInstance(Berkeley);
+const Network = Mina.Network(config.url);
+Mina.setActiveInstance(Network);
 let zkAppAddress = zkAppKey.toPublicKey();
 let zkApp = new Add(zkAppAddress);
 

--- a/templates/project-ts/src/interact.ts
+++ b/templates/project-ts/src/interact.ts
@@ -1,0 +1,69 @@
+/**
+ * This script can be used to interact with the Add contract, after deploying it.
+ *
+ * We call the update() method on the contract, create a proof and send it to the chain.
+ * The endpoint that we interact with is read from your config.json.
+ *
+ * This simulates a user interacting with the zkApp from a browser, except that here, sending the transaction happens
+ * from the script and we're using your pre-funded zkApp account to pay the transaction fee. In a real web app, the user's wallet
+ * would send the transaction and pay the fee.
+ *
+ * To run locally:
+ * Build the project: `$ npm run build`
+ * Run with node:     `$ node build/src/interact.js <network>`.
+ */
+import { Mina, PrivateKey, shutdown } from 'snarkyjs';
+import fs from 'fs/promises';
+import { Add } from './Add.js';
+
+// check command line arg
+let network = process.argv[2];
+if (!network)
+  throw Error(`Missing <network> argument.
+
+Usage:
+node build/src/interact.js <network>
+
+Example:
+node build/src/interact.js berkeley
+`);
+Error.stackTraceLimit = 1000;
+
+// parse config and private key from file
+type Config = { networks: Record<string, { url: string; keyPath: string }> };
+let configJson: Config = JSON.parse(await fs.readFile('config.json', 'utf8'));
+let config = configJson.networks[network];
+let key: { privateKey: string } = JSON.parse(
+  await fs.readFile(config.keyPath, 'utf8')
+);
+let zkAppKey = PrivateKey.fromBase58(key.privateKey);
+
+// set up Mina instance and contract we interact with
+const Berkeley = Mina.BerkeleyQANet(config.url);
+Mina.setActiveInstance(Berkeley);
+let zkAppAddress = zkAppKey.toPublicKey();
+let zkApp = new Add(zkAppAddress);
+
+// compile the contract to create prover keys
+console.log('compile the contract...');
+await Add.compile();
+
+// call update() and send transaction
+console.log('build transaction and create proof...');
+let tx = await Mina.transaction({ feePayerKey: zkAppKey, fee: 0.1e9 }, () => {
+  zkApp.update();
+});
+await tx.prove();
+console.log('send transaction...');
+let sentTx = await tx.send();
+
+if (sentTx.hash() !== undefined) {
+  console.log(`
+Success! Update transaction sent.
+
+Your smart contract state will be updated
+as soon as the transaction is included in a block:
+https://berkeley.minaexplorer.com/transaction/${sentTx.hash()}
+`);
+}
+shutdown();

--- a/templates/project-ts/src/interact.ts
+++ b/templates/project-ts/src/interact.ts
@@ -39,7 +39,7 @@ let key: { privateKey: string } = JSON.parse(
 let zkAppKey = PrivateKey.fromBase58(key.privateKey);
 
 // set up Mina instance and contract we interact with
-const Berkeley = Mina.BerkeleyQANet(config.url);
+const Berkeley = Mina.Network(config.url);
 Mina.setActiveInstance(Berkeley);
 let zkAppAddress = zkAppKey.toPublicKey();
 let zkApp = new Add(zkAppAddress);


### PR DESCRIPTION
- refactors the Add contract similarly to [Sudoku](https://github.com/o1-labs/zkapp-cli/pull/315)
- fixes the way `zk deploy` gets the current account, so that it can determine whether to call `init()` correctly
- adds a script `interact.ts` which can be invoked by users after deploying their contract, with detailed comments
- bumps release

TODOs:
- [x] test deploy
 - https://berkeley.minaexplorer.com/wallet/B62qrDe16LotjQhPRMwG12xZ8Yf5ES8ehNzZ25toJV28tE9FmeGq23A
- [x] test interaction (with script -- see account)