### PR TITLE
Add timeout to warm gittar cache step

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zkapp-cli",
-  "version": "0.6.0",
+  "version": "0.6.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "zkapp-cli",
-      "version": "0.6.0",
+      "version": "0.6.4",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zkapp-cli",
-  "version": "0.6.2",
+  "version": "0.6.4",
   "description": "CLI to create a zkApp (\"zero-knowledge app\") for Mina Protocol.",
   "keywords": [
     "cli",

--- a/src/postinstall.js
+++ b/src/postinstall.js
@@ -56,8 +56,10 @@ async function warmGittarCache() {
 
   try {
     const src = 'github:o1-labs/zkapp-cli#main';
-    await gittar.fetch(src, { force: true });
+    gittar.fetch(src, { force: true });
   } catch (err) {
     console.error(err);
   }
 }
+
+async function gittarFetchInTimeLimit(maxTimeLimit, gittarFetch) {}

--- a/src/postinstall.js
+++ b/src/postinstall.js
@@ -62,4 +62,10 @@ async function warmGittarCache() {
   }
 }
 
-async function gittarFetchInTimeLimit(maxTimeLimit, gittarFetch) {}
+async function gittarFetchInTimeLimit(maxTimeLimit, gittarFetch) {
+  const gittarTimeoutPromise = new Promise((resolve, reject) => {
+    setTimeout(() => {
+      resolve(null);
+    }, maxTimeLimit);
+  });
+}

--- a/src/postinstall.js
+++ b/src/postinstall.js
@@ -43,6 +43,7 @@ async function warmNpmCache() {
 
   try {
     for await (const pkgWithVersion of toCache) {
+      console.log(`  Adding ${pkgWithVersion} to the cache.`);
       await shExec(`npm cache add ${pkgWithVersion}`);
     }
     console.log('    Done.');

--- a/src/postinstall.js
+++ b/src/postinstall.js
@@ -64,11 +64,14 @@ async function warmGittarCache() {
 }
 
 async function gittarFetchInTimeLimit(maxTimeLimit, gittarFetch) {
-  const gittarTimeoutPromise = new Promise((resolve, reject) => {
-    setTimeout(() => {
+  let gittarTimeout;
+  const gittarTimeoutPromise = new Promise((resolve) => {
+    gittarTimeout = setTimeout(() => {
       resolve(null);
     }, maxTimeLimit);
   });
+
+  if (gittarTimeout) clearTimeout(gittarTimeout);
 
   const response = await Promise.race([gittarFetch, gittarTimeoutPromise]);
 

--- a/src/postinstall.js
+++ b/src/postinstall.js
@@ -11,8 +11,7 @@ const gittar = require('gittar');
 const shExec = util.promisify(sh.exec);
 
 (async () => {
-  gittarFetchInTimeLimit(100, warmNpmCache);
-  // await warmNpmCache();
+  await warmNpmCache();
   await warmGittarCache();
 })();
 
@@ -56,10 +55,9 @@ async function warmGittarCache() {
   console.log('  Warm cache for project template.');
 
   try {
-    console.log('  Fetching project template.');
-
     const maxTimeLimit = 7000;
     const src = 'github:o1-labs/zkapp-cli#main';
+    console.log('  Fetching project template.');
     const response = await gittarFetchInTimeLimit(
       gittar.fetch(src, { force: true }),
       maxTimeLimit

--- a/src/postinstall.js
+++ b/src/postinstall.js
@@ -55,7 +55,7 @@ async function warmGittarCache() {
   console.log('  Warm cache for project template.');
 
   try {
-    const maxTimeLimit = 7000;
+    const maxTimeLimit = 15000;
     const src = 'github:o1-labs/zkapp-cli#main';
     console.log('  Fetching project template.');
     const response = await gittarFetchInTimeLimit(

--- a/src/postinstall.js
+++ b/src/postinstall.js
@@ -44,17 +44,7 @@ async function warmNpmCache() {
     const addPkgMaxTimeLimit = 2000;
     for await (const pkgWithVersion of toCache) {
       console.log(`  Adding ${pkgWithVersion} to the cache.`);
-      // Skips "Warm NPM cache for project template deps" steps  if adding
-      // a pacakage takes longer than the add package max time limit.
-      const npmCacheResponse = await executeInTimeLimit(
-        shExec(`npm cache add ${pkgWithVersion}`),
-        addPkgMaxTimeLimit
-      );
-
-      if (npmCacheResponse === null) {
-        console.log('  Skip warm NPM cache for project template');
-        return;
-      }
+      await shExec(`npm cache add ${pkgWithVersion}`);
     }
     console.log('    Done.');
   } catch (err) {

--- a/src/postinstall.js
+++ b/src/postinstall.js
@@ -22,6 +22,7 @@ const shExec = util.promisify(sh.exec);
  */
 async function warmNpmCache() {
   console.log('  Warm NPM cache for project template deps.');
+
   // cwd is the root dir where zkapp-cli's package.json is located.
   const tsProj = fs.readFileSync(
     path.join('templates', 'project-ts', 'package.json'),
@@ -41,7 +42,6 @@ async function warmNpmCache() {
   }
 
   try {
-    const addPkgMaxTimeLimit = 2000;
     for await (const pkgWithVersion of toCache) {
       console.log(`  Adding ${pkgWithVersion} to the cache.`);
       await shExec(`npm cache add ${pkgWithVersion}`);

--- a/src/postinstall.js
+++ b/src/postinstall.js
@@ -22,7 +22,6 @@ const shExec = util.promisify(sh.exec);
  */
 async function warmNpmCache() {
   console.log('  Warm NPM cache for project template deps.');
-
   // cwd is the root dir where zkapp-cli's package.json is located.
   const tsProj = fs.readFileSync(
     path.join('templates', 'project-ts', 'package.json'),
@@ -70,4 +69,8 @@ async function gittarFetchInTimeLimit(maxTimeLimit, gittarFetch) {
       resolve(null);
     }, maxTimeLimit);
   });
+
+  const response = await Promise.race([gittarFetch, gittarTimeoutPromise]);
+
+  return response;
 }

--- a/src/postinstall.js
+++ b/src/postinstall.js
@@ -41,7 +41,7 @@ async function warmNpmCache() {
   }
 
   try {
-    const addPkgMaxTimeLimit = 1500;
+    const addPkgMaxTimeLimit = 2000;
     for await (const pkgWithVersion of toCache) {
       console.log(`  Adding ${pkgWithVersion} to the cache.`);
       // Skips "Warm NPM cache for project template deps" steps  if adding
@@ -70,7 +70,7 @@ async function warmGittarCache() {
     const src = 'github:o1-labs/zkapp-cli#main';
     console.log('  Fetching project template.');
     // Skips "Warm cache for project template" step if operation takes
-    // linger than fetch max time limit.
+    // longer than the fetch max time limit.
     const response = await executeInTimeLimit(
       gittar.fetch(src, { force: true }),
       fetchMaxTimeLimit
@@ -85,18 +85,18 @@ async function warmGittarCache() {
   }
 }
 
-async function executeInTimeLimit(gittarFetch, maxTimeLimit) {
-  let gittarTimeout;
+async function executeInTimeLimit(operation, maxTimeLimit) {
+  let timeout;
 
-  const gittarTimeoutPromise = new Promise((resolve, reject) => {
-    gittarTimeout = setTimeout(() => {
+  const timeoutPromise = new Promise((resolve, reject) => {
+    timeout = setTimeout(() => {
       resolve(null);
     }, maxTimeLimit);
   });
 
-  const response = await Promise.race([gittarFetch, gittarTimeoutPromise]);
+  const response = await Promise.race([operation, timeoutPromise]);
 
-  if (gittarTimeout) clearTimeout(gittarTimeout);
+  if (timeout) clearTimeout(timeout);
 
   return response;
 }

--- a/src/postinstall.js
+++ b/src/postinstall.js
@@ -56,8 +56,13 @@ async function warmGittarCache() {
 
   try {
     console.log('  Fetching project template.');
+    const maxTimeLimit = 7000;
     const src = 'github:o1-labs/zkapp-cli#main';
-    gittar.fetch(src, { force: true });
+    const response = await gittarFetchInTimeLimit(
+      maxTimeLimit,
+      gittar.fetch(src, { force: true })
+    );
+    if (response === null) return;
   } catch (err) {
     console.error(err);
   }

--- a/src/postinstall.js
+++ b/src/postinstall.js
@@ -58,7 +58,7 @@ async function warmGittarCache() {
     const maxTimeLimit = 15000;
     const src = 'github:o1-labs/zkapp-cli#main';
     console.log('  Fetching project template.');
-    const response = await gittarFetchInTimeLimit(
+    const response = await executeInTimeLimit(
       gittar.fetch(src, { force: true }),
       maxTimeLimit
     );
@@ -72,7 +72,7 @@ async function warmGittarCache() {
   }
 }
 
-async function gittarFetchInTimeLimit(gittarFetch, maxTimeLimit) {
+async function executeInTimeLimit(gittarFetch, maxTimeLimit) {
   let gittarTimeout;
 
   const gittarTimeoutPromise = new Promise((resolve, reject) => {

--- a/src/postinstall.js
+++ b/src/postinstall.js
@@ -56,6 +56,7 @@ async function warmGittarCache() {
   console.log('  Warm cache for project template.');
 
   try {
+    console.log('  Fetching project template.');
     const src = 'github:o1-labs/zkapp-cli#main';
     gittar.fetch(src, { force: true });
   } catch (err) {


### PR DESCRIPTION
Closes #314 

**Background**

Sometimes the installation or upgrade of the zkapp-cli hangs during the `warm cache for project template` step in the `postinstall.js` file when a network request is made by gittar to fetch the zkapp-cli templates and examples from github [here](https://github.com/o1-labs/zkapp-cli/blob/main/src/postinstall.js#L59).

**Approach**

This PR adds a timeout to the fetch gittar operation. If the fetch operation does not resolve before the the timeout, the `warm cache for project template` step is skipped, and the installation continues. See [this](https://github.com/o1-labs/zkapp-cli/issues/314) discussion for more details. 

**Next steps**

A log was added to show which NPM packages were added to the cache in the `warm NPM cache for project template deps` step. A log was also added before the gittar fetch operation in the `warm cache for project template` step. We can use these logs to gain better visibility into hanging operations in the future and adjust the approach to addressing them accordingly.  
