### PR TITLE
Add dropdown to select an example project

### DIFF
--- a/src/bin/index.js
+++ b/src/bin/index.js
@@ -83,7 +83,7 @@ yargs(hideBin(process.argv))
     'Create an example project',
     {
       name: {
-        demand: true,
+        demand: false,
         string: true,
         hidden: false,
         choices: ['sudoku', 'tictactoe'],

--- a/src/lib/example.js
+++ b/src/lib/example.js
@@ -40,6 +40,7 @@ async function example(example) {
           : red(state.symbols.cross);
       },
     });
+    example = res.example;
   }
 
   const dir = findUniqueDir(example);

--- a/src/lib/example.js
+++ b/src/lib/example.js
@@ -5,6 +5,7 @@ const ora = require('ora');
 const sh = require('shelljs');
 const util = require('util');
 const gittar = require('gittar');
+const { prompt } = require('enquirer');
 
 const _green = chalk.green;
 const _red = chalk.red;
@@ -18,11 +19,20 @@ const shExec = util.promisify(sh.exec);
  * @return {Promise<void>}
  */
 async function example(example) {
+  if (!example) {
+    const res = await prompt({
+      type: 'select',
+      name: 'example',
+      choices: ['sudoku', 'tictactoe'],
+    });
+  }
+
   const dir = findUniqueDir(example);
   const lang = 'ts';
   const isWindows = process.platform === 'win32';
 
   if (!(await fetchProjectTemplate(dir, lang))) return;
+
   if (!(await extractExample(example, dir, lang))) return;
 
   // Set dir for shell commands. Doesn't change user's dir in their CLI.

--- a/src/lib/example.js
+++ b/src/lib/example.js
@@ -6,6 +6,7 @@ const sh = require('shelljs');
 const util = require('util');
 const gittar = require('gittar');
 const { prompt } = require('enquirer');
+const { reset } = require('chalk');
 
 const _green = chalk.green;
 const _red = chalk.red;
@@ -24,6 +25,11 @@ async function example(example) {
       type: 'select',
       name: 'example',
       choices: ['sudoku', 'tictactoe'],
+      message: (state) => {
+        const style =
+          state.submitted && !state.cancelled ? state.styles.success : reset;
+        return style('Choose an example');
+      },
     });
   }
 

--- a/src/lib/example.js
+++ b/src/lib/example.js
@@ -6,7 +6,7 @@ const sh = require('shelljs');
 const util = require('util');
 const gittar = require('gittar');
 const { prompt } = require('enquirer');
-const { reset } = require('chalk');
+const { red, reset } = require('chalk');
 
 const _green = chalk.green;
 const _red = chalk.red;
@@ -29,6 +29,15 @@ async function example(example) {
         const style =
           state.submitted && !state.cancelled ? state.styles.success : reset;
         return style('Choose an example');
+      },
+      prefix: (state) => {
+        // Shows a cyan question mark when not submitted.
+        // Shows a green check mark if submitted.
+        // Shows a red "x" if ctrl+C is pressed (default is a magenta).
+        if (!state.submitted) return state.symbols.question;
+        return !state.cancelled
+          ? state.symbols.check
+          : red(state.symbols.cross);
       },
     });
   }


### PR DESCRIPTION
Closes #168 

This PR adds a dropdown to select an example project when `zk example` is entered in the CLI without entering an example name. 