### PR TITLE
Fix hung CLI after creating new project

### DIFF
--- a/src/lib/project.js
+++ b/src/lib/project.js
@@ -169,6 +169,7 @@ async function project({ name, ui }) {
     `\n  git push -u origin main`;
 
   console.log(green(str));
+  process.exit(0);
 }
 
 /**


### PR DESCRIPTION
Issue: Terminal console logging is stuck after creating a new project via command `zk project <newProject>`
Change: Added `process.exit(0)` so that the process exits without having the user terminating manually.  

CLI output: 
```bash
Next steps:
  cd testapp1
  git remote add origin <your-repo-url>
  git push -u origin main  # process should exit properly here
```
