### PR TITLE
Fix zk deploy

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zkapp-cli",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "description": "CLI to create a zkApp (\"zero-knowledge app\") for Mina Protocol.",
   "keywords": [
     "cli",

--- a/src/lib/deploy.js
+++ b/src/lib/deploy.js
@@ -469,7 +469,7 @@ async function getLatestCliVersion() {
 }
 
 async function getInstalledCliVersion() {
-  const globalInstalledPkgs = sh('npm list -g --depth 0 --json', {
+  const globalInstalledPkgs = sh('npm list -g --depth 0 --json --silent', {
     encoding: 'utf-8',
   });
 

--- a/src/lib/deploy.js
+++ b/src/lib/deploy.js
@@ -469,12 +469,10 @@ async function getLatestCliVersion() {
 }
 
 async function getInstalledCliVersion() {
-  const globalInstalledPkgs = sh(
-    'npm list --location=global --depth 0 --json',
-    {
-      encoding: 'utf-8',
-    }
-  );
+  const globalInstalledPkgs = sh('npm list -g --depth 0 --json', {
+    encoding: 'utf-8',
+  });
+
   console.log('installedPkgs', globalInstalledPkgs);
 
   return JSON.parse(globalInstalledPkgs)?.['dependencies']?.['zkapp-cli']?.[

--- a/src/lib/deploy.js
+++ b/src/lib/deploy.js
@@ -473,8 +473,6 @@ async function getInstalledCliVersion() {
     encoding: 'utf-8',
   });
 
-  console.log('installedPkgs', globalInstalledPkgs);
-
   return JSON.parse(globalInstalledPkgs)?.['dependencies']?.['zkapp-cli']?.[
     'version'
   ];

--- a/src/lib/deploy.js
+++ b/src/lib/deploy.js
@@ -475,8 +475,9 @@ async function getInstalledCliVersion() {
       encoding: 'utf-8',
     }
   );
+  console.log('installedPkgs', globalInstalledPkgs);
 
-  return JSON.parse(globalInstalledPkgs)['dependencies']['zkapp-cli'][
+  return JSON.parse(globalInstalledPkgs)?.['dependencies']?.['zkapp-cli']?.[
     'version'
   ];
 }
@@ -489,8 +490,8 @@ changes to the major version of the zkApp CLI will represnt
 breaking changes, following semver.
 */
 function hasBreakingChanges(version1, version2) {
-  const version1Arr = version1.split('.');
-  const version2Arr = version2.split('.');
+  const version1Arr = version1?.split('.');
+  const version2Arr = version2?.split('.');
 
   if (version1Arr[0] === '0') {
     return version1Arr[1] !== version2Arr[1];


### PR DESCRIPTION
Fixes #352 

**Issue** 

When entering the command `zk deploy` an error is issued from `deploy.js` which stops the cli from continuing. This occurred because the `npm list --location=global` command used to get the users current installed zkapp-cli version does not work correctly on older versions of node. The command was switched to use the legacy `npm list -g` command. This fix was tested with both Node 16 and 18.