### PR TITLE
Update UI scaffolds and bump cli to 0.7.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zkapp-cli",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "zkapp-cli",
-      "version": "0.7.5",
+      "version": "0.7.6",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zkapp-cli",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "description": "CLI to create a zkApp (\"zero-knowledge app\") for Mina Protocol.",
   "keywords": [
     "cli",

--- a/src/lib/ui/next/customNextIndex.js
+++ b/src/lib/ui/next/customNextIndex.js
@@ -8,9 +8,7 @@ import styles from '../styles/Home.module.css';
 export default function Home() {
   useEffect(() => {
     (async () => {
-      const { Mina, isReady, PublicKey, fetchAccount } = await import(
-        'snarkyjs'
-      );
+      const { Mina, isReady, PublicKey } = await import('snarkyjs');
       const { Add } = await import('../../../contracts/build/src/');
 
       await isReady;
@@ -60,7 +58,7 @@ export default function Home() {
           </div>
           <p className={styles.start}>
             Get started by editing
-            <code className={styles.code}> src/routes/+page.svelte</code>
+            <code className={styles.code}> src/pages/index.tsx</code>
           </p>
           <div className={styles.grid}>
             <a


### PR DESCRIPTION
Description

This PR updates the `zkapp-cli`  with minor changes and bumps the cli version.

- Update the get started file path on the next landing page 
- Remove the possibility of prompting the user twice if they want to generate a typescript project.