### PR TITLE
 Add UI scaffold interactive flow and fix NextJS Github Pages scaffold

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zkapp-cli",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "zkapp-cli",
-      "version": "0.7.4",
+      "version": "0.7.5",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zkapp-cli",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "description": "CLI to create a zkApp (\"zero-knowledge app\") for Mina Protocol.",
   "keywords": [
     "cli",

--- a/src/bin/index.js
+++ b/src/bin/index.js
@@ -48,7 +48,7 @@ yargs(hideBin(process.argv))
         demand: false,
         string: true,
         hidden: false,
-        choices: ['svelte', 'next', 'nuxt', 'empty', 'none'],
+        choices: ['next', 'svelte', 'nuxt', 'empty', 'none'],
         description: 'Creates an accompanying UI',
       },
     },

--- a/src/bin/index.js
+++ b/src/bin/index.js
@@ -48,7 +48,6 @@ yargs(hideBin(process.argv))
         demand: false,
         string: true,
         hidden: false,
-        default: 'none',
         choices: ['svelte', 'next', 'nuxt', 'empty', 'none'],
         description: 'Creates an accompanying UI',
       },

--- a/src/lib/project.js
+++ b/src/lib/project.js
@@ -595,7 +595,7 @@ async function scaffoldNext(projectName) {
     sh.cd('..');
 
     let apptsx = fs.readFileSync(
-      path.join('ui', 'pages', '_app.page.tsx'),
+      path.join('ui', 'src', '/pages', '_app.page.tsx'),
       'utf8'
     );
     apptsx = apptsx.replace(
@@ -604,10 +604,10 @@ async function scaffoldNext(projectName) {
 
 export default function`
     );
-    fs.writeFileSync(path.join('ui', 'pages', '_app.page.tsx'), apptsx);
+    fs.writeFileSync(path.join('ui', 'src', 'pages', '_app.page.tsx'), apptsx);
 
     fs.writeFileSync(
-      path.join('ui', 'pages', 'reactCOIServiceWorker.tsx'),
+      path.join('ui', 'src', 'pages', 'reactCOIServiceWorker.tsx'),
       `
 export {}
 

--- a/src/lib/project.js
+++ b/src/lib/project.js
@@ -41,7 +41,7 @@ async function project({ name, ui }) {
       res = await prompt({
         type: 'select',
         name: 'ui',
-        choices: ['svelte', 'next', 'nuxt', 'empty', 'none'],
+        choices: ['next', 'svelte', 'nuxt', 'empty', 'none'],
         message: (state) =>
           message(state, 'Create an accompanying UI project too?'),
         prefix: (state) => prefix(state),
@@ -423,7 +423,9 @@ async function scaffoldNext(projectName) {
     // If ctrl+c is pressed it will throw.
     return;
   }
-
+  console.log(
+    ' Choose no to use experimental `app/` directory with this project'
+  );
   // set the project name and default flags
   // https://nextjs.org/docs/api-reference/create-next-app#options
   let args = [

--- a/src/lib/project.js
+++ b/src/lib/project.js
@@ -597,7 +597,7 @@ async function scaffoldNext(projectName) {
     sh.cd('..');
 
     let apptsx = fs.readFileSync(
-      path.join('ui', 'src', '/pages', '_app.page.tsx'),
+      path.join('ui', 'src', 'pages', '_app.page.tsx'),
       'utf8'
     );
     apptsx = apptsx.replace(


### PR DESCRIPTION
Description

fixes #380 #381  

**Background**

The ui scaffolding fails for NextJS if you check yes for `Do you want to setup your project for deployment to Github Pages?`. This was blocking people from completing tutorial 4.

**Solution**

This was resolved by updating the the ui file paths in the scaffold when the option to deploy to github pages is selected. 

An interactive flow was also added as a default to guide a user to add an accompanying ui project after entering `zk project <project-name>`. 

```
? Create an accompanying UI project too? …
❯ next
  svelte
  nuxt
  empty
  none
```