### PR TITLE
fix: update file CLI help text

### DIFF
--- a/src/bin/index.js
+++ b/src/bin/index.js
@@ -56,7 +56,7 @@ yargs(hideBin(process.argv))
   )
   .command(
     ['file [name]', 'f [name]'],
-    'Create a new file & test',
+    'Create a file and the corresponding test file',
     { name: { demand: true, string: true, hidden: true } },
     (argv) => file(argv.name)
   )

--- a/src/bin/index.js
+++ b/src/bin/index.js
@@ -56,7 +56,7 @@ yargs(hideBin(process.argv))
   )
   .command(
     ['file [name]', 'f [name]'],
-    'Create a file and the corresponding test file',
+    'Create a file and generate the corresponding test file',
     { name: { demand: true, string: true, hidden: true } },
     (argv) => file(argv.name)
   )


### PR DESCRIPTION
As I begin my work with the zkApp CLI, I am seeing opportunities to improve the CLI help wording.

Less friction = more success


