### PR TITLE
Fix build errors after `zk file`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zkapp-cli",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "zkapp-cli",
-      "version": "0.5.3",
+      "version": "0.5.4",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zkapp-cli",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "CLI to create a zkApp (\"zero-knowledge app\") for Mina Protocol.",
   "keywords": [
     "cli",

--- a/src/lib/file.js
+++ b/src/lib/file.js
@@ -41,7 +41,7 @@ async function file(_path) {
 
   // TODO: Add SnarkyJS import to fileContent, when it's ready.
   const fileContent = ``;
-  const testContent = `import ${projName} from './${projName}';
+  const testContent = `// import { ${projName} } from './${projName}';
 
 describe('${projName}.js', () => {
   describe('${projName}()', () => {

--- a/templates/project-ts/tsconfig.json
+++ b/templates/project-ts/tsconfig.json
@@ -17,8 +17,7 @@
     "declaration": true,
     "sourceMap": true,
     "noFallthroughCasesInSwitch": true,
-    "allowSyntheticDefaultImports": true,
-    "isolatedModules": true
+    "allowSyntheticDefaultImports": true
   },
   "include": ["./src"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,8 +17,7 @@
     "declaration": true,
     "sourceMap": true,
     "noFallthroughCasesInSwitch": true,
-    "allowSyntheticDefaultImports": true,
-    "isolatedModules": true
+    "allowSyntheticDefaultImports": true
   },
   "include": ["./templates", "./examples"]
 }


### PR DESCRIPTION
this PR makes two changes which are a frequent source of errors when building fresh projects, and in particular, currently break at least two of the tutorials

* remove the `isolatedModules` flag from the TS config. this flag frequently causes errors about not being able to compile files without import/exports (e.g., as created by the `zk file` command). I don't see benefits of having this flag on which would make up for that
* change the `zk file` command, to not add an import in the test file like `import Contract from './Contract'`
  * since the `Contract.ts` file is initially empty, the test file is initially wrong and can't be built
  * also, it assumes that the smart contract is exported as default, while all our examples export it as a named export
  * so I commented the line out in the test, and changed it to assume a named export
  
I'm also bumping the version number to get this fix to the community quickly