### PR TITLE
Show a warning when user must upgrade their zkApp-cli version

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -13,7 +13,6 @@ module.exports = {
   plugins: ['@typescript-eslint'],
   rules: {
     'no-constant-condition': 'off',
-    'no-unused-vars': 'off',
   },
   ignorePatterns: ['*.md'],
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -13,6 +13,7 @@ module.exports = {
   plugins: ['@typescript-eslint'],
   rules: {
     'no-constant-condition': 'off',
+    'no-unused-vars': 'off',
   },
   ignorePatterns: ['*.md'],
 };

--- a/src/lib/deploy.js
+++ b/src/lib/deploy.js
@@ -59,8 +59,9 @@ async function deploy({ alias, yes }) {
     JSON.parse(globalInstalledPkg).npmGlobalPackages['zkapp-cli'];
 
   if (installedCliVersion !== latestCliVersion) {
-    log(red('You are using an old zkapp-cli version.'));
-    log(red('Run `npm upgrade -g zkapp-cli && npm update snarkyjs.'));
+    log(red(`You are using an old zkapp-cli version ${installedCliVersion}.`));
+    log(red(`The current version is ${latestCliVersion}.`));
+    log(red('Run `npm upgrade -g zkapp-cli && npm update snarkyjs`.'));
     return;
   }
 

--- a/src/lib/deploy.js
+++ b/src/lib/deploy.js
@@ -40,6 +40,11 @@ async function deploy({ alias, yes }) {
     return;
   }
 
+  // Query npm registry to get the latest CLI version.
+  const npmResponse = await fetch(
+    'https://registry.npmjs.org/-/package/zkapp-cli/dist-tags'
+  );
+
   if (!alias) {
     const aliases = Object.keys(config?.networks);
     if (!aliases.length) {

--- a/src/lib/deploy.js
+++ b/src/lib/deploy.js
@@ -8,6 +8,7 @@ const glob = require('fast-glob');
 const { step } = require('./helpers');
 const fetch = require('node-fetch');
 const util = require('util');
+const envinfo = require('envinfo');
 
 const { red, green, bold, reset } = require('chalk');
 const log = console.log;
@@ -44,6 +45,10 @@ async function deploy({ alias, yes }) {
   const npmResponse = await fetch(
     'https://registry.npmjs.org/-/package/zkapp-cli/dist-tags'
   );
+
+  const globalInstalledPkg = await envinfo.run({
+    npmGlobalPackages: ['zkapp-cli'],
+  });
 
   if (!alias) {
     const aliases = Object.keys(config?.networks);

--- a/src/lib/deploy.js
+++ b/src/lib/deploy.js
@@ -58,7 +58,7 @@ async function deploy({ alias, yes }) {
   const installedCliVersion =
     JSON.parse(globalInstalledPkg).npmGlobalPackages['zkapp-cli'];
 
-  if (installedCliVersion !== latestCliVersion) {
+  if (installedCliVersion.split('.')[1] !== latestCliVersion.split('.')[1]) {
     log(red(`You are using an old zkapp-cli version ${installedCliVersion}.`));
     log(red(`The current version is ${latestCliVersion}.`));
     log(red('Run `npm upgrade -g zkapp-cli && npm update snarkyjs`.'));

--- a/src/lib/deploy.js
+++ b/src/lib/deploy.js
@@ -58,7 +58,7 @@ async function deploy({ alias, yes }) {
   const installedCliVersion =
     JSON.parse(globalInstalledPkg).npmGlobalPackages['zkapp-cli'];
 
-  if (installedCliVersion.split('.')[1] !== latestCliVersion.split('.')[1]) {
+  if (hasBreakingChanges(installedCliVersion, latestCliVersion)) {
     log(red(`You are using an old zkapp-cli version ${installedCliVersion}.`));
     log(red(`The current version is ${latestCliVersion}.`));
     log(red('Run `npm upgrade -g zkapp-cli && npm update snarkyjs`.'));
@@ -474,6 +474,17 @@ async function deploy({ alias, yes }) {
 
   log(green(str));
   await shutdown();
+}
+
+/*
+While SnarkyJS and the zkApp CLI have a major version of 0,
+a change of the minor version represents a breaking change.
+When SnarkyJS and the zkApp have a major version of 1 or higher,
+changes to the major version of the zkapp-cli will represnt
+breaking changes, following semver.
+*/
+function hasBreakingChanges(version1, version2) {
+  return version1.split('.')[1] !== version2.split('.')[1];
 }
 
 /**

--- a/src/lib/deploy.js
+++ b/src/lib/deploy.js
@@ -42,9 +42,11 @@ async function deploy({ alias, yes }) {
   }
 
   // Query npm registry to get the latest CLI version.
-  const npmResponse = await fetch(
+  const latestCliVersion = await fetch(
     'https://registry.npmjs.org/-/package/zkapp-cli/dist-tags'
-  );
+  )
+    .then((response) => response.json())
+    .then((response) => response['latest']);
 
   const globalInstalledPkg = await envinfo.run({
     npmGlobalPackages: ['zkapp-cli'],

--- a/src/lib/deploy.js
+++ b/src/lib/deploy.js
@@ -58,6 +58,12 @@ async function deploy({ alias, yes }) {
   const installedCliVersion =
     JSON.parse(globalInstalledPkg).npmGlobalPackages['zkapp-cli'];
 
+  if (installedCliVersion !== latestCliVersion) {
+    log(red('You are using an old zkapp-cli version.'));
+    log(red('Run `npm upgrade -g zkapp-cli && npm update snarkyjs.'));
+    return;
+  }
+
   if (!alias) {
     const aliases = Object.keys(config?.networks);
     if (!aliases.length) {

--- a/src/lib/deploy.js
+++ b/src/lib/deploy.js
@@ -48,9 +48,15 @@ async function deploy({ alias, yes }) {
     .then((response) => response.json())
     .then((response) => response['latest']);
 
-  const globalInstalledPkg = await envinfo.run({
-    npmGlobalPackages: ['zkapp-cli'],
-  });
+  const globalInstalledPkg = await envinfo.run(
+    {
+      npmGlobalPackages: ['zkapp-cli'],
+    },
+    { json: true }
+  );
+
+  const installedCliVersion =
+    JSON.parse(globalInstalledPkg).npmGlobalPackages['zkapp-cli'];
 
   if (!alias) {
     const aliases = Object.keys(config?.networks);


### PR DESCRIPTION
**Addresses**
#247 

**Background**

Developers who are using old versions of the `zkapp-cli` after the protocol and SnarkyJS are upgraded, can experience error messages that are unclear without guidance for a path forward.

**Approach**

When a developer runs `zk deploy` npm is queried to get the latest version of zkApp-cli. If the the developers installed version is deemed to break from the current zkApp-cli version, a warning is shown to update the cli and upgrade SnarkyJS. See the discussion [here](https://github.com/o1-labs/zkapp-cli/issues/247) for more details.
 
**Tested** 
 
This version was tested by installing locally via `npm link` and toggling the version number to observe the expected warning behavior. 