### PR TITLE
CLI Release 0.8.0

### DIFF
--- a/examples/sudoku/ts/src/run.ts
+++ b/examples/sudoku/ts/src/run.ts
@@ -11,7 +11,7 @@
  */
 import { Sudoku, SudokuZkApp } from './sudoku.js';
 import { cloneSudoku, generateSudoku, solveSudoku } from './sudoku-lib.js';
-import { AccountUpdate, Mina, PrivateKey, shutdown } from 'snarkyjs';
+import { AccountUpdate, Mina, PrivateKey } from 'snarkyjs';
 
 // setup
 const Local = Mina.LocalBlockchain();
@@ -72,6 +72,3 @@ await tx.prove();
 await tx.sign([senderKey]).send();
 
 console.log('Is the sudoku solved?', zkApp.isSolved.get().toBoolean());
-
-// cleanup
-await shutdown();

--- a/examples/sudoku/ts/src/sudoku.test.ts
+++ b/examples/sudoku/ts/src/sudoku.test.ts
@@ -1,13 +1,6 @@
 import { Sudoku, SudokuZkApp } from './sudoku';
 import { cloneSudoku, generateSudoku, solveSudoku } from './sudoku-lib';
-import {
-  isReady,
-  shutdown,
-  PrivateKey,
-  PublicKey,
-  Mina,
-  AccountUpdate,
-} from 'snarkyjs';
+import { PrivateKey, PublicKey, Mina, AccountUpdate } from 'snarkyjs';
 
 describe('sudoku', () => {
   let zkApp: SudokuZkApp,
@@ -18,7 +11,6 @@ describe('sudoku', () => {
     senderKey: PrivateKey;
 
   beforeEach(async () => {
-    await isReady;
     let Local = Mina.LocalBlockchain({ proofsEnabled: false });
     Mina.setActiveInstance(Local);
     sender = Local.testAccounts[0].publicKey;
@@ -27,10 +19,6 @@ describe('sudoku', () => {
     zkAppAddress = zkAppPrivateKey.toPublicKey();
     zkApp = new SudokuZkApp(zkAppAddress);
     sudoku = generateSudoku(0.5);
-  });
-
-  afterAll(() => {
-    setTimeout(shutdown, 0);
   });
 
   it('accepts a correct solution', async () => {

--- a/examples/sudoku/ts/src/sudoku.ts
+++ b/examples/sudoku/ts/src/sudoku.ts
@@ -5,15 +5,12 @@ import {
   Bool,
   state,
   State,
-  isReady,
   Poseidon,
   Struct,
   Circuit,
 } from 'snarkyjs';
 
 export { Sudoku, SudokuZkApp };
-
-await isReady;
 
 class Sudoku extends Struct({
   value: Circuit.array(Circuit.array(Field, 9), 9),

--- a/examples/sudoku/ts/src/sudoku.ts
+++ b/examples/sudoku/ts/src/sudoku.ts
@@ -94,8 +94,8 @@ class SudokuZkApp extends SmartContract {
     }
 
     // finally, we check that the sudoku is the one that was originally deployed
-    let sudokuHash = this.sudokuHash.get(); // get the hash from the blockchain
-    this.sudokuHash.assertEquals(sudokuHash); // precondition that links this.sudokuHash.get() to the actual on-chain state
+    let sudokuHash = this.sudokuHash.getAndAssertEquals();
+
     sudokuInstance
       .hash()
       .assertEquals(sudokuHash, 'sudoku matches the one committed on-chain');

--- a/examples/tictactoe/ts/src/run.ts
+++ b/examples/tictactoe/ts/src/run.ts
@@ -15,14 +15,11 @@ import {
   PrivateKey,
   PublicKey,
   Mina,
-  shutdown,
-  isReady,
   AccountUpdate,
   Signature,
 } from 'snarkyjs';
 import { TicTacToe, Board } from './tictactoe.js';
 
-await isReady;
 let Local = Mina.LocalBlockchain({ proofsEnabled: false });
 Mina.setActiveInstance(Local);
 const [
@@ -108,7 +105,6 @@ let isNextPlayer2 = zkApp.nextIsPlayer2.get();
 
 console.log('did someone win?', isNextPlayer2 ? 'Player 1!' : 'Player 2!');
 // cleanup
-await shutdown();
 
 async function makeMove(
   currentPlayer: PublicKey,

--- a/examples/tictactoe/ts/src/tictactoe.test.ts
+++ b/examples/tictactoe/ts/src/tictactoe.test.ts
@@ -1,7 +1,5 @@
 import { TicTacToe } from './tictactoe';
 import {
-  isReady,
-  shutdown,
   Field,
   Bool,
   PrivateKey,
@@ -19,17 +17,12 @@ describe('tictactoe', () => {
     zkAppPrivateKey: PrivateKey;
 
   beforeEach(async () => {
-    await isReady;
     let Local = Mina.LocalBlockchain({ proofsEnabled: false });
     Mina.setActiveInstance(Local);
     [{ publicKey: player1, privateKey: player1Key }, { publicKey: player2 }] =
       Local.testAccounts;
     zkAppPrivateKey = PrivateKey.random();
     zkAppAddress = zkAppPrivateKey.toPublicKey();
-  });
-
-  afterAll(() => {
-    setTimeout(shutdown, 0);
   });
 
   it('generates and deploys tictactoe', async () => {

--- a/examples/tictactoe/ts/src/tictactoe.ts
+++ b/examples/tictactoe/ts/src/tictactoe.ts
@@ -182,10 +182,8 @@ class TicTacToe extends SmartContract {
     signature.verify(pubkey, [x, y]).assertTrue();
 
     // ensure player is valid
-    const player1 = this.player1.get();
-    this.player1.assertEquals(player1);
-    const player2 = this.player2.get();
-    this.player2.assertEquals(player2);
+    const player1 = this.player1.getAndAssertEquals();
+    const player2 = this.player2.getAndAssertEquals();
     Bool.or(pubkey.equals(player1), pubkey.equals(player2)).assertTrue();
 
     // 3. Make sure that its our turn,
@@ -195,8 +193,7 @@ class TicTacToe extends SmartContract {
     const player = pubkey.equals(player2); // player 1 is false, player 2 is true
 
     // ensure its their turn
-    const nextPlayer = this.nextIsPlayer2.get();
-    this.nextIsPlayer2.assertEquals(nextPlayer); // precondition that links this.nextIsPlayer2.get() to the actual on-chain state
+    const nextPlayer = this.nextIsPlayer2.getAndAssertEquals();
     nextPlayer.assertEquals(player);
 
     // set the next player

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,6 @@
     "": {
       "name": "zkapp-cli",
       "version": "0.7.6",
-      "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
         "chalk": "^4.1.2",
@@ -20,7 +19,7 @@
         "mina-signer": "^1.1.0",
         "ora": "^5.4.1",
         "shelljs": "^0.8.5",
-        "snarkyjs": "0.9.*",
+        "snarkyjs": "0.10.*",
         "table": "^6.8.0",
         "yargs": "^17.5.1"
       },
@@ -2257,14 +2256,6 @@
       },
       "engines": {
         "node": ">=8.6"
-      }
-    },
-    "node_modules/env": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/env/-/env-0.0.2.tgz",
-      "integrity": "sha512-yP8LfjO4ughSHD/3HgLPinWzexmaOGvRfs2TFx0SZhOm7j1xPi9evjuGcLiNVHIGLmcsgMak4eDbBzlYqGIVxw==",
-      "engines": {
-        "node": ">= 0.5.9"
       }
     },
     "node_modules/envinfo": {
@@ -5310,13 +5301,12 @@
       }
     },
     "node_modules/snarkyjs": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/snarkyjs/-/snarkyjs-0.9.2.tgz",
-      "integrity": "sha512-exqHTSQMSlvdrTQ9lnqOtgOO93W2GVyTQnyWfz4qplQhhVhQGZaJrDVPbaygEdYB9cy1+2QESA9pCp1UGBuTRg==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/snarkyjs/-/snarkyjs-0.10.0.tgz",
+      "integrity": "sha512-YFvMMUUfcStBrIkDVUhg6lgV7FYZ1y+FX6pRysHlSomytCJ8/QeapTXkF/4oQGNiFemgbTLdr6E/wzsdtoLfyg==",
       "dependencies": {
         "blakejs": "1.2.1",
         "detect-gpu": "^5.0.5",
-        "env": "^0.0.2",
         "isomorphic-fetch": "^3.0.0",
         "js-sha256": "^0.9.0",
         "reflect-metadata": "^0.1.13",
@@ -7768,11 +7758,6 @@
         "ansi-colors": "^4.1.1"
       }
     },
-    "env": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/env/-/env-0.0.2.tgz",
-      "integrity": "sha512-yP8LfjO4ughSHD/3HgLPinWzexmaOGvRfs2TFx0SZhOm7j1xPi9evjuGcLiNVHIGLmcsgMak4eDbBzlYqGIVxw=="
-    },
     "envinfo": {
       "version": "7.8.1",
       "resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.8.1.tgz",
@@ -10042,13 +10027,12 @@
       }
     },
     "snarkyjs": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/snarkyjs/-/snarkyjs-0.9.2.tgz",
-      "integrity": "sha512-exqHTSQMSlvdrTQ9lnqOtgOO93W2GVyTQnyWfz4qplQhhVhQGZaJrDVPbaygEdYB9cy1+2QESA9pCp1UGBuTRg==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/snarkyjs/-/snarkyjs-0.10.0.tgz",
+      "integrity": "sha512-YFvMMUUfcStBrIkDVUhg6lgV7FYZ1y+FX6pRysHlSomytCJ8/QeapTXkF/4oQGNiFemgbTLdr6E/wzsdtoLfyg==",
       "requires": {
         "blakejs": "1.2.1",
         "detect-gpu": "^5.0.5",
-        "env": "^0.0.2",
         "isomorphic-fetch": "^3.0.0",
         "js-sha256": "^0.9.0",
         "reflect-metadata": "^0.1.13",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zkapp-cli",
-  "version": "0.7.6",
+  "version": "0.8.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "zkapp-cli",
-      "version": "0.7.6",
+      "version": "0.8.0",
       "license": "Apache-2.0",
       "dependencies": {
         "chalk": "^4.1.2",
@@ -4184,9 +4184,9 @@
       "dev": true
     },
     "node_modules/json5": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-      "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "dev": true,
       "bin": {
         "json5": "lib/cli.js"
@@ -9203,9 +9203,9 @@
       "dev": true
     },
     "json5": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-      "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "dev": true
     },
     "jsonfile": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zkapp-cli",
-  "version": "0.7.6",
+  "version": "0.8.0",
   "description": "CLI to create a zkApp (\"zero-knowledge app\") for Mina Protocol.",
   "keywords": [
     "cli",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "lint-staged": {
     "**/*": [
-      "eslint -c .eslintrc.js src/* --fix",
+      "eslint -c .eslintrc.js src/** --fix",
       "prettier --write --ignore-unknown"
     ]
   },
@@ -44,7 +44,7 @@
     "mina-signer": "^1.1.0",
     "ora": "^5.4.1",
     "shelljs": "^0.8.5",
-    "snarkyjs": "0.9.*",
+    "snarkyjs": "0.10.*",
     "table": "^6.8.0",
     "yargs": "^17.5.1"
   },

--- a/src/lib/deploy.js
+++ b/src/lib/deploy.js
@@ -463,6 +463,7 @@ async function deploy({ alias, yes }) {
     `\n  ${getTxnUrl(graphQLUrl, txn)}`;
 
   log(green(str));
+  process.exit(0);
 }
 
 // Get the desired blockchain explorer url with txn hash

--- a/src/lib/deploy.js
+++ b/src/lib/deploy.js
@@ -100,6 +100,8 @@ async function deploy({ alias, yes }) {
       )
     );
     log(red(`Please correct your config.json and try again.`));
+
+    process.exit(1);
     return;
   }
 
@@ -222,6 +224,7 @@ async function deploy({ alias, yes }) {
       )
     );
 
+    process.exit(1);
     return;
   }
 
@@ -245,6 +248,7 @@ async function deploy({ alias, yes }) {
       )
     );
 
+    process.exit(1);
     return;
   }
 
@@ -257,6 +261,7 @@ async function deploy({ alias, yes }) {
       )
     );
 
+    process.exit(1);
     return;
   }
 
@@ -271,6 +276,7 @@ async function deploy({ alias, yes }) {
       )
     );
 
+    process.exit(1);
     return;
   }
 
@@ -328,6 +334,7 @@ async function deploy({ alias, yes }) {
       )
     );
 
+    process.exit(1);
     return;
   }
   fee = `${Number(fee) * 1e9}`; // in nanomina (1 billion = 1.0 mina)
@@ -344,6 +351,7 @@ async function deploy({ alias, yes }) {
       )
     );
 
+    process.exit(1);
     return;
   }
 
@@ -450,7 +458,7 @@ async function deploy({ alias, yes }) {
   if (!txn || txn?.kind === 'error') {
     // Note that the thrown error object is already console logged via step().
     log(red(getErrorMessage(txn)));
-
+    process.exit(1);
     return;
   }
 

--- a/src/lib/deploy.js
+++ b/src/lib/deploy.js
@@ -196,9 +196,7 @@ async function deploy({ alias, yes }) {
   if (process.platform === 'win32') {
     snarkyjsImportPath = 'file://' + snarkyjsImportPath;
   }
-  let { isReady, shutdown, PrivateKey, Mina, Bool } = await import(
-    snarkyjsImportPath
-  );
+  let { PrivateKey, Mina, Bool } = await import(snarkyjsImportPath);
 
   const graphQLUrl = config.deployAliases[alias]?.url ?? DEFAULT_GRAPHQL;
 
@@ -215,7 +213,7 @@ async function deploy({ alias, yes }) {
         `  Transaction relayer node is offline. Please try again or use a different "url" for this deploy alias in your config.json`
       )
     );
-    await shutdown();
+
     return;
   } else if (nodeStatus.syncStatus !== 'SYNCED') {
     log(
@@ -223,7 +221,7 @@ async function deploy({ alias, yes }) {
         `  Transaction relayer node is not in a synced state. Its status is "${nodeStatus.syncStatus}".\n  Please try again when the node is synced or use a different "url" for this deploy alias in your config.json`
       )
     );
-    await shutdown();
+
     return;
   }
 
@@ -246,7 +244,7 @@ async function deploy({ alias, yes }) {
         `  Failed to find the "${contractName}" smart contract in your build directory.\n  Please confirm that your config.json contains the name of the smart contract that you desire to deploy to this deploy alias.`
       )
     );
-    await shutdown();
+
     return;
   }
 
@@ -258,7 +256,7 @@ async function deploy({ alias, yes }) {
         `  Failed to find the "${contractName}" smart contract in your build directory.\n  Check that you have exported your smart contract class using a named export and try again.`
       )
     );
-    await shutdown();
+
     return;
   }
 
@@ -272,11 +270,9 @@ async function deploy({ alias, yes }) {
         `  Failed to find the zkApp private key.\n  Please make sure your config.json has the correct 'keyPath' property.`
       )
     );
-    await shutdown();
+
     return;
   }
-
-  await isReady;
 
   let zkApp = smartContractImports[contractName]; //  The specified zkApp class to deploy
   let zkAppPrivateKey = PrivateKey.fromBase58(privateKey); //  The private key of the zkApp
@@ -331,7 +327,7 @@ async function deploy({ alias, yes }) {
         `  The "fee" property is not specified for this deploy alias in config.json. Please update your config.json and try again.`
       )
     );
-    await shutdown();
+
     return;
   }
   fee = `${Number(fee) * 1e9}`; // in nanomina (1 billion = 1.0 mina)
@@ -347,7 +343,7 @@ async function deploy({ alias, yes }) {
         `  Failed to find the fee payer's account on chain.\n  Please make sure the account "${zkAppAddressBase58}" has previously been funded.`
       )
     );
-    await shutdown();
+
     return;
   }
 
@@ -454,7 +450,7 @@ async function deploy({ alias, yes }) {
   if (!txn || txn?.kind === 'error') {
     // Note that the thrown error object is already console logged via step().
     log(red(getErrorMessage(txn)));
-    await shutdown();
+
     return;
   }
 
@@ -467,7 +463,6 @@ async function deploy({ alias, yes }) {
     `\n  ${getTxnUrl(graphQLUrl, txn)}`;
 
   log(green(str));
-  await shutdown();
 }
 
 // Get the desired blockchain explorer url with txn hash

--- a/src/lib/example.js
+++ b/src/lib/example.js
@@ -92,6 +92,7 @@ async function example(example) {
     `\n  npm run start`;
 
   console.log(_green(str));
+  process.exit(0);
 }
 
 /**

--- a/src/lib/file.test.js
+++ b/src/lib/file.test.js
@@ -1,5 +1,5 @@
 const path = require('path');
-const { file, parsePath, pathExists } = require('./file');
+const { parsePath } = require('./file');
 
 describe('file.js', () => {
   describe('file()', () => {

--- a/src/lib/project.js
+++ b/src/lib/project.js
@@ -187,7 +187,8 @@ async function fetchProjectTemplate() {
   const spin = ora({ text: `${step}...`, discardStdin: true }).start();
 
   try {
-    const src = 'github:o1-labs/zkapp-cli#main';
+    const src = 'github:o1-labs/zkapp-cli#release-0.7.7';
+    // const src = 'github:o1-labs/zkapp-cli#main';
     await gittar.fetch(src, { force: true });
 
     // Note: Extract will overwrite any existing dir's contents. Ensure
@@ -453,8 +454,9 @@ async function scaffoldNext(projectName) {
   webpack(config) {
     config.resolve.alias = {
       ...config.resolve.alias,
-      snarkyjs: require('path').resolve('node_modules/snarkyjs'),
-    }
+      snarkyjs: require('path').resolve('node_modules/snarkyjs')
+    };
+    config.experiments = { ...config.experiments, topLevelAwait: true };
     return config;
   },
   // To enable SnarkyJS for the web, we must set the COOP and COEP headers.

--- a/src/lib/project.js
+++ b/src/lib/project.js
@@ -704,8 +704,8 @@ function scaffoldNuxt() {
   export default defineNuxtConfig({
     
     vite: {
-      build: { target: "es2020" },
-      optimizeDeps: { esbuildOptions: { target: "es2020" } },
+      build: { target: "esnext" },
+      optimizeDeps: { esbuildOptions: { target: "esnext" } },
     },
 
     css: ['~/assets/styles/globals.css']

--- a/src/lib/project.js
+++ b/src/lib/project.js
@@ -187,8 +187,7 @@ async function fetchProjectTemplate() {
   const spin = ora({ text: `${step}...`, discardStdin: true }).start();
 
   try {
-    const src = 'github:o1-labs/zkapp-cli#release-0.7.7';
-    // const src = 'github:o1-labs/zkapp-cli#main';
+    const src = 'github:o1-labs/zkapp-cli#main';
     await gittar.fetch(src, { force: true });
 
     // Note: Extract will overwrite any existing dir's contents. Ensure
@@ -345,7 +344,7 @@ function scaffoldSvelte() {
   const customViteConfig = vitConfig.replace(
     /^}(.*?)$/gm, // Search for the last '}' in the file.
     `,
-    optimizeDeps: { esbuildOptions: { target: 'es2020' } }
+    optimizeDeps: { esbuildOptions: { target: 'esnext' } }
   });`
   );
 

--- a/src/lib/system.test.js
+++ b/src/lib/system.test.js
@@ -1,5 +1,3 @@
-const { system } = require('./system');
-
 describe('system.js', () => {
   describe('system()', () => {
     it.todo('should be correct');

--- a/src/lib/ui/next/customNextIndex.js
+++ b/src/lib/ui/next/customNextIndex.js
@@ -8,10 +8,8 @@ import styles from '../styles/Home.module.css';
 export default function Home() {
   useEffect(() => {
     (async () => {
-      const { Mina, isReady, PublicKey } = await import('snarkyjs');
+      const { Mina, PublicKey } = await import('snarkyjs');
       const { Add } = await import('../../../contracts/build/src/');
-
-      await isReady;
 
       // Update this to use the address (public key) for your zkApp account.
       // To try it out, you can try this address for an example "Add" smart contract that we've deployed to

--- a/src/lib/ui/nuxt/customNuxtIndex.js
+++ b/src/lib/ui/nuxt/customNuxtIndex.js
@@ -121,10 +121,9 @@ import GradientBG from '~/components/GradientBG.vue'
 export default {
   setup() {
     onMounted(async () => {
-      const { Mina, isReady, PublicKey } = await import('snarkyjs')
+      const { Mina, PublicKey } = await import('snarkyjs')
       const { Add } = await import('../../contracts/build/src/')
 
-      await isReady
       // Update this to use the address (public key) for your zkApp account.
       // To try it out, you can try this address for an example "Add" smart contract that we've deployed to
       // Berkeley Testnet B62qkwohsqTBPsvhYE8cPZSpzJMgoKn4i1LQRuBAtVXWpaT4dgH6WoA.

--- a/src/lib/ui/nuxt/headers.js
+++ b/src/lib/ui/nuxt/headers.js
@@ -1,8 +1,7 @@
+/* eslint-disable no-undef */
 // To enable SnarkyJS for the web, we must set the COOP and COEP headers.
 // See here for more information: https://docs.minaprotocol.com/zkapps/how-to-write-a-zkapp-ui#enabling-coop-and-coep-headers
-const defineEventHandler = ({ node: { res } }) => {
+export default defineEventHandler(({ node: { res } }) => {
   res.setHeader('Cross-Origin-Embedder-Policy', 'require-corp');
   res.setHeader('Cross-Origin-Opener-Policy', 'same-origin');
-};
-
-export default defineEventHandler;
+});

--- a/src/lib/ui/nuxt/headers.js
+++ b/src/lib/ui/nuxt/headers.js
@@ -1,6 +1,8 @@
 // To enable SnarkyJS for the web, we must set the COOP and COEP headers.
 // See here for more information: https://docs.minaprotocol.com/zkapps/how-to-write-a-zkapp-ui#enabling-coop-and-coep-headers
-export default defineEventHandler(({ node: { req, res } }) => {
+const defineEventHandler = ({ node: { res } }) => {
   res.setHeader('Cross-Origin-Embedder-Policy', 'require-corp');
   res.setHeader('Cross-Origin-Opener-Policy', 'same-origin');
-});
+};
+
+export default defineEventHandler;

--- a/templates/project-ts/jest.config.js
+++ b/templates/project-ts/jest.config.js
@@ -7,8 +7,8 @@ export default {
     'ts-jest': {
       useESM: true,
     },
-    testTimeout: 1_000_000,
   },
+  testTimeout: 1_000_000,
   transform: {
     '^.+\\.(t)s$': 'ts-jest',
     '^.+\\.(j)s$': 'babel-jest',

--- a/templates/project-ts/jest.config.js
+++ b/templates/project-ts/jest.config.js
@@ -7,6 +7,7 @@ export default {
     'ts-jest': {
       useESM: true,
     },
+    testTimeout: 1_000_000,
   },
   transform: {
     '^.+\\.(t)s$': 'ts-jest',

--- a/templates/project-ts/package.json
+++ b/templates/project-ts/package.json
@@ -45,6 +45,6 @@
     "typescript": "^4.7.2"
   },
   "peerDependencies": {
-    "snarkyjs": "0.9.*"
+    "snarkyjs": "0.10.*"
   }
 }

--- a/templates/project-ts/src/Add.test.ts
+++ b/templates/project-ts/src/Add.test.ts
@@ -20,7 +20,7 @@ describe('Add', () => {
     zkApp: Add;
 
   beforeAll(async () => {
-    await Add.compile();
+    if (proofsEnabled) await Add.compile();
   });
 
   beforeEach(() => {

--- a/templates/project-ts/src/Add.test.ts
+++ b/templates/project-ts/src/Add.test.ts
@@ -20,7 +20,7 @@ describe('Add', () => {
     zkApp: Add;
 
   beforeAll(async () => {
-    if (proofsEnabled) Add.compile();
+    await Add.compile();
   });
 
   beforeEach(() => {

--- a/templates/project-ts/src/Add.test.ts
+++ b/templates/project-ts/src/Add.test.ts
@@ -1,13 +1,5 @@
 import { Add } from './Add';
-import {
-  isReady,
-  shutdown,
-  Field,
-  Mina,
-  PrivateKey,
-  PublicKey,
-  AccountUpdate,
-} from 'snarkyjs';
+import { Field, Mina, PrivateKey, PublicKey, AccountUpdate } from 'snarkyjs';
 
 /*
  * This file specifies how to test the `Add` example smart contract. It is safe to delete this file and replace
@@ -28,7 +20,6 @@ describe('Add', () => {
     zkApp: Add;
 
   beforeAll(async () => {
-    await isReady;
     if (proofsEnabled) Add.compile();
   });
 
@@ -42,13 +33,6 @@ describe('Add', () => {
     zkAppPrivateKey = PrivateKey.random();
     zkAppAddress = zkAppPrivateKey.toPublicKey();
     zkApp = new Add(zkAppAddress);
-  });
-
-  afterAll(() => {
-    // `shutdown()` internally calls `process.exit()` which will exit the running Jest process early.
-    // Specifying a timeout of 0 is a workaround to defer `shutdown()` until Jest is done running all tests.
-    // This should be fixed with https://github.com/MinaProtocol/mina/issues/10943
-    setTimeout(shutdown, 0);
   });
 
   async function localDeploy() {

--- a/templates/project-ts/src/Add.ts
+++ b/templates/project-ts/src/Add.ts
@@ -18,8 +18,7 @@ export class Add extends SmartContract {
   }
 
   @method update() {
-    const currentState = this.num.get();
-    this.num.assertEquals(currentState); // precondition that links this.num.get() to the actual on-chain state
+    const currentState = this.num.getAndAssertEquals();
     const newState = currentState.add(2);
     this.num.set(newState);
   }

--- a/templates/project-ts/src/interact.ts
+++ b/templates/project-ts/src/interact.ts
@@ -12,7 +12,7 @@
  * Build the project: `$ npm run build`
  * Run with node:     `$ node build/src/interact.js <network>`.
  */
-import { Mina, PrivateKey, shutdown } from 'snarkyjs';
+import { Mina, PrivateKey } from 'snarkyjs';
 import fs from 'fs/promises';
 import { Add } from './Add.js';
 
@@ -30,7 +30,9 @@ node build/src/interact.js berkeley
 Error.stackTraceLimit = 1000;
 
 // parse config and private key from file
-type Config = { deployAliases: Record<string, { url: string; keyPath: string }> };
+type Config = {
+  deployAliases: Record<string, { url: string; keyPath: string }>;
+};
 let configJson: Config = JSON.parse(await fs.readFile('config.json', 'utf8'));
 let config = configJson.deployAliases[network];
 let key: { privateKey: string } = JSON.parse(
@@ -66,4 +68,3 @@ as soon as the transaction is included in a block:
 https://berkeley.minaexplorer.com/transaction/${sentTx.hash()}
 `);
 }
-shutdown();


### PR DESCRIPTION
This PR is the corresponding zkApp cli  release to [this](https://github.com/o1-labs/snarkyjs/pull/872) SnarkyJS PR release of version `0.10.0`.

- SnarkyJS minor version dependency updated in cli package.json to `0.10.*`.
- SnarkyJS minor version peer dependency updated in template/example contract package.json to `0.10.*`.
- Remove deprecated `isReady` and `shutdown` from cli, template/examples contracts, and UI scaffolds for each supported framework. 
- Configure UI scaffolds for `NextJS`, `Svelte,` and `Nuxt` to support top-level await used in the latest SnarkyJS release.
- Exit the cli config and deploy processes on success and error.
- Add `state.getAndAssertEquals()` to examples and test contracts. 
- Increase the template/example project jest test timeout.

**Tested**

This was tested by generating projects with various cli flows including the ui scaffolds. The template `add` contract was successfully deployed and can be viewed on [minaexplorer](https://berkeley.minaexplorer.com/transaction/5Ju4cKtUNwr2wQvN1xYmqM5Ngko4GVS7jjz4UFjNNtSPaDyBs5W5)  .