### PR TITLE
Show desired block explorer urls 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.2] - 2023-02-02
+
+### Added
+
+Show desired blockchain explorer transaction urls [#358](https://github.com/o1-labs/zkapp-cli/pull/358)
+
+## [0.6.1] - 2023-01-030
+
+### Changed
+
+Bug fixes. [#353](https://github.com/o1-labs/zkapp-cli/pull/347)
+
+## [0.6.0] - 2023-01-018
+
+### Changed
+
+- Upgraded SnarkyJS to `0.8.0`. [#349](https://github.com/o1-labs/zkapp-cli/pull/347)
+
 ## [0.5.5] - 2023-01-011
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zkapp-cli",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "CLI to create a zkApp (\"zero-knowledge app\") for Mina Protocol.",
   "keywords": [
     "cli",

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -169,8 +169,8 @@ async function config() {
   log(green(str));
 }
 
-function getExplorerName(networkUrl) {
-  return new URL(networkUrl).hostname
+function getExplorerName(graphQLUrl) {
+  return new URL(graphQLUrl).hostname
     .split('.')
     .filter((item) => item === 'minascan' || item === 'minaexplorer')?.[0];
 }

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -168,6 +168,7 @@ async function config() {
 
   log(green(str));
 }
+
 function getExplorerName(networkUrl) {
   return networkUrl
     .split('.')

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -163,7 +163,7 @@ async function config() {
     `\nNext steps:` +
     `\n  - If this is a testnet, request tMINA at:\n    https://faucet.minaprotocol.com/?address=${encodeURIComponent(
       keyPair.publicKey
-    )}` +
+    )}&?network=${networkName}` +
     `\n  - To deploy, run: \`zk deploy ${network}\``;
 
   log(green(str));

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -170,7 +170,7 @@ async function config() {
 }
 
 function getExplorerName(networkUrl) {
-  return networkUrl
+  return new URL(networkUrl).hostname
     .split('.')
     .filter((item) => item === 'minascan' || item === 'minaexplorer')?.[0];
 }

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -156,19 +156,19 @@ async function config() {
     fs.outputJsonSync(`${DIR}/config.json`, config, { spaces: 2 });
   });
 
-  const networkName = getNetworkName(config?.networks[network]?.url);
+  const explorerName = getExplorerName(config?.networks[network]?.url);
 
   const str =
     `\nSuccess!\n` +
     `\nNext steps:` +
     `\n  - If this is a testnet, request tMINA at:\n    https://faucet.minaprotocol.com/?address=${encodeURIComponent(
       keyPair.publicKey
-    )}&?network=${networkName}` +
+    )}&?explorer=${explorerName}` +
     `\n  - To deploy, run: \`zk deploy ${network}\``;
 
   log(green(str));
 }
-function getNetworkName(networkUrl) {
+function getExplorerName(networkUrl) {
   return networkUrl
     .split('.')
     .filter((item) => (item === 'minascan') | (item === 'minaexplorer'))?.[0];

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -172,7 +172,7 @@ async function config() {
 function getExplorerName(networkUrl) {
   return networkUrl
     .split('.')
-    .filter((item) => (item === 'minascan') | (item === 'minaexplorer'))?.[0];
+    .filter((item) => item === 'minascan' || item === 'minaexplorer')?.[0];
 }
 module.exports = {
   config,

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -156,6 +156,8 @@ async function config() {
     fs.outputJsonSync(`${DIR}/config.json`, config, { spaces: 2 });
   });
 
+  const networkName = getNetworkName(config?.networks[network]?.url);
+
   const str =
     `\nSuccess!\n` +
     `\nNext steps:` +
@@ -166,7 +168,11 @@ async function config() {
 
   log(green(str));
 }
-
+function getNetworkName(networkUrl) {
+  return networkUrl
+    .split('.')
+    .filter((item) => (item === 'minascan') | (item === 'minaexplorer'))?.[0];
+}
 module.exports = {
   config,
 };

--- a/src/lib/deploy.js
+++ b/src/lib/deploy.js
@@ -463,12 +463,12 @@ async function deploy({ alias, yes }) {
 }
 
 function getTxUrl(graphQLEndpoint, txn) {
-  const networkName = graphQLEndpoint
+  const explorerName = graphQLEndpoint
     .split('.')
     .filter((item) => (item === 'minascan') | (item === 'minaexplorer'))?.[0];
   let txBaseUrl;
 
-  switch (networkName) {
+  switch (explorerName) {
     case 'minascan':
       txBaseUrl = `https://minascan.io/berkeley/zk-transaction/`;
       break;

--- a/src/lib/deploy.js
+++ b/src/lib/deploy.js
@@ -456,36 +456,36 @@ async function deploy({ alias, yes }) {
     `\nNext step:` +
     `\n  Your smart contract will be live (or updated)` +
     `\n  as soon as the transaction is included in a block:` +
-    `\n  ${getTxUrl(graphQLEndpoint, txn)}`;
+    `\n  ${getTxnUrl(graphQLEndpoint, txn)}`;
 
   log(green(str));
   await shutdown();
 }
 
 // Get the desired blockchain explorer url with txn hash
-function getTxUrl(graphQLEndpoint, txn) {
+function getTxnUrl(graphQLEndpoint, txn) {
   const MINASCAN_BASE_URL = `https://minascan.io/berkeley/zk-transaction/`;
   const MINA_EXPLORER_BASE_URL = `https://berkeley.minaexplorer.com/transaction/`;
   const randomIndex = Math.floor(Math.random() * 2);
 
-  const explorerName = graphQLEndpoint
+  const explorerName = new URL(graphQLEndpoint).hostname
     .split('.')
     .filter((item) => item === 'minascan' || item === 'minaexplorer')?.[0];
-  let txBaseUrl;
+  let txnBaseUrl;
 
   switch (explorerName) {
     case 'minascan':
-      txBaseUrl = MINASCAN_BASE_URL;
+      txnBaseUrl = MINASCAN_BASE_URL;
       break;
     case 'minaexplorer':
-      txBaseUrl = MINA_EXPLORER_BASE_URL;
+      txnBaseUrl = MINA_EXPLORER_BASE_URL;
       break;
     default:
-      txBaseUrl = [MINASCAN_BASE_URL, MINA_EXPLORER_BASE_URL][randomIndex];
+      txnBaseUrl = [MINASCAN_BASE_URL, MINA_EXPLORER_BASE_URL][randomIndex];
       break;
   }
 
-  return `${txBaseUrl}${txn.data.sendZkapp.zkapp.hash}`;
+  return `${txnBaseUrl}${txn.data.sendZkapp.zkapp.hash}`;
 }
 
 // Query npm registry to get the latest CLI version.

--- a/src/lib/deploy.js
+++ b/src/lib/deploy.js
@@ -464,6 +464,10 @@ async function deploy({ alias, yes }) {
 
 // Get the desired blockchain explorer url with txn hash
 function getTxUrl(graphQLEndpoint, txn) {
+  const MINASCAN_BASE_URL = `https://minascan.io/berkeley/zk-transaction/`;
+  const MINA_EXPLORER_BASE_URL = `https://berkeley.minaexplorer.com/transaction/`;
+  const randomIndex = Math.floor(Math.random() * 2);
+
   const explorerName = graphQLEndpoint
     .split('.')
     .filter((item) => item === 'minascan' || item === 'minaexplorer')?.[0];
@@ -471,13 +475,13 @@ function getTxUrl(graphQLEndpoint, txn) {
 
   switch (explorerName) {
     case 'minascan':
-      txBaseUrl = `https://minascan.io/berkeley/zk-transaction/`;
+      txBaseUrl = MINASCAN_BASE_URL;
       break;
     case 'minaexplorer':
-      txBaseUrl = `https://berkeley.minaexplorer.com/transaction/`;
+      txBaseUrl = MINA_EXPLORER_BASE_URL;
       break;
     default:
-      txBaseUrl = `https://berkeley.minaexplorer.com/transaction/`;
+      txBaseUrl = [MINASCAN_BASE_URL, MINA_EXPLORER_BASE_URL][randomIndex];
       break;
   }
 

--- a/src/lib/deploy.js
+++ b/src/lib/deploy.js
@@ -466,7 +466,8 @@ async function deploy({ alias, yes }) {
 function getTxnUrl(graphQLUrl, txn) {
   const MINASCAN_BASE_URL = `https://minascan.io/berkeley/zk-transaction/`;
   const MINA_EXPLORER_BASE_URL = `https://berkeley.minaexplorer.com/transaction/`;
-  const randomIndex = Math.floor(Math.random() * 2);
+  const explorers = [MINASCAN_BASE_URL, MINA_EXPLORER_BASE_URL];
+  const randomExplorersIndex = Math.floor(Math.random() * explorers.length);
 
   const explorerName = new URL(graphQLUrl).hostname
     .split('.')
@@ -481,7 +482,8 @@ function getTxnUrl(graphQLUrl, txn) {
       txnBaseUrl = MINA_EXPLORER_BASE_URL;
       break;
     default:
-      txnBaseUrl = [MINASCAN_BASE_URL, MINA_EXPLORER_BASE_URL][randomIndex];
+      // An explorer will be randomly selected from the availble explorers if the developer doesn't specify
+      txnBaseUrl = explorers[randomExplorersIndex];
       break;
   }
 

--- a/src/lib/deploy.js
+++ b/src/lib/deploy.js
@@ -462,6 +462,7 @@ async function deploy({ alias, yes }) {
   await shutdown();
 }
 
+// Get the desired blockchain explorer url with txn hash
 function getTxUrl(graphQLEndpoint, txn) {
   const explorerName = graphQLEndpoint
     .split('.')

--- a/src/lib/deploy.js
+++ b/src/lib/deploy.js
@@ -477,6 +477,7 @@ function getTxUrl(graphQLEndpoint, txn) {
       txBaseUrl = `https://berkeley.minaexplorer.com/transaction/`;
       break;
     default:
+      txBaseUrl = `https://berkeley.minaexplorer.com/transaction/`;
       break;
   }
 

--- a/src/lib/deploy.js
+++ b/src/lib/deploy.js
@@ -466,7 +466,7 @@ async function deploy({ alias, yes }) {
 function getTxUrl(graphQLEndpoint, txn) {
   const explorerName = graphQLEndpoint
     .split('.')
-    .filter((item) => (item === 'minascan') | (item === 'minaexplorer'))?.[0];
+    .filter((item) => item === 'minascan' || item === 'minaexplorer')?.[0];
   let txBaseUrl;
 
   switch (explorerName) {

--- a/src/lib/deploy.js
+++ b/src/lib/deploy.js
@@ -473,7 +473,9 @@ function getTxUrl(graphQLEndpoint) {
     case 'minascan':
       txBaseUrl = `https://minascan.io/berkeley/zk-transaction/`;
       break;
-
+    case 'minaexplorer':
+      txBaseUrl = `https://berkeley.minaexplorer.com/transaction/`;
+      break;
     default:
       break;
   }

--- a/src/lib/deploy.js
+++ b/src/lib/deploy.js
@@ -450,14 +450,13 @@ async function deploy({ alias, yes }) {
     return;
   }
 
-  const txUrl = `https://berkeley.minaexplorer.com/transaction/${txn.data.sendZkapp.zkapp.hash}`; // TODO: Make the network configurable
   const str =
     `\nSuccess! Deploy transaction sent.` +
     `\n` +
     `\nNext step:` +
     `\n  Your smart contract will be live (or updated)` +
     `\n  as soon as the transaction is included in a block:` +
-    `\n  ${txUrl}`;
+    `\n  ${getTxUrl(graphQLEndpoint, txn)}`;
 
   log(green(str));
   await shutdown();

--- a/src/lib/deploy.js
+++ b/src/lib/deploy.js
@@ -463,7 +463,7 @@ async function deploy({ alias, yes }) {
   await shutdown();
 }
 
-function getTxUrl(graphQLEndpoint) {
+function getTxUrl(graphQLEndpoint, txn) {
   const networkName = graphQLEndpoint
     .split('.')
     .filter((item) => (item === 'minascan') | (item === 'minaexplorer'))?.[0];
@@ -479,6 +479,8 @@ function getTxUrl(graphQLEndpoint) {
     default:
       break;
   }
+
+  return `${txBaseUrl}${txn.data.sendZkapp.zkapp.hash}`;
 }
 
 // Query npm registry to get the latest CLI version.

--- a/src/lib/deploy.js
+++ b/src/lib/deploy.js
@@ -450,10 +450,6 @@ async function deploy({ alias, yes }) {
     return;
   }
 
-  const networkName = graphQLEndpoint
-    .split('.')
-    .filter((item) => (item === 'minascan') | (item === 'minaexplorer'))?.[0];
-
   const txUrl = `https://berkeley.minaexplorer.com/transaction/${txn.data.sendZkapp.zkapp.hash}`; // TODO: Make the network configurable
   const str =
     `\nSuccess! Deploy transaction sent.` +
@@ -465,6 +461,22 @@ async function deploy({ alias, yes }) {
 
   log(green(str));
   await shutdown();
+}
+
+function getTxUrl(graphQLEndpoint) {
+  const networkName = graphQLEndpoint
+    .split('.')
+    .filter((item) => (item === 'minascan') | (item === 'minaexplorer'))?.[0];
+  let txBaseUrl;
+
+  switch (networkName) {
+    case 'minascan':
+      txBaseUrl = `https://minascan.io/berkeley/zk-transaction/`;
+      break;
+
+    default:
+      break;
+  }
 }
 
 // Query npm registry to get the latest CLI version.

--- a/src/lib/deploy.js
+++ b/src/lib/deploy.js
@@ -193,6 +193,7 @@ async function deploy({ alias, yes }) {
   );
 
   const graphQLEndpoint = config?.networks[alias]?.url ?? DEFAULT_GRAPHQL;
+
   const { data: nodeStatus } = await sendGraphQL(
     graphQLEndpoint,
     `query {
@@ -448,6 +449,10 @@ async function deploy({ alias, yes }) {
     await shutdown();
     return;
   }
+
+  const networkName = graphQLEndpoint
+    .split('.')
+    .filter((item) => (item === 'minascan') | (item === 'minaexplorer'))?.[0];
 
   const txUrl = `https://berkeley.minaexplorer.com/transaction/${txn.data.sendZkapp.zkapp.hash}`; // TODO: Make the network configurable
   const str =


### PR DESCRIPTION
Closes #357

This PR displays the developers desired blockchain explorer URL after sending a deploy transaction. 

**Approach**

The desired blockchain explorer name is parsed from the `Mina GraphQL API URL` that the developer adds after entering the `zk config` command. A blockchain explorer URL with a transaction hash, is constructed and displayed in the `zkapp-cli` after sending a deploy transaction.  This can be extended to support Mainnet and future blockchain explorers. 

<img width="1201" alt="minascanDeploy" src="https://user-images.githubusercontent.com/2808242/216130544-c8a55ce5-43fb-4531-874b-ce4e33717b01.png">

<img width="1025" alt="minaexplorerDeploy" src="https://user-images.githubusercontent.com/2808242/216130554-f13cf5b5-22e0-448d-bc04-8f5d48c5f1b9.png">

The blockchain explorer name is also added to the displayed faucet URL as a query parameter after a developer enters the `zk config` command and adds a new `Mina GraphQL API URL`. The explorer name query parameter can be used in the faucet to display the desired block explorer transaction URL after an account is funded.  

<img width="1454" alt="minascanFaucet" src="https://user-images.githubusercontent.com/2808242/216135031-f4dc832b-26cf-4fd0-99aa-c84182ab3529.png">

**Testing**

This was tested by generating new projects and deploying them with the two currently available `Mina GraphQL API URL`s.
