### PR TITLE
Clean up deploy and log full errors to the console

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zkapp-cli",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "zkapp-cli",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "license": "Apache-2.0",
       "dependencies": {
         "chalk": "^4.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zkapp-cli",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "CLI to create a zkApp (\"zero-knowledge app\") for Mina Protocol.",
   "keywords": [
     "cli",

--- a/src/lib/deploy.js
+++ b/src/lib/deploy.js
@@ -198,7 +198,7 @@ async function deploy({ alias, yes }) {
   if (process.platform === 'win32') {
     snarkyjsImportPath = 'file://' + snarkyjsImportPath;
   }
-  let { PrivateKey, Mina, Bool } = await import(snarkyjsImportPath);
+  let { PrivateKey, Mina } = await import(snarkyjsImportPath);
 
   const graphQLUrl = config.deployAliases[alias]?.url ?? DEFAULT_GRAPHQL;
 
@@ -268,7 +268,9 @@ async function deploy({ alias, yes }) {
   // Attempt to import the private key from the `keys` directory. This private key will be used to deploy the zkApp.
   let privateKey;
   try {
-    privateKey = fs.readJSONSync(`${DIR}/${config.deployAliases[alias].keyPath}`).privateKey;
+    privateKey = fs.readJSONSync(
+      `${DIR}/${config.deployAliases[alias].keyPath}`
+    ).privateKey;
   } catch (_) {
     log(
       red(
@@ -360,14 +362,7 @@ async function deploy({ alias, yes }) {
     Mina.setActiveInstance(Network);
     let tx = await Mina.transaction({ sender: zkAppAddress, fee }, () => {
       let zkapp = new zkApp(zkAppAddress);
-      zkapp.deploy({ verificationKey, zkappKey: zkAppPrivateKey });
-      // manually patch the tx (TODO: have this implemented properly in snarkyjs)
-      // remove the nonce precondition
-      zkapp.self.body.preconditions.account.nonce.isSome = Bool(false);
-      // don't increment the nonce
-      zkapp.self.body.incrementNonce = Bool(false);
-      // use full commitment (means with include the fee payer in the signature, so we're protected against replays)
-      zkapp.self.body.useFullCommitment = Bool(true);
+      zkapp.deploy({ verificationKey });
     });
     return { tx, json: tx.sign([zkAppPrivateKey]).toJSON() };
   });

--- a/src/lib/helpers.js
+++ b/src/lib/helpers.js
@@ -19,6 +19,7 @@ async function step(str, fn) {
   } catch (err) {
     spin.fail(str);
     console.error('  ' + red(err)); // maintain expected indentation
+    console.log(err);
     process.exit(1);
   }
 }


### PR DESCRIPTION
fixes https://github.com/o1-labs/zkapp-cli/issues/406

* no longer use the `zkAppKey` argument of `deploy`, which was just a workaround for a missing precondition
  * a [snarkyjs PR](https://github.com/o1-labs/snarkyjs/pull/908) will remove this argument from snarkyjs, but we can stop using it independently
* remove other manual patching of `zkapp.deploy()` that is no longer necessary
* log full error trace to the console, so debugging CLI failures becomes less painful:
 
![image](https://github.com/o1-labs/zkapp-cli/assets/20989968/24b457b6-2a63-4fbf-bc8e-7e735664232c)
