### PR TITLE
Update to SnarkyJS 0.8.0 [Do Not Merge Until SnarkyJS 0.8.0 is Published to npm and Added]

### DIFF
--- a/examples/sudoku/ts/src/run.ts
+++ b/examples/sudoku/ts/src/run.ts
@@ -56,7 +56,7 @@ try {
     zkApp.submitSolution(Sudoku.from(sudoku), Sudoku.from(noSolution));
   });
   await tx.prove();
-  await tx.send();
+  await tx.sign([senderKey]).send();
 } catch {
   console.log('There was an error submitting the solution, as expected');
 }
@@ -68,7 +68,7 @@ tx = await Mina.transaction(sender, () => {
   zkApp.submitSolution(Sudoku.from(sudoku), Sudoku.from(solution!));
 });
 await tx.prove();
-await tx.send();
+await tx.sign([senderKey]).send();
 console.log('Is the sudoku solved?', zkApp.isSolved.get().toBoolean());
 
 // cleanup

--- a/examples/sudoku/ts/src/run.ts
+++ b/examples/sudoku/ts/src/run.ts
@@ -17,7 +17,7 @@ import { AccountUpdate, Mina, PrivateKey, shutdown } from 'snarkyjs';
 const Local = Mina.LocalBlockchain();
 Mina.setActiveInstance(Local);
 
-const account = Local.testAccounts[0].privateKey;
+const { publicKey: deployerAccount } = Local.testAccounts[0];
 const sudoku = generateSudoku(0.5);
 const zkAppPrivateKey = PrivateKey.random();
 const zkAppAddress = zkAppPrivateKey.toPublicKey();
@@ -26,8 +26,8 @@ const zkApp = new SudokuZkApp(zkAppAddress);
 
 console.log('Deploying and initializing Sudoku...');
 await SudokuZkApp.compile();
-let tx = await Mina.transaction(account, () => {
-  AccountUpdate.fundNewAccount(account);
+let tx = await Mina.transaction(deployerAccount, () => {
+  AccountUpdate.fundNewAccount(deployerAccount);
   zkApp.deploy();
   zkApp.update(Sudoku.from(sudoku));
 });
@@ -52,7 +52,7 @@ noSolution[0][0] = (noSolution[0][0] % 9) + 1;
 
 console.log('Submitting wrong solution...');
 try {
-  let tx = await Mina.transaction(account, () => {
+  let tx = await Mina.transaction(deployerAccount, () => {
     zkApp.submitSolution(Sudoku.from(sudoku), Sudoku.from(noSolution));
   });
   await tx.prove();
@@ -64,7 +64,7 @@ console.log('Is the sudoku solved?', zkApp.isSolved.get().toBoolean());
 
 // submit the actual solution
 console.log('Submitting solution...');
-tx = await Mina.transaction(account, () => {
+tx = await Mina.transaction(deployerAccount, () => {
   zkApp.submitSolution(Sudoku.from(sudoku), Sudoku.from(solution!));
 });
 await tx.prove();

--- a/examples/sudoku/ts/src/sudoku.test.ts
+++ b/examples/sudoku/ts/src/sudoku.test.ts
@@ -14,13 +14,13 @@ describe('sudoku', () => {
     zkAppPrivateKey: PrivateKey,
     zkAppAddress: PublicKey,
     sudoku: number[][],
-    account: PrivateKey;
+    account: PublicKey;
 
   beforeEach(async () => {
     await isReady;
     let Local = Mina.LocalBlockchain({ proofsEnabled: false });
     Mina.setActiveInstance(Local);
-    account = Local.testAccounts[0].privateKey;
+    account = Local.testAccounts[0].publicKey;
     zkAppPrivateKey = PrivateKey.random();
     zkAppAddress = zkAppPrivateKey.toPublicKey();
     zkApp = new SudokuZkApp(zkAppAddress);
@@ -77,7 +77,7 @@ async function deploy(
   zkApp: SudokuZkApp,
   zkAppPrivateKey: PrivateKey,
   sudoku: number[][],
-  account: PrivateKey
+  account: PublicKey
 ) {
   let tx = await Mina.transaction(account, () => {
     AccountUpdate.fundNewAccount(account);

--- a/examples/sudoku/ts/src/sudoku.test.ts
+++ b/examples/sudoku/ts/src/sudoku.test.ts
@@ -46,7 +46,7 @@ describe('sudoku', () => {
       zkApp.submitSolution(Sudoku.from(sudoku), Sudoku.from(solution!));
     });
     await tx.prove();
-    await tx.send();
+    await tx.sign([senderKey]).send();
 
     isSolved = zkApp.isSolved.get().toBoolean();
     expect(isSolved).toBe(true);
@@ -67,7 +67,7 @@ describe('sudoku', () => {
         zkApp.submitSolution(Sudoku.from(sudoku), Sudoku.from(noSolution));
       });
       await tx.prove();
-      await tx.send();
+      await tx.sign([senderKey]).send();
     }).rejects.toThrow(/array contains the numbers 1...9/);
 
     let isSolved = zkApp.isSolved.get().toBoolean();

--- a/examples/tictactoe/ts/src/run.ts
+++ b/examples/tictactoe/ts/src/run.ts
@@ -24,7 +24,8 @@ import { TicTacToe, Board } from './tictactoe.js';
 await isReady;
 let Local = Mina.LocalBlockchain({ proofsEnabled: false });
 Mina.setActiveInstance(Local);
-const [{ privateKey: player1 }, { privateKey: player2 }] = Local.testAccounts;
+const [{ publicKey: player1, privateKey: player1Key }, { publicKey: player2 }] =
+  Local.testAccounts;
 
 const zkAppPrivateKey = PrivateKey.random();
 const zkAppPublicKey = zkAppPrivateKey.toPublicKey();
@@ -35,7 +36,7 @@ console.log('\n\n====== DEPLOYING ======\n\n');
 const txn = await Mina.transaction(player1, () => {
   AccountUpdate.fundNewAccount(player1);
   zkApp.deploy();
-  zkApp.startGame(player1.toPublicKey(), player2.toPublicKey());
+  zkApp.startGame(player1, player2);
 });
 await txn.prove();
 /**
@@ -45,7 +46,7 @@ await txn.prove();
  * (but `deploy()` changes some of those permissions to "proof" and adds the verification key that enables proofs.
  * that's why we don't need `tx.sign()` for the later transactions.)
  */
-await txn.sign([zkAppPrivateKey]).send();
+await txn.sign([zkAppPrivateKey, player1Key]).send();
 
 console.log('after transaction');
 

--- a/examples/tictactoe/ts/src/tictactoe.test.ts
+++ b/examples/tictactoe/ts/src/tictactoe.test.ts
@@ -16,7 +16,6 @@ describe('tictactoe', () => {
   let player1: PublicKey,
     player1Key: PrivateKey,
     player2: PublicKey,
-    player2Key: PrivateKey,
     zkAppAddress: PublicKey,
     zkAppPrivateKey: PrivateKey;
 
@@ -24,10 +23,8 @@ describe('tictactoe', () => {
     await isReady;
     let Local = Mina.LocalBlockchain({ proofsEnabled: false });
     Mina.setActiveInstance(Local);
-    [
-      { publicKey: player1, privateKey: player1Key },
-      { publicKey: player2, privateKey: player2Key },
-    ] = Local.testAccounts;
+    [{ publicKey: player1, privateKey: player1Key }, { publicKey: player2 }] =
+      Local.testAccounts;
     zkAppPrivateKey = PrivateKey.random();
     zkAppAddress = zkAppPrivateKey.toPublicKey();
   });

--- a/examples/tictactoe/ts/src/tictactoe.test.ts
+++ b/examples/tictactoe/ts/src/tictactoe.test.ts
@@ -9,6 +9,7 @@ import {
   Mina,
   AccountUpdate,
   Signature,
+  zkappCommandToJson,
 } from 'snarkyjs';
 
 describe('tictactoe', () => {
@@ -58,16 +59,16 @@ describe('tictactoe', () => {
       zkApp.startGame(player1, player2);
     });
     await txn.prove();
-    await txn.sign([zkAppPrivateKey]).send();
+    await txn.sign([zkAppPrivateKey, player1Key]).send();
 
     // move
     const [x, y] = [Field(0), Field(0)];
-    const signature = Signature.create(player1, [x, y]);
+    const signature = Signature.create(player1Key, [x, y]);
     txn = await Mina.transaction(player1, async () => {
       zkApp.play(player1, signature, x, y);
     });
     await txn.prove();
-    await txn.send();
+    await txn.sign([player1Key]).send();
 
     const nextIsPlayer2 = zkApp.nextIsPlayer2.get();
     expect(nextIsPlayer2).toEqual(Bool(true));

--- a/examples/tictactoe/ts/src/tictactoe.test.ts
+++ b/examples/tictactoe/ts/src/tictactoe.test.ts
@@ -12,8 +12,10 @@ import {
 } from 'snarkyjs';
 
 describe('tictactoe', () => {
-  let player1: PrivateKey,
-    player2: PrivateKey,
+  let player1: PublicKey,
+    player1Key: PrivateKey,
+    player2: PublicKey,
+    player2Key: PrivateKey,
     zkAppAddress: PublicKey,
     zkAppPrivateKey: PrivateKey;
 
@@ -21,7 +23,10 @@ describe('tictactoe', () => {
     await isReady;
     let Local = Mina.LocalBlockchain({ proofsEnabled: false });
     Mina.setActiveInstance(Local);
-    [{ privateKey: player1 }, { privateKey: player2 }] = Local.testAccounts;
+    [
+      { publicKey: player1, privateKey: player1Key },
+      { publicKey: player2, privateKey: player2Key },
+    ] = Local.testAccounts;
     zkAppPrivateKey = PrivateKey.random();
     zkAppAddress = zkAppPrivateKey.toPublicKey();
   });
@@ -35,7 +40,7 @@ describe('tictactoe', () => {
     const txn = await Mina.transaction(player1, () => {
       AccountUpdate.fundNewAccount(player1);
       zkApp.deploy();
-      zkApp.startGame(player1.toPublicKey(), player2.toPublicKey());
+      zkApp.startGame(player1, player2);
     });
     await txn.prove();
     await txn.sign([zkAppPrivateKey]).send();
@@ -50,7 +55,7 @@ describe('tictactoe', () => {
     let txn = await Mina.transaction(player1, () => {
       AccountUpdate.fundNewAccount(player1);
       zkApp.deploy();
-      zkApp.startGame(player1.toPublicKey(), player2.toPublicKey());
+      zkApp.startGame(player1, player2);
     });
     await txn.prove();
     await txn.sign([zkAppPrivateKey]).send();
@@ -59,7 +64,7 @@ describe('tictactoe', () => {
     const [x, y] = [Field(0), Field(0)];
     const signature = Signature.create(player1, [x, y]);
     txn = await Mina.transaction(player1, async () => {
-      zkApp.play(player1.toPublicKey(), signature, x, y);
+      zkApp.play(player1, signature, x, y);
     });
     await txn.prove();
     await txn.send();

--- a/examples/tictactoe/ts/src/tictactoe.test.ts
+++ b/examples/tictactoe/ts/src/tictactoe.test.ts
@@ -43,7 +43,7 @@ describe('tictactoe', () => {
       zkApp.startGame(player1, player2);
     });
     await txn.prove();
-    await txn.sign([zkAppPrivateKey]).send();
+    await txn.sign([zkAppPrivateKey, player1Key]).send();
     const board = zkApp.board.get();
     expect(board).toEqual(Field(0));
   });

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "mina-signer": "^1.1.0",
         "ora": "^5.4.1",
         "shelljs": "^0.8.5",
-        "snarkyjs": "^0.7.3",
+        "snarkyjs": "^0.8.0",
         "table": "^6.8.0",
         "yargs": "^17.5.1"
       },
@@ -1714,6 +1714,11 @@
         "readable-stream": "^3.4.0"
       }
     },
+    "node_modules/blakejs": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.2.1.tgz",
+      "integrity": "sha512-QXUSXI3QVc/gJME0dBpXrag1kbzOqCjCX8/b54ntNyW6sjtoqxqRk3LTmXzaJoh71zMsDCjM+47jS7XiwN/+fQ=="
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -2147,6 +2152,14 @@
       "dev": true,
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/detect-gpu": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/detect-gpu/-/detect-gpu-5.0.7.tgz",
+      "integrity": "sha512-llA18Saewy9CyIy+M1gcaApkdm2XyfbVrplvXwXwH0rgnuw/ZKaUfjIUlJv7ofm5nCbZbyzJM9P2bwJzzJib7g==",
+      "dependencies": {
+        "webgl-constants": "^1.1.1"
       }
     },
     "node_modules/detect-newline": {
@@ -4080,6 +4093,11 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/js-sha256": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.9.0.tgz",
+      "integrity": "sha512-sga3MHh9sgQN2+pJ9VYZ+1LPwXOxuBJBA5nrR5/ofPfuiJBE2hnjsaN8se8JznOmGLN2p49Pe5U/ttafcs/apA=="
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -5292,12 +5310,15 @@
       }
     },
     "node_modules/snarkyjs": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/snarkyjs/-/snarkyjs-0.7.3.tgz",
-      "integrity": "sha512-PA+UMugISjBOq/iAiQugdoJg3jFJkqdNMige/BWm9TE8HfBYDxjoh7Aj6YIm4+RO/vHwzOcTtkfKR9OrKY+c+A==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/snarkyjs/-/snarkyjs-0.8.0.tgz",
+      "integrity": "sha512-vQsHoBzOXTA0X0S+iYmFAlDjz2iWq43bK5qm5Qt3KvM0ME9iwun+aZY/Y9OgWfio+D7JDVPSFRIUKCCOhWgTNw==",
       "dependencies": {
+        "blakejs": "1.2.1",
+        "detect-gpu": "^5.0.5",
         "env": "^0.0.2",
         "isomorphic-fetch": "^3.0.0",
+        "js-sha256": "^0.9.0",
         "reflect-metadata": "^0.1.13",
         "tslib": "^2.3.0"
       },
@@ -5881,6 +5902,11 @@
       "dependencies": {
         "defaults": "^1.0.3"
       }
+    },
+    "node_modules/webgl-constants": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/webgl-constants/-/webgl-constants-1.1.1.tgz",
+      "integrity": "sha512-LkBXKjU5r9vAW7Gcu3T5u+5cvSvh5WwINdr0C+9jpzVB41cjQAP5ePArDtk/WHYdVj0GefCgM73BA7FlIiNtdg=="
     },
     "node_modules/webidl-conversions": {
       "version": "6.1.0",
@@ -7338,6 +7364,11 @@
         "readable-stream": "^3.4.0"
       }
     },
+    "blakejs": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.2.1.tgz",
+      "integrity": "sha512-QXUSXI3QVc/gJME0dBpXrag1kbzOqCjCX8/b54ntNyW6sjtoqxqRk3LTmXzaJoh71zMsDCjM+47jS7XiwN/+fQ=="
+    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -7656,6 +7687,14 @@
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
       "dev": true
+    },
+    "detect-gpu": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/detect-gpu/-/detect-gpu-5.0.7.tgz",
+      "integrity": "sha512-llA18Saewy9CyIy+M1gcaApkdm2XyfbVrplvXwXwH0rgnuw/ZKaUfjIUlJv7ofm5nCbZbyzJM9P2bwJzzJib7g==",
+      "requires": {
+        "webgl-constants": "^1.1.1"
+      }
     },
     "detect-newline": {
       "version": "3.1.0",
@@ -9099,6 +9138,11 @@
         }
       }
     },
+    "js-sha256": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.9.0.tgz",
+      "integrity": "sha512-sga3MHh9sgQN2+pJ9VYZ+1LPwXOxuBJBA5nrR5/ofPfuiJBE2hnjsaN8se8JznOmGLN2p49Pe5U/ttafcs/apA=="
+    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -9998,12 +10042,15 @@
       }
     },
     "snarkyjs": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/snarkyjs/-/snarkyjs-0.7.3.tgz",
-      "integrity": "sha512-PA+UMugISjBOq/iAiQugdoJg3jFJkqdNMige/BWm9TE8HfBYDxjoh7Aj6YIm4+RO/vHwzOcTtkfKR9OrKY+c+A==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/snarkyjs/-/snarkyjs-0.8.0.tgz",
+      "integrity": "sha512-vQsHoBzOXTA0X0S+iYmFAlDjz2iWq43bK5qm5Qt3KvM0ME9iwun+aZY/Y9OgWfio+D7JDVPSFRIUKCCOhWgTNw==",
       "requires": {
+        "blakejs": "1.2.1",
+        "detect-gpu": "^5.0.5",
         "env": "^0.0.2",
         "isomorphic-fetch": "^3.0.0",
+        "js-sha256": "^0.9.0",
         "reflect-metadata": "^0.1.13",
         "tslib": "^2.3.0"
       }
@@ -10442,6 +10489,11 @@
       "requires": {
         "defaults": "^1.0.3"
       }
+    },
+    "webgl-constants": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/webgl-constants/-/webgl-constants-1.1.1.tgz",
+      "integrity": "sha512-LkBXKjU5r9vAW7Gcu3T5u+5cvSvh5WwINdr0C+9jpzVB41cjQAP5ePArDtk/WHYdVj0GefCgM73BA7FlIiNtdg=="
     },
     "webidl-conversions": {
       "version": "6.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zkapp-cli",
-  "version": "0.5.4",
+  "version": "0.6.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "zkapp-cli",
-      "version": "0.5.4",
+      "version": "0.6.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zkapp-cli",
-  "version": "0.5.6",
+  "version": "0.6.0",
   "description": "CLI to create a zkApp (\"zero-knowledge app\") for Mina Protocol.",
   "keywords": [
     "cli",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "mina-signer": "^1.1.0",
     "ora": "^5.4.1",
     "shelljs": "^0.8.5",
-    "snarkyjs": "^0.7.3",
+    "snarkyjs": "^0.8.0",
     "table": "^6.8.0",
     "yargs": "^17.5.1"
   },

--- a/src/lib/deploy.js
+++ b/src/lib/deploy.js
@@ -356,7 +356,7 @@ async function deploy({ alias, yes }) {
       // use full commitment (means with include the fee payer in the signature, so we're protected against replays)
       zkapp.self.body.useFullCommitment = Bool(true);
     });
-    return { tx, json: tx.sign().toJSON() };
+    return { tx, json: tx.sign([zkAppPrivateKey]).toJSON() };
   });
 
   if (isInitMethod) {

--- a/src/lib/deploy.js
+++ b/src/lib/deploy.js
@@ -364,7 +364,10 @@ async function deploy({ alias, yes }) {
       'Create transaction proof (takes 10-30 sec)',
       async () => {
         await transaction.tx.prove();
-        return { tx: transaction.tx, json: transaction.tx.sign().toJSON() };
+        return {
+          tx: transaction.tx,
+          json: transaction.tx.sign([zkAppPrivateKey]).toJSON(),
+        };
       }
     );
   }

--- a/templates/project-ts/package-lock.json
+++ b/templates/project-ts/package-lock.json
@@ -24,7 +24,7 @@
         "typescript": "^4.7.2"
       },
       "peerDependencies": {
-        "snarkyjs": "^0.7.3"
+        "snarkyjs": "^0.8.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -3208,6 +3208,12 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
+    "node_modules/blakejs": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.2.1.tgz",
+      "integrity": "sha512-QXUSXI3QVc/gJME0dBpXrag1kbzOqCjCX8/b54ntNyW6sjtoqxqRk3LTmXzaJoh71zMsDCjM+47jS7XiwN/+fQ==",
+      "peer": true
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -3637,6 +3643,15 @@
       "dev": true,
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/detect-gpu": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/detect-gpu/-/detect-gpu-5.0.7.tgz",
+      "integrity": "sha512-llA18Saewy9CyIy+M1gcaApkdm2XyfbVrplvXwXwH0rgnuw/ZKaUfjIUlJv7ofm5nCbZbyzJM9P2bwJzzJib7g==",
+      "peer": true,
+      "dependencies": {
+        "webgl-constants": "^1.1.1"
       }
     },
     "node_modules/detect-newline": {
@@ -6631,6 +6646,12 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/js-sha256": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.9.0.tgz",
+      "integrity": "sha512-sga3MHh9sgQN2+pJ9VYZ+1LPwXOxuBJBA5nrR5/ofPfuiJBE2hnjsaN8se8JznOmGLN2p49Pe5U/ttafcs/apA==",
+      "peer": true
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -7891,13 +7912,16 @@
       "dev": true
     },
     "node_modules/snarkyjs": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/snarkyjs/-/snarkyjs-0.7.3.tgz",
-      "integrity": "sha512-PA+UMugISjBOq/iAiQugdoJg3jFJkqdNMige/BWm9TE8HfBYDxjoh7Aj6YIm4+RO/vHwzOcTtkfKR9OrKY+c+A==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/snarkyjs/-/snarkyjs-0.8.0.tgz",
+      "integrity": "sha512-vQsHoBzOXTA0X0S+iYmFAlDjz2iWq43bK5qm5Qt3KvM0ME9iwun+aZY/Y9OgWfio+D7JDVPSFRIUKCCOhWgTNw==",
       "peer": true,
       "dependencies": {
+        "blakejs": "1.2.1",
+        "detect-gpu": "^5.0.5",
         "env": "^0.0.2",
         "isomorphic-fetch": "^3.0.0",
+        "js-sha256": "^0.9.0",
         "reflect-metadata": "^0.1.13",
         "tslib": "^2.3.0"
       },
@@ -8471,6 +8495,12 @@
       "dependencies": {
         "makeerror": "1.0.12"
       }
+    },
+    "node_modules/webgl-constants": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/webgl-constants/-/webgl-constants-1.1.1.tgz",
+      "integrity": "sha512-LkBXKjU5r9vAW7Gcu3T5u+5cvSvh5WwINdr0C+9jpzVB41cjQAP5ePArDtk/WHYdVj0GefCgM73BA7FlIiNtdg==",
+      "peer": true
     },
     "node_modules/webidl-conversions": {
       "version": "6.1.0",
@@ -10992,6 +11022,12 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
+    "blakejs": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.2.1.tgz",
+      "integrity": "sha512-QXUSXI3QVc/gJME0dBpXrag1kbzOqCjCX8/b54ntNyW6sjtoqxqRk3LTmXzaJoh71zMsDCjM+47jS7XiwN/+fQ==",
+      "peer": true
+    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -11333,6 +11369,15 @@
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
       "dev": true
+    },
+    "detect-gpu": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/detect-gpu/-/detect-gpu-5.0.7.tgz",
+      "integrity": "sha512-llA18Saewy9CyIy+M1gcaApkdm2XyfbVrplvXwXwH0rgnuw/ZKaUfjIUlJv7ofm5nCbZbyzJM9P2bwJzzJib7g==",
+      "peer": true,
+      "requires": {
+        "webgl-constants": "^1.1.1"
+      }
     },
     "detect-newline": {
       "version": "3.1.0",
@@ -13568,6 +13613,12 @@
         }
       }
     },
+    "js-sha256": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.9.0.tgz",
+      "integrity": "sha512-sga3MHh9sgQN2+pJ9VYZ+1LPwXOxuBJBA5nrR5/ofPfuiJBE2hnjsaN8se8JznOmGLN2p49Pe5U/ttafcs/apA==",
+      "peer": true
+    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -14516,13 +14567,16 @@
       }
     },
     "snarkyjs": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/snarkyjs/-/snarkyjs-0.7.3.tgz",
-      "integrity": "sha512-PA+UMugISjBOq/iAiQugdoJg3jFJkqdNMige/BWm9TE8HfBYDxjoh7Aj6YIm4+RO/vHwzOcTtkfKR9OrKY+c+A==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/snarkyjs/-/snarkyjs-0.8.0.tgz",
+      "integrity": "sha512-vQsHoBzOXTA0X0S+iYmFAlDjz2iWq43bK5qm5Qt3KvM0ME9iwun+aZY/Y9OgWfio+D7JDVPSFRIUKCCOhWgTNw==",
       "peer": true,
       "requires": {
+        "blakejs": "1.2.1",
+        "detect-gpu": "^5.0.5",
         "env": "^0.0.2",
         "isomorphic-fetch": "^3.0.0",
+        "js-sha256": "^0.9.0",
         "reflect-metadata": "^0.1.13",
         "tslib": "^2.3.0"
       },
@@ -14949,6 +15003,12 @@
       "requires": {
         "makeerror": "1.0.12"
       }
+    },
+    "webgl-constants": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/webgl-constants/-/webgl-constants-1.1.1.tgz",
+      "integrity": "sha512-LkBXKjU5r9vAW7Gcu3T5u+5cvSvh5WwINdr0C+9jpzVB41cjQAP5ePArDtk/WHYdVj0GefCgM73BA7FlIiNtdg==",
+      "peer": true
     },
     "webidl-conversions": {
       "version": "6.1.0",

--- a/templates/project-ts/package.json
+++ b/templates/project-ts/package.json
@@ -45,6 +45,6 @@
     "typescript": "^4.7.2"
   },
   "peerDependencies": {
-    "snarkyjs": "^0.7.3"
+    "snarkyjs": "^0.8.0"
   }
 }

--- a/templates/project-ts/src/interact.ts
+++ b/templates/project-ts/src/interact.ts
@@ -50,7 +50,7 @@ await Add.compile();
 
 // call update() and send transaction
 console.log('build transaction and create proof...');
-let tx = await Mina.transaction({ feePayerKey: zkAppKey, fee: 0.1e9 }, () => {
+let tx = await Mina.transaction({ sender: zkAppAddress, fee: 0.1e9 }, () => {
   zkApp.update();
 });
 await tx.prove();

--- a/templates/project-ts/src/interact.ts
+++ b/templates/project-ts/src/interact.ts
@@ -55,7 +55,7 @@ let tx = await Mina.transaction({ sender: zkAppAddress, fee: 0.1e9 }, () => {
 });
 await tx.prove();
 console.log('send transaction...');
-let sentTx = await tx.send();
+let sentTx = await tx.sign([zkAppKey]).send();
 
 if (sentTx.hash() !== undefined) {
   console.log(`


### PR DESCRIPTION
Addresses #334 & #337

This PR updates the CLI to be compatible with the upcoming SnarkyJS 0.8.0 release. The `Mina.transaction` api has been updated to pass in the fee payer as a public key throughout the CLI and in all the example and template contracts. See [this](https://github.com/o1-labs/snarkyjs/pull/652) SnarkyJS PR and this [issue](https://github.com/o1-labs/snarkyjs/issues/635) for more details. 