### PR TITLE
Fix "cannot find module" when running jest tests

### DIFF
--- a/templates/project-ts/jest.config.js
+++ b/templates/project-ts/jest.config.js
@@ -17,4 +17,7 @@ export default {
     '<rootDir>/node_modules/(?!snarkyjs/node_modules/tslib)',
   ],
   modulePathIgnorePatterns: ['<rootDir>/build/'],
+  moduleNameMapper: {
+    '^(\\.{1,2}/.+)\\.js$': '$1',
+  }
 };


### PR DESCRIPTION
It seems the jest tests fail if you use `.js` in the file path names. Conversely, `npm run start` fails if you don't have `.js` in the filename

To solve this problem, I make that Jest maps imports that end in `.js` to ones that don't. Seems to fix the issue

https://stackoverflow.com/a/69598249/1780045