### PR TITLE
Show SnarkyJS version with zk system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,16 +5,103 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/o1-labs/zkapp-cli/compare/feature/deploy-alias...HEAD)
+## [0.5.5] - 2023-01-011
 
-## [0.4.15] - 2021-09-015
+### Changed
+
+- Fix to show SnarkyJS version with 'zk system' command. [#349](https://github.com/o1-labs/zkapp-cli/pull/349)
+- Allow '.js' imports to work in Jest. [#339](https://github.com/o1-labs/zkapp-cli/pull/339)
+- Minor fix to exit the cli process after generating a new project. [#330](https://github.com/o1-labs/zkapp-cli/pull/330)
+
+### Added
+
+- Add dropdown to select an example project. [#348](https://github.com/o1-labs/zkapp-cli/pull/348)
+- Show a warning when users must upgrade their zkApp-cli version. [#327](https://github.com/o1-labs/zkapp-cli/pull/327)
+- Add a 'tsc watch' script. [#326](https://github.com/o1-labs/zkapp-cli/pull/326)
+
+## [0.5.4] - 2022-12-01
+
+### Changed
+
+- Fix build errors when using 'zk file'. [#325](https://github.com/o1-labs/zkapp-cli/pull/325)
+
+## [0.5.3]
+
+### Changed
+
+- Fix template contract and add interaction script. [#320](https://github.com/o1-labs/zkapp-cli/pull/320)
+- Fix tictactoe example. [#318](https://github.com/o1-labs/zkapp-cli/pull/318)
+
+## [0.5.2]
+
+### Changed
+
+- Fix Sudoku and enable CLI to create init() proofs. [#315](https://github.com/o1-labs/zkapp-cli/pull/315)
+
+## [0.5.1]
+
+### Changed
+
+- Upgraded SnarkyJS to `0.7.1`. [#309](https://github.com/o1-labs/zkapp-cli/pull/309)
+- Fix GraphQL error handling. [#307](https://github.com/o1-labs/zkapp-cli/pull/307/files)
+
+## [0.5.0]
+
+### Changed
+
+- Upgraded SnarkyJS to `0.7.0`. [#306](https://github.com/o1-labs/zkapp-cli/pull/306)
+- Update tsconfig ES target. [#303](https://github.com/o1-labs/zkapp-cli/pull/303)
+
+### Added
+
+- Import a smart contract into the Nuxt UI project scaffold. [#305](https://github.com/o1-labs/zkapp-cli/pull/305)
+- Provide a better error message when an unknown error occurs in deployment. [#304](https://github.com/o1-labs/zkapp-cli/pull/304)
+- Import a smart contract into the Svelte UI project scaffold. [#302](https://github.com/o1-labs/zkapp-cli/pull/302)
+
+## [0.4.19] - 2022-11-04
+
+## [0.4.18] - 2022-10-02
+
+### Changed
+
+- Exit the CLI when a project step fails. [#281](https://github.com/o1-labs/zkapp-cli/pull/281)
+- Fix confirmation step to not consume user input entered earlier. [#265](https://github.com/o1-labs/zkapp-cli/pull/265)
+- Set default verion of user's smart contract project to 0.1.0. [#264](https://github.com/o1-labs/zkapp-cli/pull/264)
+- Constrain valid example names for better error handling. [#263](https://github.com/o1-labs/zkapp-cli/pull/263)
+
+### Added
+
+- Add ability to generate UI project alongsde the smart contract.
+
+  - Add an option to NextJS to set it up for github pages. [#292] https://github.com/o1-labs/zkapp-cli/pull/292)
+  - Import a smart contract into the NextJS UI project scaffold. [#290](https://github.com/o1-labs/zkapp-cli/pull/290)
+  - Fixes to the NextJS project for snarkyjs + typescript. [#287](https://github.com/o1-labs/zkapp-cli/pull/287)
+  - Add a NextJS typescript prompt. [#285](https://github.com/o1-labs/zkapp-cli/pull/285)
+  - Add COOP & COEP headers for SvelteKit, NextJS, & NuxtJS. [#279](https://github.com/o1-labs/zkapp-cli/pull/279)
+  - Working mvp of UI monorepo. [#266](https://github.com/o1-labs/zkapp-cli/pull/266)
+
+- Add Github issue templates. [#270](https://github.com/o1-labs/zkapp-cli/pull/270), [#275](https://github.com/o1-labs/zkapp-cli/pull/275), & [#276](https://github.com/o1-labs/zkapp-cli/pull/276)
+
+## [0.4.17] - 2022-10-07
+
+### Changed
+
+- Fix running 'zk deploy' on windows. [#256](https://github.com/o1-labs/zkapp-cli/pull/256)
+
+## [0.4.16] - 2022-9-026
+
+### Changed
+
+- Update readme. [#253](https://github.com/o1-labs/zkapp-cli/pull/253)
+
+## [0.4.15] - 2022-09-015
 
 ### Changed
 
 - Upgraded SnarkyJS to `0.6.0`. [#249](https://github.com/o1-labs/zkapp-cli/pull/249)
 - Renamed the references of Party to AccountUpdate and parties to zkappCommand in CLI and template/examples to match changes in Mina Protocol and SnarkyJS.
 
-## [0.4.7] - 2021-06-14
+## [0.4.7] - 2022-06-14
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Fix to show SnarkyJS version with 'zk system' command. [#349](https://github.com/o1-labs/zkapp-cli/pull/349)
+- Fix to show SnarkyJS version with `zk system` command. [#349](https://github.com/o1-labs/zkapp-cli/pull/349)
 - Allow '.js' imports to work in Jest. [#339](https://github.com/o1-labs/zkapp-cli/pull/339)
 - Minor fix to exit the cli process after generating a new project. [#330](https://github.com/o1-labs/zkapp-cli/pull/330)
 
@@ -17,25 +17,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add dropdown to select an example project. [#348](https://github.com/o1-labs/zkapp-cli/pull/348)
 - Show a warning when users must upgrade their zkApp-cli version. [#327](https://github.com/o1-labs/zkapp-cli/pull/327)
-- Add a 'tsc watch' script. [#326](https://github.com/o1-labs/zkapp-cli/pull/326)
+- Add a `tsc watch` script. [#326](https://github.com/o1-labs/zkapp-cli/pull/326)
 
 ## [0.5.4] - 2022-12-01
 
 ### Changed
 
-- Fix build errors when using 'zk file'. [#325](https://github.com/o1-labs/zkapp-cli/pull/325)
+- Fix build errors when using `zk file`. [#325](https://github.com/o1-labs/zkapp-cli/pull/325)
 
 ## [0.5.3]
 
 ### Changed
 
-- Fix template contract and add interaction script. [#320](https://github.com/o1-labs/zkapp-cli/pull/320)
+- Fix template contract, add interaction script, and upgrade to SnarkyJS `0.7.3`. [#320](https://github.com/o1-labs/zkapp-cli/pull/320)
 - Fix tictactoe example. [#318](https://github.com/o1-labs/zkapp-cli/pull/318)
 
 ## [0.5.2]
 
 ### Changed
 
+- Upgraded SnarkyJS to `0.7.2` [#316](https://github.com/o1-labs/zkapp-cli/pull/316)
 - Fix Sudoku and enable CLI to create init() proofs. [#315](https://github.com/o1-labs/zkapp-cli/pull/315)
 
 ## [0.5.1]
@@ -66,14 +67,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Exit the CLI when a project step fails. [#281](https://github.com/o1-labs/zkapp-cli/pull/281)
 - Fix confirmation step to not consume user input entered earlier. [#265](https://github.com/o1-labs/zkapp-cli/pull/265)
-- Set default verion of user's smart contract project to 0.1.0. [#264](https://github.com/o1-labs/zkapp-cli/pull/264)
+- Set default verion of user's smart contract project to `0.1.0`. [#264](https://github.com/o1-labs/zkapp-cli/pull/264)
 - Constrain valid example names for better error handling. [#263](https://github.com/o1-labs/zkapp-cli/pull/263)
 
 ### Added
 
 - Add ability to generate UI project alongsde the smart contract.
 
-  - Add an option to NextJS to set it up for github pages. [#292] https://github.com/o1-labs/zkapp-cli/pull/292)
+  - Add an option to NextJS to set it up for github pages. [#292](https://github.com/o1-labs/zkapp-cli/pull/292)
   - Import a smart contract into the NextJS UI project scaffold. [#290](https://github.com/o1-labs/zkapp-cli/pull/290)
   - Fixes to the NextJS project for snarkyjs + typescript. [#287](https://github.com/o1-labs/zkapp-cli/pull/287)
   - Add a NextJS typescript prompt. [#285](https://github.com/o1-labs/zkapp-cli/pull/285)
@@ -86,7 +87,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Fix running 'zk deploy' on windows. [#256](https://github.com/o1-labs/zkapp-cli/pull/256)
+- Fix running `zk deploy` on windows. [#256](https://github.com/o1-labs/zkapp-cli/pull/256)
 
 ## [0.4.16] - 2022-9-026
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zkapp-cli",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "description": "CLI to create a zkApp (\"zero-knowledge app\") for Mina Protocol.",
   "keywords": [
     "cli",

--- a/src/lib/system.js
+++ b/src/lib/system.js
@@ -6,6 +6,9 @@ function system() {
     encoding: 'utf-8',
   });
 
+  const installedSnarkyJSversion =
+    JSON.parse(installedPkgs)['dependencies']?.['snarkyjs']?.['version'];
+
   console.log('Please include the following when submitting a Github issue:');
   envinfo
     .run(

--- a/src/lib/system.js
+++ b/src/lib/system.js
@@ -2,13 +2,7 @@ const envinfo = require('envinfo');
 const sh = require('child_process').execSync;
 
 function system() {
-  const installedPkgs = sh('npm list --all --depth 0 --json', {
-    encoding: 'utf-8',
-  });
-
-  const installedSnarkyJSversion =
-    JSON.parse(installedPkgs)['dependencies']?.['snarkyjs']?.['version'];
-
+  const installedSnarkyJSversion = getInstalledSnarkyJSversion();
   console.log('Please include the following when submitting a Github issue:');
   envinfo
     .run(
@@ -27,11 +21,19 @@ function system() {
         `snarkyjs: ${
           installedSnarkyJSversion
             ? installedSnarkyJSversion
-            : 'not in a project'
+            : 'Not Found (not in a project)'
         }`
       );
     })
     .then((env) => console.log(env));
+}
+
+function getInstalledSnarkyJSversion() {
+  const installedPkgs = sh('npm list --all --depth 0 --json', {
+    encoding: 'utf-8',
+  });
+
+  return JSON.parse(installedPkgs)['dependencies']?.['snarkyjs']?.['version'];
 }
 
 module.exports = { system };

--- a/src/lib/system.js
+++ b/src/lib/system.js
@@ -22,7 +22,14 @@ function system() {
     )
     .then((env) => {
       const str = 'snarkyjs: Not Found';
-      return env.replace(str, `${str} (not in a project)`);
+      return env.replace(
+        str,
+        `snarkyjs: ${
+          installedSnarkyJSversion
+            ? installedSnarkyJSversion
+            : 'not in a project'
+        }`
+      );
     })
     .then((env) => console.log(env));
 }

--- a/src/lib/system.js
+++ b/src/lib/system.js
@@ -1,6 +1,11 @@
 const envinfo = require('envinfo');
+const sh = require('child_process').execSync;
 
 function system() {
+  const installedPkgs = sh('npm list --all --depth 0 --json', {
+    encoding: 'utf-8',
+  });
+
   console.log('Please include the following when submitting a Github issue:');
   envinfo
     .run(


### PR DESCRIPTION
Fixes #345 

**Background**
When the `zk system` command is entered, the installed SnarkyJS version is not shown along with the other system info. 
```
System:
    OS: macOS 12.0.1
    CPU: (10) arm64 Apple M1 Pro
  Binaries:
    Node: 18.3.0 - /opt/homebrew/bin/node
    Yarn: 1.22.19 - /opt/homebrew/bin/yarn
    npm: 8.11.0 - /opt/homebrew/bin/npm
  npmPackages:
    snarkyjs: Not Found (not in a project)
  npmGlobalPackages:
    zkapp-cli: 0.5.4
```
This occurs because SnarkyJS is a peer dependency of zkApp projects, and the library used to get system info is not able to find peer dependency packages.  This PR adds functionality to get the users SnarkyJS version and display it along with the other system info.  
