### PR TITLE
Use SnarkyJS version of 0.9.*

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zkapp-cli",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "zkapp-cli",
-      "version": "0.7.2",
+      "version": "0.7.3",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "mina-signer": "^1.1.0",
         "ora": "^5.4.1",
         "shelljs": "^0.8.5",
-        "snarkyjs": "^0.9.2",
+        "snarkyjs": "^0.9.*",
         "table": "^6.8.0",
         "yargs": "^17.5.1"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zkapp-cli",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "CLI to create a zkApp (\"zero-knowledge app\") for Mina Protocol.",
   "keywords": [
     "cli",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "mina-signer": "^1.1.0",
     "ora": "^5.4.1",
     "shelljs": "^0.8.5",
-    "snarkyjs": "^0.9.2",
+    "snarkyjs": "^0.9.*",
     "table": "^6.8.0",
     "yargs": "^17.5.1"
   },

--- a/templates/project-ts/package-lock.json
+++ b/templates/project-ts/package-lock.json
@@ -24,7 +24,7 @@
         "typescript": "^4.7.2"
       },
       "peerDependencies": {
-        "snarkyjs": "^0.9.2"
+        "snarkyjs": "^0.9.*"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/templates/project-ts/package.json
+++ b/templates/project-ts/package.json
@@ -45,6 +45,6 @@
     "typescript": "^4.7.2"
   },
   "peerDependencies": {
-    "snarkyjs": "^0.9.2"
+    "snarkyjs": "^0.9.*"
   }
 }


### PR DESCRIPTION
Closes #374 

This was tested manually to confirm the correct SnarkyJS version in generated projects. It was also confirmed that the correct SnarkyJS version was displayed when running `zk system` .