### PR TITLE
Update "networks" in config.json to "deployAliases" 

### DIFF
--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -32,6 +32,11 @@ async function config() {
     return;
   }
 
+  // Checks to see if developer has the legacy networks config object
+  const deployAliasesConfigName = config?.['networks']
+    ? 'networks'
+    : 'deployAliases';
+
   // Build table of existing deployAliases found in their config.json
   let tableData = [[bold('Name'), bold('Url'), bold('Smart Contract')]];
   for (const deployAlias in config.deployAliases) {

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -33,7 +33,8 @@ async function config() {
   }
 
   // Checks if developer has the legacy networks or deploy aliases in config.json
-  if (!config.hasOwn('deployAliases')) config.deployAliases = config?.networks;
+  if (!Object.prototype.hasOwnProperty.call(config, 'deployAliases'))
+    config.deployAliases = config?.networks;
 
   // Build table of existing deployAliases found in their config.json
   let tableData = [[bold('Name'), bold('Url'), bold('Smart Contract')]];

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -167,7 +167,9 @@ async function config() {
     fs.outputJsonSync(`${DIR}/config.json`, config, { spaces: 2 });
   });
 
-  const explorerName = getExplorerName(config?.deployAliases[deployAlias]?.url);
+  const explorerName = getExplorerName(
+    config?.[deployAliasesConfigName][deployAlias]?.url
+  );
 
   const str =
     `\nSuccess!\n` +

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -144,7 +144,7 @@ async function config() {
   const keyPair = await step(
     `Create key pair at keys/${deployAlias}.json`,
     async () => {
-      const client = new Client({ deployAlias: 'testnet' }); // TODO: Make this configurable for mainnet and testnet.
+      const client = new Client({ network: 'testnet' }); // TODO: Make this configurable for mainnet and testnet.
       let keyPair = client.genKeys();
       fs.outputJsonSync(`${DIR}/keys/${deployAlias}.json`, keyPair, {
         spaces: 2,

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -32,7 +32,7 @@ async function config() {
     return;
   }
 
-  // Checks to see if developer has the legacy networks config object
+  // Checks if developer has the legacy networks or deployAliases in config.json
   const deployAliasesConfigName = config?.['networks']
     ? 'networks'
     : 'deployAliases';

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -9,7 +9,7 @@ const Client = require('mina-signer');
 const log = console.log;
 
 /**
- * Show existing networks in `config.json` and allow a user to add a new
+ * Show existing deployAliases in `config.json` and allow a user to add a new
  * network and url--and generate a key pair for it.
  * @returns {Promise<void>}
  */
@@ -32,10 +32,10 @@ async function config() {
     return;
   }
 
-  // Build table of existing networks found in their config.json
+  // Build table of existing deployAliases found in their config.json
   let tableData = [[bold('Name'), bold('Url'), bold('Smart Contract')]];
-  for (const network in config.networks) {
-    const { url, smartContract } = config.networks[network];
+  for (const network in config.deployAliases) {
+    const { url, smartContract } = config.deployAliases[network];
     tableData.push([
       network,
       url ?? '',
@@ -50,11 +50,11 @@ async function config() {
     border: getBorderCharacters('norc'),
     header: {
       alignment: 'center',
-      content: bold('Networks in config.json'),
+      content: bold('DeployAliases in config.json'),
     },
   };
 
-  // Show "none found", if no networks exist.
+  // Show "none found", if no deployAliases exist.
   if (tableData.length === 1) {
     // Add some padding to empty name & url columns, to feel more natural.
     tableData[0][0] = tableData[0][0] + ' '.repeat(2);
@@ -98,7 +98,7 @@ async function config() {
       validate: async (val) => {
         val = val.toLowerCase().trim().replace(' ', '-');
         if (!val) return red('Name is required.');
-        if (Object.keys(config.networks).includes(val)) {
+        if (Object.keys(config.deployAliases).includes(val)) {
           return red('Name already exists.');
         }
         return true;
@@ -152,11 +152,15 @@ async function config() {
   );
 
   await step(`Add network to config.json`, async () => {
-    config.networks[network] = { url, keyPath: `keys/${network}.json`, fee };
+    config.deployAliases[network] = {
+      url,
+      keyPath: `keys/${network}.json`,
+      fee,
+    };
     fs.outputJsonSync(`${DIR}/config.json`, config, { spaces: 2 });
   });
 
-  const explorerName = getExplorerName(config?.networks[network]?.url);
+  const explorerName = getExplorerName(config?.deployAliases[network]?.url);
 
   const str =
     `\nSuccess!\n` +

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -35,7 +35,7 @@ async function config() {
   // Checks if developer has the legacy networks in config.json and renames it to deploy aliases.
   if (Object.prototype.hasOwnProperty.call(config, 'networks')) {
     Object.assign(config, { deployAliases: config.networks });
-    delete config['networks'];
+    delete config.networks;
   }
 
   // Build table of existing deploy aliases found in their config.json

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -9,8 +9,8 @@ const Client = require('mina-signer');
 const log = console.log;
 
 /**
- * Show existing deployAliases in `config.json` and allow a user to add a new
- * deployAlias and url--and generate a key pair for it.
+ * Show existing deploy aliases in `config.json` and allow a user to add a new
+ * deploy alias and url--and generate a key pair for it.
  * @returns {Promise<void>}
  */
 async function config() {
@@ -36,7 +36,7 @@ async function config() {
   if (!Object.prototype.hasOwnProperty.call(config, 'deployAliases'))
     config.deployAliases = config?.networks;
 
-  // Build table of existing deployAliases found in their config.json
+  // Build table of existing deploy aliases found in their config.json
   let tableData = [[bold('Name'), bold('Url'), bold('Smart Contract')]];
   for (const deployAlias in config.deployAliases) {
     const { url, smartContract } = config.deployAliases[deployAlias];
@@ -47,7 +47,7 @@ async function config() {
     ]);
   }
 
-  // Sort alphabetically by deployAlias name.
+  // Sort alphabetically by deploy alias name.
   tableData = tableData.sort((a, b) => a[0].localeCompare(b[0]));
 
   const tableConfig = {
@@ -58,7 +58,7 @@ async function config() {
     },
   };
 
-  // Show "none found", if no deployAliases exist.
+  // Show "none found", if no deploy aliases exist.
   if (tableData.length === 1) {
     // Add some padding to empty name & url columns, to feel more natural.
     tableData[0][0] = tableData[0][0] + ' '.repeat(2);
@@ -75,7 +75,7 @@ async function config() {
   console.log('Add a new deploy alias:');
 
   // TODO: Later, show pre-configured list to choose from or let user
-  // add a custom deployAlias.
+  // add a custom deploy alias.
 
   function formatPrefixSymbol(state) {
     // Shows a cyan question mark when not submitted.

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -34,9 +34,8 @@ async function config() {
 
   // Checks if developer has the legacy networks in config.json and renames it to deploy aliases.
   if (Object.prototype.hasOwnProperty.call(config, 'networks')) {
-    delete Object.assign(config, { deployAliases: config.networks })[
-      'networks'
-    ];
+    Object.assign(config, { deployAliases: config.networks });
+    delete config['networks'];
   }
 
   // Build table of existing deploy aliases found in their config.json

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -39,8 +39,8 @@ async function config() {
 
   // Build table of existing deployAliases found in their config.json
   let tableData = [[bold('Name'), bold('Url'), bold('Smart Contract')]];
-  for (const deployAlias in config.deployAliases) {
-    const { url, smartContract } = config.deployAliases[deployAlias];
+  for (const deployAlias in config[deployAliasesConfigName]) {
+    const { url, smartContract } = config[deployAliasesConfigName][deployAlias];
     tableData.push([
       deployAlias,
       url ?? '',
@@ -103,7 +103,7 @@ async function config() {
       validate: async (val) => {
         val = val.toLowerCase().trim().replace(' ', '-');
         if (!val) return red('Name is required.');
-        if (Object.keys(config.deployAliases).includes(val)) {
+        if (Object.keys(config[deployAliasesConfigName]).includes(val)) {
           return red('Name already exists.');
         }
         return true;
@@ -159,7 +159,7 @@ async function config() {
   );
 
   await step(`Add deployAlias to config.json`, async () => {
-    config.deployAliases[deployAlias] = {
+    config[deployAliasesConfigName][deployAlias] = {
       url,
       keyPath: `keys/${deployAlias}.json`,
       fee,

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -32,9 +32,11 @@ async function config() {
     return;
   }
 
-  // Checks if developer has the legacy networks or deploy aliases in config.json
-  if (!Object.prototype.hasOwnProperty.call(config, 'deployAliases'))
-    config.deployAliases = config?.networks;
+  // Checks if developer has the legacy networks in config.json and renames it to deploy aliases.
+  if (Object.prototype.hasOwnProperty.call(config, 'networks')) {
+    Object.assign(config, { deployAliases: config.networks })['networks'];
+    delete config['networks'];
+  }
 
   // Build table of existing deploy aliases found in their config.json
   let tableData = [[bold('Name'), bold('Url'), bold('Smart Contract')]];

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -34,8 +34,9 @@ async function config() {
 
   // Checks if developer has the legacy networks in config.json and renames it to deploy aliases.
   if (Object.prototype.hasOwnProperty.call(config, 'networks')) {
-    Object.assign(config, { deployAliases: config.networks })['networks'];
-    delete config['networks'];
+    delete Object.assign(config, { deployAliases: config.networks })[
+      'networks'
+    ];
   }
 
   // Build table of existing deploy aliases found in their config.json

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -32,7 +32,7 @@ async function config() {
     return;
   }
 
-  // Checks if developer has the legacy networks or deployAliases in config.json
+  // Checks if developer has the legacy networks or deploy aliases in config.json
   if (!config.hasOwn('deployAliases')) config.deployAliases = config?.networks;
 
   // Build table of existing deployAliases found in their config.json
@@ -53,7 +53,7 @@ async function config() {
     border: getBorderCharacters('norc'),
     header: {
       alignment: 'center',
-      content: bold('DeployAliases in config.json'),
+      content: bold('Deploy Aliases in config.json'),
     },
   };
 
@@ -71,7 +71,7 @@ async function config() {
   const msg = '\n  ' + table(tableData, tableConfig).replaceAll('\n', '\n  ');
   log(msg);
 
-  console.log('Add a new deployAlias:');
+  console.log('Add a new deploy alias:');
 
   // TODO: Later, show pre-configured list to choose from or let user
   // add a custom deployAlias.
@@ -156,7 +156,7 @@ async function config() {
     }
   );
 
-  await step(`Add deployAlias to config.json`, async () => {
+  await step(`Add deploy alias to config.json`, async () => {
     config.deployAliases[deployAlias] = {
       url,
       keyPath: `keys/${deployAlias}.json`,

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -33,14 +33,12 @@ async function config() {
   }
 
   // Checks if developer has the legacy networks or deployAliases in config.json
-  const deployAliasesConfigName = config?.['networks']
-    ? 'networks'
-    : 'deployAliases';
+  if (!config.hasOwn('deployAliases')) config.deployAliases = config?.networks;
 
   // Build table of existing deployAliases found in their config.json
   let tableData = [[bold('Name'), bold('Url'), bold('Smart Contract')]];
-  for (const deployAlias in config[deployAliasesConfigName]) {
-    const { url, smartContract } = config[deployAliasesConfigName][deployAlias];
+  for (const deployAlias in config.deployAliases) {
+    const { url, smartContract } = config.deployAliases[deployAlias];
     tableData.push([
       deployAlias,
       url ?? '',
@@ -103,7 +101,7 @@ async function config() {
       validate: async (val) => {
         val = val.toLowerCase().trim().replace(' ', '-');
         if (!val) return red('Name is required.');
-        if (Object.keys(config[deployAliasesConfigName]).includes(val)) {
+        if (Object.keys(config.deployAliases).includes(val)) {
           return red('Name already exists.');
         }
         return true;
@@ -159,7 +157,7 @@ async function config() {
   );
 
   await step(`Add deployAlias to config.json`, async () => {
-    config[deployAliasesConfigName][deployAlias] = {
+    config.deployAliases[deployAlias] = {
       url,
       keyPath: `keys/${deployAlias}.json`,
       fee,
@@ -167,9 +165,7 @@ async function config() {
     fs.outputJsonSync(`${DIR}/config.json`, config, { spaces: 2 });
   });
 
-  const explorerName = getExplorerName(
-    config?.[deployAliasesConfigName][deployAlias]?.url
-  );
+  const explorerName = getExplorerName(config.deployAliases[deployAlias]?.url);
 
   const str =
     `\nSuccess!\n` +

--- a/src/lib/deploy.js
+++ b/src/lib/deploy.js
@@ -16,7 +16,7 @@ const DEFAULT_GRAPHQL = 'https://proxy.berkeley.minaexplorer.com/graphql'; // Th
 
 /**
  * Deploy a smart contract to the specified deploy alias. If no deploy alias param is
- * provided, yargs will tell the user that the deployAlias param is required.
+ * provided, yargs will tell the user that the deploy alias param is required.
  * @param {string} alias   The deploy alias to deploy to.
  * @param {string} yes     Run non-interactively. I.e. skip confirmation steps.
  * @return {Promise<void>} Sends tx to a relayer, if confirmed by user.
@@ -88,7 +88,7 @@ async function deploy({ alias, yes }) {
   alias = alias.toLowerCase();
 
   if (!config.deployAliases[alias]) {
-    log(red('Deploy Alias name not found in config.json.'));
+    log(red('Deploy alias name not found in config.json.'));
     log(red('You can add a deploy alias by running `zk config`.'));
     return;
   }
@@ -564,7 +564,7 @@ async function findSmartContracts(path) {
  * @returns {string}       The smart contract name.
  */
 function chooseSmartContract(config, deploy, deployAliasName) {
-  // If the deployAlias in config.json has a smartContract specified, use it.
+  // If the deploy alias in config.json has a smartContract specified, use it.
   if (config.deployAliases[deployAliasName]?.smartContract) {
     return config.deployAliases[deployAliasName]?.smartContract;
   }
@@ -575,7 +575,7 @@ function chooseSmartContract(config, deploy, deployAliasName) {
   }
 
   // If 2+ smartContract classes exist in build.json, return falsy.
-  // We'll need to ask the user which they want to use for this deployAlias.
+  // We'll need to ask the user which they want to use for this deploy alias.
   return '';
 }
 

--- a/src/lib/deploy.js
+++ b/src/lib/deploy.js
@@ -51,7 +51,7 @@ async function deploy({ alias, yes }) {
   }
 
   if (!alias) {
-    const aliases = Object.keys(config?.networks);
+    const aliases = Object.keys(config?.deployAliases);
     if (!aliases.length) {
       log(red('No deploy aliases found in config.json.'));
       log(red('Run `zk config` to add a deploy alias, then try again.'));
@@ -83,13 +83,13 @@ async function deploy({ alias, yes }) {
 
   alias = alias.toLowerCase();
 
-  if (!config.networks[alias]) {
+  if (!config.deployAliases[alias]) {
     log(red('Network name not found in config.json.'));
     log(red('You can add a network by running `zk config`.'));
     return;
   }
 
-  if (!config.networks[alias].url) {
+  if (!config.deployAliases[alias].url) {
     log(red(`No 'url' property is specified for this network in config.json.`));
     log(red(`Please correct your config.json and try again.`));
     return;
@@ -159,9 +159,9 @@ async function deploy({ alias, yes }) {
     // the step formatting.
     await step('Choose smart contract', async () => {});
 
-    if (config.networks[alias]?.smartContract) {
+    if (config.deployAliases[alias]?.smartContract) {
       log(
-        `  The '${config.networks[alias]?.smartContract}' smart contract will be used\n  for this network as specified in config.json.`
+        `  The '${config.deployAliases[alias]?.smartContract}' smart contract will be used\n  for this network as specified in config.json.`
       );
     } else {
       log(
@@ -174,8 +174,8 @@ async function deploy({ alias, yes }) {
   // Occurs when this is the first time we're deploying to a given network.
   // Important to ensure the same smart contract will always be deployed to
   // the same network.
-  if (config.networks[alias]?.smartContract !== contractName) {
-    config.networks[alias].smartContract = contractName;
+  if (config.deployAliases[alias]?.smartContract !== contractName) {
+    config.deployAliases[alias].smartContract = contractName;
     fs.writeJSONSync(`${DIR}/config.json`, config, { spaces: 2 });
     log(
       `  Your config.json was updated to always use this\n  smart contract when deploying to this network.`
@@ -192,7 +192,7 @@ async function deploy({ alias, yes }) {
     snarkyjsImportPath
   );
 
-  const graphQLUrl = config?.networks[alias]?.url ?? DEFAULT_GRAPHQL;
+  const graphQLUrl = config?.deployAliases[alias]?.url ?? DEFAULT_GRAPHQL;
 
   const { data: nodeStatus } = await sendGraphQL(
     graphQLUrl,
@@ -316,7 +316,7 @@ async function deploy({ alias, yes }) {
     log('  Using the cached verification key');
   }
 
-  let { fee } = config.networks[alias];
+  let { fee } = config.deployAliases[alias];
   if (!fee) {
     log(
       red(
@@ -376,7 +376,7 @@ async function deploy({ alias, yes }) {
 
   const settings = [
     [bold('Network'), reset(alias)],
-    [bold('Url'), reset(config.networks[alias].url)],
+    [bold('Url'), reset(config.deployAliases[alias].url)],
     [bold('Smart Contract'), reset(contractName)],
   ];
 
@@ -556,8 +556,8 @@ async function findSmartContracts(path) {
  */
 function chooseSmartContract(config, deploy, network) {
   // If the network in config.json has a smartContract specified, use it.
-  if (config.networks[network]?.smartContract) {
-    return config.networks[network]?.smartContract;
+  if (config.deployAliases[network]?.smartContract) {
+    return config.deployAliases[network]?.smartContract;
   }
 
   // If only one smart contract exists in the build, use it.

--- a/src/lib/deploy.js
+++ b/src/lib/deploy.js
@@ -44,7 +44,8 @@ async function deploy({ alias, yes }) {
   const installedCliVersion = await getInstalledCliVersion();
 
   // Checks if developer has the legacy networks or deploy aliases in config.json
-  if (!config.hasOwn('deployAliases')) config.deployAliases = config?.networks;
+  if (!Object.prototype.hasOwnProperty.call(config, 'deployAliases'))
+    config.deployAliases = config?.networks;
 
   if (hasBreakingChanges(installedCliVersion, latestCliVersion)) {
     log(red(`You are using an old zkapp-cli version ${installedCliVersion}.`));
@@ -559,6 +560,7 @@ async function findSmartContracts(path) {
  * Choose which smart contract should be deployed for this deploy alias.
  * @param {object} config  The config.json in object format.
  * @param {object} deploy  The build/build.json in object format.
+ * @param {string} deployAliasName The deploy alias name.
  * @returns {string}       The smart contract name.
  */
 function chooseSmartContract(config, deploy, deployAliasName) {

--- a/src/lib/deploy.js
+++ b/src/lib/deploy.js
@@ -15,7 +15,7 @@ const log = console.log;
 const DEFAULT_GRAPHQL = 'https://proxy.berkeley.minaexplorer.com/graphql'; // The endpoint used to interact with the network
 
 /**
- * Deploy a smart contract to the specified deployAlias. If no deployAlias param is
+ * Deploy a smart contract to the specified deploy alias. If no deploy alias param is
  * provided, yargs will tell the user that the deployAlias param is required.
  * @param {string} alias   The deploy alias to deploy to.
  * @param {string} yes     Run non-interactively. I.e. skip confirmation steps.
@@ -42,7 +42,8 @@ async function deploy({ alias, yes }) {
 
   const latestCliVersion = await getLatestCliVersion();
   const installedCliVersion = await getInstalledCliVersion();
-  // Checks if developer has the legacy networks or deployAliases in config.json
+
+  // Checks if developer has the legacy networks or deploy aliases in config.json
   if (!config.hasOwn('deployAliases')) config.deployAliases = config?.networks;
 
   if (hasBreakingChanges(installedCliVersion, latestCliVersion)) {
@@ -86,13 +87,17 @@ async function deploy({ alias, yes }) {
   alias = alias.toLowerCase();
 
   if (!config.deployAliases[alias]) {
-    log(red('Network name not found in config.json.'));
-    log(red('You can add a network by running `zk config`.'));
+    log(red('Deploy Alias name not found in config.json.'));
+    log(red('You can add a deploy alias by running `zk config`.'));
     return;
   }
 
   if (!config.deployAliases[alias].url) {
-    log(red(`No 'url' property is specified for this network in config.json.`));
+    log(
+      red(
+        `No 'url' property is specified for this deploy alias in config.json.`
+      )
+    );
     log(red(`Please correct your config.json and try again.`));
     return;
   }
@@ -129,10 +134,10 @@ async function deploy({ alias, yes }) {
     return { smartContracts };
   });
 
-  // Identify which smart contract should be deployed for this network.
+  // Identify which smart contract should be deployed for this deploy alias.
   let contractName = chooseSmartContract(config, build, alias);
 
-  // If no smart contract is specified for this network in config.json &
+  // If no smart contract is specified for this deploy alias in config.json &
   // 2+ smart contracts exist in build.json, ask which they want to use.
   if (!contractName) {
     const res = await prompt({
@@ -163,7 +168,7 @@ async function deploy({ alias, yes }) {
 
     if (config.deployAliases[alias]?.smartContract) {
       log(
-        `  The '${config.deployAliases[alias]?.smartContract}' smart contract will be used\n  for this network as specified in config.json.`
+        `  The '${config.deployAliases[alias]?.smartContract}' smart contract will be used\n  for this deploy alias as specified in config.json.`
       );
     } else {
       log(
@@ -172,15 +177,15 @@ async function deploy({ alias, yes }) {
     }
   }
 
-  // Set the default smartContract name for this network in config.json.
-  // Occurs when this is the first time we're deploying to a given network.
+  // Set the default smartContract name for this deploy alias in config.json.
+  // Occurs when this is the first time we're deploying to a given deploy alias.
   // Important to ensure the same smart contract will always be deployed to
-  // the same network.
+  // the same deploy alias.
   if (config.deployAliases[alias]?.smartContract !== contractName) {
     config.deployAliases[alias].smartContract = contractName;
     fs.writeJSONSync(`${DIR}/config.json`, config, { spaces: 2 });
     log(
-      `  Your config.json was updated to always use this\n  smart contract when deploying to this network.`
+      `  Your config.json was updated to always use this\n  smart contract when deploying to this deploy alias.`
     );
   }
 
@@ -377,7 +382,7 @@ async function deploy({ alias, yes }) {
   let transactionJson = transaction.json;
 
   const settings = [
-    [bold('Network'), reset(alias)],
+    [bold('Deploy Alias'), reset(alias)],
     [bold('Url'), reset(config.deployAliases[alias].url)],
     [bold('Smart Contract'), reset(contractName)],
   ];
@@ -551,7 +556,7 @@ async function findSmartContracts(path) {
 }
 
 /**
- * Choose which smart contract should be deployed for this network.
+ * Choose which smart contract should be deployed for this deploy alias.
  * @param {object} config  The config.json in object format.
  * @param {object} deploy  The build/build.json in object format.
  * @returns {string}       The smart contract name.

--- a/src/lib/deploy.test.js
+++ b/src/lib/deploy.test.js
@@ -16,14 +16,9 @@ describe('deploy.js', () => {
           },
         };
         const deploy = {};
-        const network = 'mainnet';
-        const deployAliasesConfigName = 'deployAliases';
-        const result = chooseSmartContract(
-          config,
-          deploy,
-          deployAliasesConfigName,
-          network
-        );
+        const deployAliasName = 'mainnet';
+
+        const result = chooseSmartContract(config, deploy, deployAliasName);
         expect(result).toEqual('Foo');
       });
     });
@@ -34,19 +29,14 @@ describe('deploy.js', () => {
           mainnet: {},
         },
       };
-      const deployAliasesConfigName = 'deployAliases';
-      const network = 'mainnet';
+
+      const deployAliasName = 'mainnet';
       describe('if only one smart contract exists in the build (deploy.json)', () => {
         it('should select that smart contract', () => {
           const deploy = {
             smartContracts: ['Bar'],
           };
-          const result = chooseSmartContract(
-            config,
-            deploy,
-            deployAliasesConfigName,
-            network
-          );
+          const result = chooseSmartContract(config, deploy, deployAliasName);
           expect(result).toEqual('Bar');
         });
       });
@@ -55,12 +45,8 @@ describe('deploy.js', () => {
           const deploy = {
             smartContracts: ['Foo', 'Bar'],
           };
-          const result = chooseSmartContract(
-            config,
-            deploy,
-            deployAliasesConfigName,
-            network
-          );
+          const deployAliasName = 'mainnet';
+          const result = chooseSmartContract(config, deploy, deployAliasName);
           expect(result).toEqual(''); // falsy
         });
       });

--- a/src/lib/deploy.test.js
+++ b/src/lib/deploy.test.js
@@ -9,7 +9,7 @@ describe('deploy.js', () => {
       it('should select that smart contract', () => {
         const config = {
           version: 1,
-          networks: {
+          deployAliases: {
             mainnet: {
               smartContract: 'Foo',
             },
@@ -17,24 +17,36 @@ describe('deploy.js', () => {
         };
         const deploy = {};
         const network = 'mainnet';
-        const result = chooseSmartContract(config, deploy, network);
+        const deployAliasesConfigName = 'deployAliases';
+        const result = chooseSmartContract(
+          config,
+          deploy,
+          deployAliasesConfigName,
+          network
+        );
         expect(result).toEqual('Foo');
       });
     });
     describe('if the network in config.json does NOT have a smartContract specified', () => {
       const config = {
         version: 1,
-        networks: {
+        deployAliases: {
           mainnet: {},
         },
       };
+      const deployAliasesConfigName = 'deployAliases';
       const network = 'mainnet';
       describe('if only one smart contract exists in the build (deploy.json)', () => {
         it('should select that smart contract', () => {
           const deploy = {
             smartContracts: ['Bar'],
           };
-          const result = chooseSmartContract(config, deploy, network);
+          const result = chooseSmartContract(
+            config,
+            deploy,
+            deployAliasesConfigName,
+            network
+          );
           expect(result).toEqual('Bar');
         });
       });
@@ -43,7 +55,12 @@ describe('deploy.js', () => {
           const deploy = {
             smartContracts: ['Foo', 'Bar'],
           };
-          const result = chooseSmartContract(config, deploy, network);
+          const result = chooseSmartContract(
+            config,
+            deploy,
+            deployAliasesConfigName,
+            network
+          );
           expect(result).toEqual(''); // falsy
         });
       });

--- a/templates/project-ts/config.json
+++ b/templates/project-ts/config.json
@@ -1,4 +1,4 @@
 {
   "version": 1,
-  "networks": {}
+  "deployAliases": {}
 }


### PR DESCRIPTION
Closes #217 

This PR updates `networks`  to `deployAliases` in the `config.json` and throughout the `zkApp-cli` for clarity. The `config.js` and `deploy.js` files were changed to support both cases if either `networks` or `deployAliases` are found in the `config.json`.  