### PR TITLE
Update Next UI scaffold defaults

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zkapp-cli",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "zkapp-cli",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "license": "Apache-2.0",
       "dependencies": {
         "chalk": "^4.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zkapp-cli",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "CLI to create a zkApp (\"zero-knowledge app\") for Mina Protocol.",
   "keywords": [
     "cli",

--- a/src/lib/project.js
+++ b/src/lib/project.js
@@ -423,6 +423,7 @@ async function scaffoldNext(projectName) {
     '--use-npm',
     '--src-dir',
     '--import-alias "@/*"',
+    '--no-app',
   ];
 
   spawnSync('npx', args, {

--- a/src/lib/project.js
+++ b/src/lib/project.js
@@ -412,9 +412,7 @@ async function scaffoldNext(projectName) {
     // If ctrl+c is pressed it will throw.
     return;
   }
-  console.log(
-    ' Choose no to use experimental `app/` directory with this project'
-  );
+
   // set the project name and default flags
   // https://nextjs.org/docs/api-reference/create-next-app#options
   let args = [

--- a/src/lib/project.js
+++ b/src/lib/project.js
@@ -418,7 +418,7 @@ async function scaffoldNext(projectName) {
   // set the project name and default flags
   // https://nextjs.org/docs/api-reference/create-next-app#options
   let args = [
-    'create-next-app@latest',
+    'create-next-app@13.4.1',
     'ui',
     '--use-npm',
     '--src-dir',


### PR DESCRIPTION
Fixes #401 

The cli ui scaffold currently does not support using the new NextJs [App Router](https://nextjs.org/docs/app). The scaffold fails if a user selects yes to the prompt to use the App Router. 

This PR adds a flag to select no to using the App Router as a default. The `create-next-app` version is also locked to the current version `13.4.1` to avoid  future breaking changes to the scaffold. A [seperate issue](https://github.com/o1-labs/zkapp-cli/issues/400) was created to add support to use the App Router. 