### PR TITLE
Improve eslint config for typescript

### DIFF
--- a/templates/project-ts/.eslintrc.cjs
+++ b/templates/project-ts/.eslintrc.cjs
@@ -5,7 +5,12 @@ module.exports = {
     node: true,
     jest: true,
   },
-  extends: ['eslint:recommended', 'plugin:snarkyjs/recommended'],
+  extends: [
+    'eslint:recommended',
+    'plugin:@typescript-eslint/eslint-recommended',
+    'plugin:@typescript-eslint/recommended',
+    'plugin:snarkyjs/recommended',
+  ],
   parser: '@typescript-eslint/parser',
   parserOptions: {
     ecmaVersion: 'latest',
@@ -13,5 +18,6 @@ module.exports = {
   plugins: ['@typescript-eslint', 'snarkyjs'],
   rules: {
     'no-constant-condition': 'off',
+    'prefer-const': 'off',
   },
 };


### PR DESCRIPTION
this fixes the problem that eslint is not able to properly parse TS files, it has problems like complaining when types for function signatures "don't use their function arguments".
source for solution: https://stackoverflow.com/a/58513127/7354533

I think there would be an alternative to this: not use `@typescript-eslint/parser` at all. in that case, type linting is done by TS itself, that's how it is setup in the snarkyjs repo and seems to work very well.