### PR TITLE
Fix NextJS UI scaffold

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zkapp-cli",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "zkapp-cli",
-      "version": "0.7.3",
+      "version": "0.7.4",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zkapp-cli",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "description": "CLI to create a zkApp (\"zero-knowledge app\") for Mina Protocol.",
   "keywords": [
     "cli",

--- a/src/lib/project.js
+++ b/src/lib/project.js
@@ -424,10 +424,11 @@ async function scaffoldNext(projectName) {
     return;
   }
 
-  let args = ['create-next-app@latest', 'ui', '--use-npm'];
+  // set the project name and default flags
+  // https://nextjs.org/docs/api-reference/create-next-app#options
+  let args = ['create-next-app@latest', 'ui', '--use-npm', '--src-dir'];
   if (useTypescript) args.push('--ts');
 
-  // https://nextjs.org/docs/api-reference/create-next-app#options
   spawnSync('npx', args, {
     stdio: 'inherit',
     shell: true,

--- a/src/lib/project.js
+++ b/src/lib/project.js
@@ -426,7 +426,13 @@ async function scaffoldNext(projectName) {
 
   // set the project name and default flags
   // https://nextjs.org/docs/api-reference/create-next-app#options
-  let args = ['create-next-app@latest', 'ui', '--use-npm', '--src-dir'];
+  let args = [
+    'create-next-app@latest',
+    'ui',
+    '--use-npm',
+    '--src-dir',
+    '--import-alias "@/*"',
+  ];
   if (useTypescript) args.push('--ts');
 
   spawnSync('npx', args, {
@@ -513,7 +519,10 @@ async function scaffoldNext(projectName) {
         "sourceMap": true,
         "noFallthroughCasesInSwitch": true,
         "allowSyntheticDefaultImports": true,
-        "isolatedModules": true
+        "isolatedModules": true,
+        "paths": {
+          "@/*": ["./src/*"]
+    }
       },
     "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
     "exclude": ["node_modules"]

--- a/src/lib/project.js
+++ b/src/lib/project.js
@@ -481,7 +481,7 @@ async function scaffoldNext(projectName) {
   const indexFileName = useTypescript ? 'index.tsx' : 'index.jsx';
 
   fs.writeFileSync(
-    path.join('ui', 'pages', indexFileName),
+    path.join('ui', 'src/pages', indexFileName),
     customNextIndex,
     'utf8'
   );

--- a/src/lib/project.js
+++ b/src/lib/project.js
@@ -487,12 +487,12 @@ async function scaffoldNext(projectName) {
   );
 
   sh.mv(
-    path.join('ui', 'pages', '_app.tsx'),
-    path.join('ui', 'pages', '_app.page.tsx')
+    path.join('ui', 'src/pages', '_app.tsx'),
+    path.join('ui', 'src/pages', '_app.page.tsx')
   );
   sh.mv(
-    path.join('ui', 'pages', 'index.tsx'),
-    path.join('ui', 'pages', 'index.page.tsx')
+    path.join('ui', 'src/pages', 'index.tsx'),
+    path.join('ui', 'src/pages', 'index.page.tsx')
   );
 
   const tsconfig = `

--- a/src/lib/ui/next/customNextIndex.js
+++ b/src/lib/ui/next/customNextIndex.js
@@ -3,7 +3,7 @@ import Head from 'next/head';
 import Image from 'next/image';
 import styles from '../styles/Home.module.css';
 import { useEffect, useState } from 'react';
-import type { Add } from '../../contracts/src/';
+import type { Add } from '../../../contracts/src/';
 import {
   Mina,
   isReady,
@@ -15,7 +15,7 @@ export default function Home() {
   useEffect(() => {
     (async () => {
       await isReady;
-      const { Add } = await import('../../contracts/build/src/');
+      const { Add } = await import('../../../contracts/build/src/');
 
       // Update this to use the address (public key) for your zkApp account
       // To try it out, you can try this address for an example "Add" smart contract that we've deployed to 


### PR DESCRIPTION
**Description** 

fixes #372 

**Background**

The UI scaffold fails when a user runs `zk project someproj --ui next` and selects yes when prompted to add a src directory. 

```
Would you like to use `src/` directory with this project? … No / Yes
```

This option was recently added to `create-next-app`. The error occurred because the scaffold expects a pages directory at the root of the UI project. 

**Solution** 

This was resolved by passing a flag to `create-next-app` to add a src directory as a [default](https://nextjs.org/docs/advanced-features/src-directory). The `pages` paths in the scaffold were updated to include src as well as the contract imports.
