### PR TITLE
Add Third Party Feepayer 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zkapp-cli",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "zkapp-cli",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "license": "Apache-2.0",
       "dependencies": {
         "chalk": "^4.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zkapp-cli",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "zkapp-cli",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "license": "Apache-2.0",
       "dependencies": {
         "chalk": "^4.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zkapp-cli",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "CLI to create a zkApp (\"zero-knowledge app\") for Mina Protocol.",
   "keywords": [
     "cli",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zkapp-cli",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "CLI to create a zkApp (\"zero-knowledge app\") for Mina Protocol.",
   "keywords": [
     "cli",

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -37,23 +37,11 @@ async function config() {
 
   let isFeepayerCached = false;
   let cachedFeePayerAlias;
+  let cachedFeepayerAliases;
   let cachedFeePayerAddress;
-  // Check if feepayer keys have previous been store on a users dir
+
   try {
-    let cachedfeepayerAliases = fs.readdirSync(
-      `${HOME_DIR}/.cache/zkapp-cli/keys/`
-    );
-
-    cachedfeepayerAliases = cachedfeepayerAliases
-      .filter((fileName) => fileName.includes('json'))
-      .map((name) => name.slice(0, -5));
-
-    // TODO: Add select prompt when multiple feepayors are cached
-    cachedFeePayerAlias = cachedfeepayerAliases[0];
-
-    cachedFeePayerAddress = fs.readJSONSync(
-      `${HOME_DIR}/.cache/zkapp-cli/keys/${cachedFeePayerAlias}.json`
-    ).publicKey;
+    cachedFeepayerAliases = getCachedFeePayerAlias(HOME_DIR);
     isFeepayerCached = true;
   } catch (err) {
     if (err.code !== 'ENOENT') {
@@ -301,6 +289,16 @@ async function config() {
     `\n  - To deploy, run: \`zk deploy ${deployAliasName}\``;
 
   log(green(str));
+}
+
+// Check if feepayer alias/aliases are stored on users machine and returns an array of them.
+function getCachedFeePayerAlias(directory) {
+  let aliases = fs.readdirSync(`${directory}/.cache/zkapp-cli/keys/`);
+
+  aliases = aliases
+    .filter((fileName) => fileName.includes('json'))
+    .map((name) => name.slice(0, -5));
+  return aliases;
 }
 
 function createKeyPair(network) {

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -118,90 +118,18 @@ async function config() {
     return state.cancelled ? red(state.symbols.cross) : state.symbols.check;
   }
 
-  const initialFeepayerPrompts = [
-    {
-      type: 'select',
-      name: 'feepayer',
-      choices: [
-        {
-          name: `Recover fee-payer account from an existing base58 private key`,
-          value: 'recover',
-        },
-        { name: 'Create a new feepayer key pair', value: 'create' },
-      ],
-      message: (state) => {
-        const style = state.submitted && !state.cancelled ? green : reset;
-        return style('Choose an account to pay transaction fees:');
-      },
-      result() {
-        return this.focused.value;
-      },
-      skip() {
-        return isFeepayerCached; // The prompt is only displayed if a feepayor has not been previously cached
-      },
-    },
-
-    {
-      type: 'select',
-      name: 'feepayer',
-      choices: [
-        {
-          name: `Use stored account ${defaultFeePayerAlias} (public key: ${defaultFeePayerAddress}) `,
-          value: 'defaultCache',
-        },
-        {
-          name: 'Use a different account (select to see options)',
-          value: 'other',
-        },
-      ],
-      message: (state) => {
-        const style = state.submitted && !state.cancelled ? green : reset;
-        return style('Choose an account to pay transaction fees:');
-      },
-      result() {
-        return this.focused.value;
-      },
-      skip() {
-        return !isFeepayerCached; // Only display this prompt question if feeyper is cached
-      },
-    },
-  ];
-
-  const recoverFeepayerPrompts = [
-    {
-      type: 'input',
-      name: 'feepayerKey',
-      message: (state) => {
-        const style = state.submitted && !state.cancelled ? green : reset;
-        return style('Account private key (base58):');
-      },
-      skip() {
-        return this.state.answers.feepayer !== 'create';
-      },
-    },
-    {
-      type: 'input',
-      name: 'feepayerAliasName',
-      message: (state) => {
-        const style = state.submitted && !state.cancelled ? green : reset;
-        return style('Choose an alias for this account');
-      },
-      validate: async (val) => {
-        val = val.toLowerCase().trim().replace(' ', '-');
-        if (!val) return red('Fee-payer alias is required.');
-        return true;
-      },
-    },
-  ];
-
   const initialPromptResponse = await prompt([
     ...prompts.deployAliasPrompts(config),
-    ...initialFeepayerPrompts,
+    ...prompts.initialFeepayerPrompts(
+      defaultFeePayerAlias,
+      defaultFeePayerAddress,
+      isFeepayerCached
+    ),
   ]);
 
   let recoverFeepayerResponse;
   if (initialPromptResponse.feepayer === 'recover') {
-    recoverFeepayerResponse = await prompt(recoverFeepayerPrompts);
+    recoverFeepayerResponse = await prompt(prompts.recoverFeepayerPrompts);
   }
 
   let otherFeepayerResponse;

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -178,7 +178,7 @@ async function config() {
         name: 'feepayerAliasName',
         message: (state) => {
           const style = state.submitted && !state.cancelled ? green : reset;
-          return style('Choose an alias for this account');
+          return style('Create an alias for this account');
         },
         validate: async (val) => {
           val = val.toLowerCase().trim().replace(' ', '-');

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -164,7 +164,7 @@ async function config() {
     url,
     fee,
     feepayer,
-    feepayerAliasName,
+    feepayerAlias,
     feepayerKey,
     alternateCachedFeepayerAlias,
   } = promptResponse;
@@ -174,17 +174,17 @@ async function config() {
   let feepayerKeyPair;
   switch (feepayer) {
     case 'create':
-      feepayerKeyPair = await createKeyPairStep(HOME_DIR, feepayerAliasName);
+      feepayerKeyPair = await createKeyPairStep(HOME_DIR, feepayerAlias);
       break;
     case 'recover':
       feepayerKeyPair = await recoverKeyPairStep(
         HOME_DIR,
         feepayerKey,
-        feepayerAliasName
+        feepayerAlias
       );
       break;
     case 'defaultCache':
-      feepayerAliasName = defaultFeepayerAlias;
+      feepayerAlias = defaultFeepayerAlias;
       feepayerKeyPair = await savedKeyPairStep(
         HOME_DIR,
         defaultFeepayerAlias,
@@ -192,7 +192,7 @@ async function config() {
       );
       break;
     case 'alternateCachedFeepayer':
-      feepayerAliasName = alternateCachedFeepayerAlias;
+      feepayerAlias = alternateCachedFeepayerAlias;
       feepayerKeyPair = await savedKeyPairStep(
         HOME_DIR,
         alternateCachedFeepayerAlias
@@ -214,16 +214,16 @@ async function config() {
   );
 
   await step(`Add deploy alias to config.json`, async () => {
-    if (!feepayerAliasName) {
+    if (!feepayerAlias) {
       // No fee payer alias, return early to prevent creating a deploy alias with invalid fee payer
-      log(red(`Invalid fee payer alias ${feepayerAliasName}" .`));
+      log(red(`Invalid fee payer alias ${feepayerAlias}" .`));
       process.exit(1);
     }
     config.deployAliases[deployAliasName] = {
       url,
       keyPath: `keys/${deployAliasName}.json`,
-      feepayerKeyPath: `${HOME_DIR}/.cache/zkapp-cli/keys/${feepayerAliasName}.json`,
-      feepayerAliasName,
+      feepayerKeyPath: `${HOME_DIR}/.cache/zkapp-cli/keys/${feepayerAlias}.json`,
+      feepayerAlias,
       fee,
     };
     fs.outputJsonSync(`${DIR}/config.json`, config, { spaces: 2 });
@@ -245,19 +245,19 @@ async function config() {
 }
 
 // Creates a new feepayer key pair
-async function createKeyPairStep(directory, feepayerAliasName) {
-  if (!feepayerAliasName) {
+async function createKeyPairStep(directory, feepayerAlias) {
+  if (!feepayerAlias) {
     // No fee payer alias, return early to prevent generating key pair with undefined alias
-    log(red(`Invalid fee payer alias ${feepayerAliasName}.`));
+    log(red(`Invalid fee payer alias ${feepayerAlias}.`));
     return;
   }
   return await step(
-    `Create fee payer key pair at ${HOME_DIR}/.cache/zkapp-cli/keys/${feepayerAliasName}.json`,
+    `Create fee payer key pair at ${HOME_DIR}/.cache/zkapp-cli/keys/${feepayerAlias}.json`,
     async () => {
       const keyPair = createKeyPair('testnet');
 
       fs.outputJsonSync(
-        `${directory}/.cache/zkapp-cli/keys/${feepayerAliasName}.json`,
+        `${directory}/.cache/zkapp-cli/keys/${feepayerAlias}.json`,
         keyPair,
         {
           spaces: 2,
@@ -268,9 +268,9 @@ async function createKeyPairStep(directory, feepayerAliasName) {
   );
 }
 
-async function recoverKeyPairStep(directory, feepayerKey, feepayerAliasName) {
+async function recoverKeyPairStep(directory, feepayerKey, feepayerAlias) {
   return await step(
-    `Recover fee payer keypair from ${feepayerKey} and add to ${HOME_DIR}/.cache/zkapp-cli/keys/${feepayerAliasName}.json`,
+    `Recover fee payer keypair from ${feepayerKey} and add to ${HOME_DIR}/.cache/zkapp-cli/keys/${feepayerAlias}.json`,
     async () => {
       const feepayorPrivateKey = PrivateKey.fromBase58(feepayerKey);
       const feepayerAddress = feepayorPrivateKey.toPublicKey();
@@ -281,7 +281,7 @@ async function recoverKeyPairStep(directory, feepayerKey, feepayerAliasName) {
       };
 
       fs.outputJsonSync(
-        `${directory}/.cache/zkapp-cli/keys/${feepayerAliasName}.json`,
+        `${directory}/.cache/zkapp-cli/keys/${feepayerAlias}.json`,
         keyPair,
         {
           spaces: 2,
@@ -292,20 +292,20 @@ async function recoverKeyPairStep(directory, feepayerKey, feepayerAliasName) {
   );
 }
 // Returns a cached keypair from a given feepayer alias
-async function savedKeyPairStep(directory, feepayerAliasName, address) {
-  if (!feepayerAliasName) {
+async function savedKeyPairStep(directory, feepayerAlias, address) {
+  if (!feepayerAlias) {
     // No fee payer alias, return early to prevent generating key pair with undefined alias
-    log(red(`Invalid fee payer alias: ${feepayerAliasName}.`));
+    log(red(`Invalid fee payer alias: ${feepayerAlias}.`));
     process.exit(1);
   }
   const keyPair = fs.readJSONSync(
-    `${directory}/.cache/zkapp-cli/keys/${feepayerAliasName}.json`
+    `${directory}/.cache/zkapp-cli/keys/${feepayerAlias}.json`
   );
 
   if (!address) address = keyPair.publicKey;
 
   return await step(
-    `Use stored fee payer ${feepayerAliasName} (public key: ${address}) `,
+    `Use stored fee payer ${feepayerAlias} (public key: ${address}) `,
 
     async () => {
       return keyPair;

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -265,13 +265,25 @@ async function config() {
           return this.focused.value;
         },
       },
+      {
+        type: 'select',
+        name: 'feePayerAlias',
+        choices: cachedFeepayerAliases,
+        message: (state) => {
+          const style = state.submitted && !state.cancelled ? green : reset;
+          return style('Choose another saved fee-payer:');
+        },
+        skip() {
+          return this.state.answers.feepayer !== 'alternateCachedFeepayer';
+        },
+      },
     ]);
   }
 
   let feepayerAliasResponse;
 
   if (
-    (initialPromptResponse?.feepayer !== 'defaultCache') &
+    (initialPromptResponse?.feepayer !== 'defaultCache') |
     (otherFeepayerResponse?.feepayor !== 'alternateCachedFeepayer')
   ) {
     feepayerAliasResponse = await prompt([

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -19,8 +19,6 @@ const log = console.log;
 async function config() {
   // Get project root, so the CLI command can be run anywhere inside their proj.
   const DIR = await findPrefix(process.cwd());
-  // Get users home directory path.
-  // const HOME_DIR = os.homedir();
 
   let config;
   try {
@@ -167,7 +165,6 @@ async function config() {
     ...feepayerAliasResponse,
   };
 
-  console.log('prompt response', promptResponse);
   // If user presses "ctrl + c" during interactive prompt, exit.
   let {
     deployAliasName,
@@ -232,7 +229,6 @@ async function config() {
   const explorerName = getExplorerName(
     config.deployAliases[deployAliasName]?.url
   );
-  console.log('feepayerKeyPair', feepayerKeyPair);
 
   const str =
     `\nSuccess!\n` +

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -100,7 +100,7 @@ async function config() {
   const msg = '\n  ' + table(tableData, tableConfig).replaceAll('\n', '\n  ');
   log(msg);
 
-  console.log('Add a new deploy alias:');
+  console.log('Enter values to create a deploy alias:');
 
   // TODO: Later, show pre-configured list to choose from or let user
   // add a custom deploy alias.
@@ -190,8 +190,6 @@ async function config() {
 
   // If user presses "ctrl + c" during interactive prompt, exit.
   const { deployAliasName, url, fee, feepayerAliasName } = promptResponse;
-
-  console.log('prompt response', promptResponse);
 
   if (!deployAliasName || !url || !fee) return;
 

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -154,6 +154,14 @@ async function config() {
         skip() {
           return this.state.answers.feepayer !== 'alternateCachedFeepayer';
         },
+        result() {
+          // Workaround for a bug in enquirer that returns the first value of choices when the
+          // question is skipped https://github.com/enquirer/enquirer/issues/340 .
+          // This returns the previous prompt value if prompt is skipped.
+          if (this.state.answers.feepayer !== 'alternateCachedFeepayer') {
+            return this.state.answers.feepayer;
+          }
+        },
       },
     ]);
   }

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -283,8 +283,8 @@ async function config() {
   let feepayerAliasResponse;
 
   if (
-    (initialPromptResponse?.feepayer !== 'defaultCache') |
-    (otherFeepayerResponse?.feepayor !== 'alternateCachedFeepayer')
+    (initialPromptResponse?.feepayer !== 'defaultCache') &
+    (otherFeepayerResponse?.feepayer !== 'alternateCachedFeepayer')
   ) {
     feepayerAliasResponse = await prompt([
       {

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -214,6 +214,11 @@ async function config() {
   );
 
   await step(`Add deploy alias to config.json`, async () => {
+    if (!feepayerAliasName) {
+      // No fee payer alias, return early to prevent creating a deploy alias with invalid fee payer
+      log(red(`Invalid fee payer alias ${feepayerAliasName}" .`));
+      process.exit(1);
+    }
     config.deployAliases[deployAliasName] = {
       url,
       keyPath: `keys/${deployAliasName}.json`,
@@ -241,6 +246,12 @@ async function config() {
 
 // Creates a new feepayer key pair
 async function createKeyPairStep(directory, feepayerAliasName) {
+  feepayerAliasName = undefined;
+  if (!feepayerAliasName) {
+    // No fee payer alias, return early to prevent generating key pair with undefined alias
+    log(red(`  Invalid fee payer alias ${feepayerAliasName}" .`));
+    return;
+  }
   return await step(
     `Create fee payer key pair at ${HOME_DIR}/.cache/zkapp-cli/keys/${feepayerAliasName}.json`,
     async () => {
@@ -282,15 +293,20 @@ async function recoverKeyPairStep(directory, feepayerKey, feepayerAliasName) {
   );
 }
 // Returns a cached keypair from a given feepayer alias
-async function savedKeyPairStep(directory, alias, address) {
+async function savedKeyPairStep(directory, feepayerAliasName, address) {
+  if (!feepayerAliasName) {
+    // No fee payer alias, return early to prevent generating key pair with undefined alias
+    log(red(`  Invalid fee payer alias: ${feepayerAliasName} .`));
+    process.exit(1);
+  }
   const keyPair = fs.readJSONSync(
-    `${directory}/.cache/zkapp-cli/keys/${alias}.json`
+    `${directory}/.cache/zkapp-cli/keys/${feepayerAliasName}.json`
   );
 
   if (!address) address = keyPair.publicKey;
 
   return await step(
-    `Use stored fee payer ${alias} (public key: ${address}) `,
+    `Use stored fee payer ${feepayerAliasName} (public key: ${address}) `,
 
     async () => {
       return keyPair;

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -149,7 +149,7 @@ async function config() {
         choices: cachedFeepayerAliases,
         message: (state) => {
           const style = state.submitted && !state.cancelled ? green : reset;
-          return style('Choose another saved fee-payer:');
+          return style('Choose another saved feepayer:');
         },
         skip() {
           return this.state.answers.feepayer !== 'alternateCachedFeepayer';
@@ -182,7 +182,7 @@ async function config() {
         },
         validate: async (val) => {
           val = val.toLowerCase().trim().replace(' ', '-');
-          if (!val) return red('Fee-payer alias is required.');
+          if (!val) return red('Feepayer alias is required.');
           return true;
         },
       },
@@ -269,10 +269,10 @@ function getCachedFeepayerAliases(directory) {
 function getFeepayorChoices(cachedFeepayerAliases) {
   const choices = [
     {
-      name: `Recover fee-payer account from an existing base58 private key`,
+      name: `Recover feepayer account from an existing base58 private key`,
       value: 'recover',
     },
-    { name: 'Create a new fee-payer key pair', value: 'create' },
+    { name: 'Create a new feepayer key pair', value: 'create' },
   ];
 
   // Displays an additional prompt to select a different feepayer if more than one feepayer is cached

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -207,11 +207,11 @@ async function config() {
       choices: cachedFeepayerAliases,
       message: (state) => {
         const style = state.submitted && !state.cancelled ? green : reset;
-        return style('Choose another saved feeyper:');
+        return style('Choose another saved feeypayer:');
       },
       skip() {
         return (
-          (this.state.answers.feepayer === 'defaultCache') |
+          (this.state.answers.feepayer !== 'alternateCachedfeePayer') |
           (cachedFeepayerAliases.length === 1)
         );
       },
@@ -232,7 +232,7 @@ async function config() {
       name: 'feepayerAliasName',
       message: (state) => {
         const style = state.submitted && !state.cancelled ? green : reset;
-        return style('Choose an alias for this account:');
+        return style('Choose an alias for this account');
       },
       validate: async (val) => {
         val = val.toLowerCase().trim().replace(' ', '-');
@@ -240,13 +240,19 @@ async function config() {
         return true;
       },
       skip() {
-        return this.state.answers.feepayer === 'cache';
+        const { feepayer } = this.state.answers;
+        return (
+          (feepayer === 'defaultCache') |
+          (feepayer === 'alternateCachedFeepayer')
+        );
       },
     },
   ]);
 
   // If user presses "ctrl + c" during interactive prompt, exit.
   const { deployAliasName, url, fee, feepayerAliasName } = response;
+
+  console.log('response', response);
 
   if (!deployAliasName || !url || !fee) return;
 
@@ -311,6 +317,7 @@ function getCachedFeePayerAliases(directory) {
   aliases = aliases
     .filter((fileName) => fileName.includes('json'))
     .map((name) => name.slice(0, -5));
+  console.log('aliases', aliases);
   return aliases;
 }
 
@@ -326,8 +333,8 @@ function getFeepayorChoices(cachedFeepayerAliases) {
   // Displays an additional prompt to select a different feepayer if more than one feepayer is cached
   if (cachedFeepayerAliases.length > 1)
     choices.push({
-      name: 'Choose another saved feeyper:',
-      value: 'alternateCachedfeePayer',
+      name: 'Choose another saved feeypayer',
+      value: 'alternateCachedFeepayer',
     });
 
   return choices;

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -169,14 +169,8 @@ async function config() {
 
   console.log('prompt response', promptResponse);
   // If user presses "ctrl + c" during interactive prompt, exit.
-  const {
-    deployAliasName,
-    url,
-    fee,
-    feepayer,
-    feepayerAliasName,
-    feepayerKey,
-  } = promptResponse;
+  let { deployAliasName, url, fee, feepayer, feepayerAliasName, feepayerKey } =
+    promptResponse;
 
   // create -> generate new key pair with feepayerAliasName
   // recover -> take feepayerkey and recover public key -> add to config.json -> prompt adding <alias> <keypath>
@@ -202,7 +196,10 @@ async function config() {
       feepayerKeyPair = await recoverKeyPairStep();
       break;
     case 'defaultCache':
-      feepayerKeyPair = await recoverKeyPairStep();
+      feepayerKeyPair = await savedKeyPairStep(
+        defaultFeepayerAlias,
+        defaultFeepayerAddress
+      );
       break;
     default:
       break;
@@ -245,6 +242,20 @@ async function config() {
           {
             spaces: 2,
           }
+        );
+        return keyPair;
+      }
+    );
+  }
+  // Adds the fee payer alias and keypath to the config.json
+  async function savedKeyPairStep(alias, address) {
+    return await step(
+      `Use stored fee payer ${alias} (public key: ${address}) `,
+
+      async () => {
+        feepayerAliasName = alias;
+        const keyPair = fs.readJSONSync(
+          `${HOME_DIR}/.cache/zkapp-cli/keys/${alias}.json`
         );
         return keyPair;
       }

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -246,10 +246,9 @@ async function config() {
 
 // Creates a new feepayer key pair
 async function createKeyPairStep(directory, feepayerAliasName) {
-  feepayerAliasName = undefined;
   if (!feepayerAliasName) {
     // No fee payer alias, return early to prevent generating key pair with undefined alias
-    log(red(`  Invalid fee payer alias ${feepayerAliasName}" .`));
+    log(red(`Invalid fee payer alias ${feepayerAliasName}.`));
     return;
   }
   return await step(
@@ -296,7 +295,7 @@ async function recoverKeyPairStep(directory, feepayerKey, feepayerAliasName) {
 async function savedKeyPairStep(directory, feepayerAliasName, address) {
   if (!feepayerAliasName) {
     // No fee payer alias, return early to prevent generating key pair with undefined alias
-    log(red(`  Invalid fee payer alias: ${feepayerAliasName} .`));
+    log(red(`Invalid fee payer alias: ${feepayerAliasName}.`));
     process.exit(1);
   }
   const keyPair = fs.readJSONSync(

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -6,6 +6,7 @@ const { table, getBorderCharacters } = require('table');
 const { step } = require('./helpers');
 const { green, red, bold, gray, reset } = require('chalk');
 const Client = require('mina-signer');
+const { prompts } = require('./prompts');
 
 const log = console.log;
 
@@ -117,57 +118,6 @@ async function config() {
     return state.cancelled ? red(state.symbols.cross) : state.symbols.check;
   }
 
-  const deployAliasPrompts = [
-    {
-      type: 'input',
-      name: 'deployAliasName',
-      message: (state) => {
-        const style = state.submitted && !state.cancelled ? green : reset;
-        return style('Choose a name (can be anything):');
-      },
-      prefix: formatPrefixSymbol,
-      validate: async (val) => {
-        val = val.toLowerCase().trim().replace(' ', '-');
-        if (!val) return red('Name is required.');
-        if (Object.keys(config.deployAliases).includes(val)) {
-          return red('Name already exists.');
-        }
-        return true;
-      },
-      result: (val) => val.toLowerCase().trim().replace(' ', '-'),
-    },
-    {
-      type: 'input',
-      name: 'url',
-      message: (state) => {
-        const style = state.submitted && !state.cancelled ? green : reset;
-        return style('Set the Mina GraphQL API URL to deploy to:');
-      },
-      prefix: formatPrefixSymbol,
-      validate: (val) => {
-        if (!val) return red('Url is required.');
-        return true;
-      },
-      result: (val) => val.trim().replace(/ /, ''),
-    },
-    {
-      type: 'input',
-      name: 'fee',
-      message: (state) => {
-        const style = state.submitted && !state.cancelled ? green : reset;
-        return style('Set transaction fee to use when deploying (in MINA):');
-      },
-      prefix: formatPrefixSymbol,
-      validate: (val) => {
-        if (!val) return red('Fee is required.');
-        if (isNaN(val)) return red('Fee must be a number.');
-        if (val < 0) return red("Fee can't be negative.");
-        return true;
-      },
-      result: (val) => val.trim().replace(/ /, ''),
-    },
-  ];
-
   const initialFeepayerPrompts = [
     {
       type: 'select',
@@ -245,7 +195,7 @@ async function config() {
   ];
 
   const initialPromptResponse = await prompt([
-    ...deployAliasPrompts,
+    ...prompts.deployAliasPrompts(config),
     ...initialFeepayerPrompts,
   ]);
 

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -193,17 +193,7 @@ async function config() {
     {
       type: 'select',
       name: 'feepayer',
-      choices: [
-        {
-          name: `Recover fee-payer account from an existing base58 private key`,
-          value: 'recover',
-        },
-        { name: 'Create a new fee-payer key pair', value: 'create' },
-      ],
-      message: (state) => {
-        const style = state.submitted && !state.cancelled ? green : reset;
-        return style('Choose an account to pay transaction fees:');
-      },
+      choices: getFeepayorChoices(cachedFeepayerAliases),
       result() {
         return this.focused.value;
       },
@@ -322,6 +312,25 @@ function getCachedFeePayerAliases(directory) {
     .filter((fileName) => fileName.includes('json'))
     .map((name) => name.slice(0, -5));
   return aliases;
+}
+
+function getFeepayorChoices(cachedFeepayerAliases) {
+  const choices = [
+    {
+      name: `Recover fee-payer account from an existing base58 private key`,
+      value: 'recover',
+    },
+    { name: 'Create a new fee-payer key pair', value: 'create' },
+  ];
+
+  // Displays an additional prompt to select a different feepayer if more than one feepayer is cached
+  if (cachedFeepayerAliases.length > 1)
+    choices.push({
+      name: 'Choose another saved feeyper:',
+      value: 'alternateCachedfeePayer',
+    });
+
+  return choices;
 }
 
 function getCachedFeePayerAddress(directory, feePayorAlias) {

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -121,7 +121,9 @@ async function config() {
   let otherFeepayerResponse;
 
   if (initialPromptResponse.feepayer === 'recover') {
-    recoverFeepayerResponse = await prompt(recoverFeepayerPrompts);
+    recoverFeepayerResponse = await prompt(
+      recoverFeepayerPrompts(cachedFeepayerAliases)
+    );
   }
 
   if (initialPromptResponse?.feepayer === 'create') {
@@ -134,11 +136,15 @@ async function config() {
     );
 
     if (otherFeepayerResponse.feepayer === 'recover') {
-      recoverFeepayerResponse = await prompt(recoverFeepayerPrompts);
+      recoverFeepayerResponse = await prompt(
+        recoverFeepayerPrompts(cachedFeepayerAliases)
+      );
     }
 
     if (otherFeepayerResponse.feepayer === 'create') {
-      feepayerAliasResponse = await prompt(feepayerAliasPrompt);
+      feepayerAliasResponse = await prompt(
+        feepayerAliasPrompt(cachedFeepayerAliases)
+      );
     }
   }
 

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -49,8 +49,6 @@ async function config() {
       defaultFeePayerAlias
     );
 
-    console.log('cachedFeepayerAliases', cachedFeepayerAliases);
-    console.log('default feepayer', defaultFeePayerAddress);
     isFeepayerCached = true;
   } catch (err) {
     if (err.code !== 'ENOENT') {
@@ -149,7 +147,7 @@ async function config() {
         choices: cachedFeepayerAliases,
         message: (state) => {
           const style = state.submitted && !state.cancelled ? green : reset;
-          return style('Choose another saved feepayer:');
+          return style('Choose another saved fee payer:');
         },
         skip() {
           return this.state.answers.feepayer !== 'alternateCachedFeepayer';
@@ -182,7 +180,7 @@ async function config() {
         },
         validate: async (val) => {
           val = val.toLowerCase().trim().replace(' ', '-');
-          if (!val) return red('Feepayer alias is required.');
+          if (!val) return red('Fee payer alias is required.');
           return true;
         },
       },
@@ -202,7 +200,7 @@ async function config() {
   if (!deployAliasName || !url || !fee) return;
 
   const feepayerKeyPair = await step(
-    `Create feepayer key pair at ${HOME_DIR}/.cache/zkapp-cli/keys/${feepayerAliasName}.json`,
+    `Create fee payer key pair at ${HOME_DIR}/.cache/zkapp-cli/keys/${feepayerAliasName}.json`,
     async () => {
       const keyPair = createKeyPair('testnet');
 
@@ -269,10 +267,10 @@ function getCachedFeepayerAliases(directory) {
 function getFeepayorChoices(cachedFeepayerAliases) {
   const choices = [
     {
-      name: `Recover feepayer account from an existing base58 private key`,
+      name: `Recover fee payer account from an existing base58 private key`,
       value: 'recover',
     },
-    { name: 'Create a new feepayer key pair', value: 'create' },
+    { name: 'Create a new fee payer key pair', value: 'create' },
   ];
 
   // Displays an additional prompt to select a different feepayer if more than one feepayer is cached

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -41,9 +41,9 @@ async function config() {
   let defaultFeePayerAddress;
 
   try {
-    cachedFeepayerAliases = getCachedFeePayerAliases(HOME_DIR);
+    cachedFeepayerAliases = getCachedFeepayerAliases(HOME_DIR);
     defaultFeePayerAlias = cachedFeepayerAliases[0];
-    defaultFeePayerAddress = getCachedFeePayerAddress(
+    defaultFeePayerAddress = getCachedFeepayerAddress(
       HOME_DIR,
       defaultFeePayerAlias
     );
@@ -217,11 +217,6 @@ async function config() {
     },
   ];
 
-  const initialPromptResponse = await prompt([
-    ...deployAliasPrompts,
-    ...initialFeepayerPrompts,
-  ]);
-
   const recoverFeepayerPrompts = [
     {
       type: 'input',
@@ -249,6 +244,11 @@ async function config() {
     },
   ];
 
+  const initialPromptResponse = await prompt([
+    ...deployAliasPrompts,
+    ...initialFeepayerPrompts,
+  ]);
+
   let recoverFeepayerResponse;
   if (initialPromptResponse.feepayer === 'recover') {
     recoverFeepayerResponse = await prompt(recoverFeepayerPrompts);
@@ -271,8 +271,8 @@ async function config() {
   let feepayerAliasResponse;
 
   if (
-    (initialPromptResponse.feepayer !== 'defaultCache') &
-    (otherFeepayerResponse.feePayor !== 'alternateCachedFeepayer')
+    (initialPromptResponse?.feepayer !== 'defaultCache') &
+    (otherFeepayerResponse?.feepayor !== 'alternateCachedFeepayer')
   ) {
     feepayerAliasResponse = await prompt([
       {
@@ -360,7 +360,7 @@ async function config() {
 }
 
 // Check if feepayer alias/aliases are stored on users machine and returns an array of them.
-function getCachedFeePayerAliases(directory) {
+function getCachedFeepayerAliases(directory) {
   let aliases = fs.readdirSync(`${directory}/.cache/zkapp-cli/keys/`);
 
   aliases = aliases
@@ -389,7 +389,7 @@ function getFeepayorChoices(cachedFeepayerAliases) {
   return choices;
 }
 
-function getCachedFeePayerAddress(directory, feePayorAlias) {
+function getCachedFeepayerAddress(directory, feePayorAlias) {
   const address = fs.readJSONSync(
     `${directory}/.cache/zkapp-cli/keys/${feePayorAlias}.json`
   ).publicKey;

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -172,7 +172,7 @@ async function config() {
       choices: [
         {
           name: `Use stored account ${defaultFeePayerAlias} (public key: ${defaultFeePayerAddress}) `,
-          value: 'cache',
+          value: 'defaultCache',
         },
         {
           name: 'Use a different account (select to see options)',
@@ -208,7 +208,7 @@ async function config() {
         return this.focused.value;
       },
       skip() {
-        return this.state.answers.feepayer === 'cache';
+        return this.state.answers.feepayer === 'defaultCache';
       },
     },
     {
@@ -218,6 +218,12 @@ async function config() {
       message: (state) => {
         const style = state.submitted && !state.cancelled ? green : reset;
         return style('Choose another saved feeyper:');
+      },
+      skip() {
+        return (
+          (this.state.answers.feepayer === 'defaultCache') |
+          (cachedFeepayerAliases.length === 1)
+        );
       },
     },
     {

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -212,6 +212,15 @@ async function config() {
       },
     },
     {
+      type: 'select',
+      name: 'feePayorAlias',
+      choices: cachedFeepayerAliases,
+      message: (state) => {
+        const style = state.submitted && !state.cancelled ? green : reset;
+        return style('Choose another saved feeyper:');
+      },
+    },
+    {
       type: 'input',
       name: 'feepayerKey',
       message: (state) => {

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -268,10 +268,40 @@ async function config() {
     ]);
   }
 
-  // If user presses "ctrl + c" during interactive prompt, exit.
-  const { deployAliasName, url, fee, feepayerAliasName } = response;
+  let feepayerAliasResponse;
 
-  console.log('response', response);
+  if (
+    (initialPromptResponse.feepayer !== 'defaultCache') &
+    (otherFeepayerResponse.feePayor !== 'alternateCachedFeepayer')
+  ) {
+    feepayerAliasResponse = await prompt([
+      {
+        type: 'input',
+        name: 'feepayerAliasName',
+        message: (state) => {
+          const style = state.submitted && !state.cancelled ? green : reset;
+          return style('Choose an alias for this account');
+        },
+        validate: async (val) => {
+          val = val.toLowerCase().trim().replace(' ', '-');
+          if (!val) return red('Fee-payer alias is required.');
+          return true;
+        },
+      },
+    ]);
+  }
+
+  const promptResponse = {
+    ...initialPromptResponse,
+    ...recoverFeepayerResponse,
+    ...otherFeepayerResponse,
+    ...feepayerAliasResponse,
+  };
+
+  // If user presses "ctrl + c" during interactive prompt, exit.
+  const { deployAliasName, url, fee, feepayerAliasName } = promptResponse;
+
+  console.log('prompt response', promptResponse);
 
   if (!deployAliasName || !url || !fee) return;
 

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -117,7 +117,7 @@ async function config() {
     return state.cancelled ? red(state.symbols.cross) : state.symbols.check;
   }
 
-  const response = await prompt([
+  let response = await prompt([
     {
       type: 'input',
       name: 'deployAliasName',
@@ -184,6 +184,7 @@ async function config() {
         return style('Choose an account to pay transaction fees:');
       },
       result() {
+        console.log('result in use stored prompt', this.focused);
         return this.focused.value;
       },
       skip() {
@@ -198,7 +199,8 @@ async function config() {
         return this.focused.value;
       },
       skip() {
-        return this.state.answers.feepayer === 'defaultCache';
+        console.log('result in select alternate alias', this.state.answers);
+        return this.state.answers.feepayer !== 'other';
       },
     },
     {
@@ -212,7 +214,7 @@ async function config() {
       skip() {
         return (
           (this.state.answers.feepayer !== 'alternateCachedfeePayer') |
-          (cachedFeepayerAliases.length === 1)
+          (cachedFeepayerAliases?.length === 1)
         );
       },
     },
@@ -224,7 +226,7 @@ async function config() {
         return style('Account private key (base58):');
       },
       skip() {
-        return this.state.answers.feepayer !== 'recover';
+        return this.state.answers.feepayer === 'recover';
       },
     },
     {
@@ -236,11 +238,12 @@ async function config() {
       },
       validate: async (val) => {
         val = val.toLowerCase().trim().replace(' ', '-');
-        if (!val) return red('Fee-payer alias is required.');
+        if (!val) return red('Feepayer alias is required.');
         return true;
       },
       skip() {
         const { feepayer } = this.state.answers;
+        console.log('feepayer in skip choose alias', this.state.answers);
         return (
           (feepayer === 'defaultCache') |
           (feepayer === 'alternateCachedFeepayer')
@@ -331,7 +334,7 @@ function getFeepayorChoices(cachedFeepayerAliases) {
   ];
 
   // Displays an additional prompt to select a different feepayer if more than one feepayer is cached
-  if (cachedFeepayerAliases.length > 1)
+  if (cachedFeepayerAliases?.length > 1)
     choices.push({
       name: 'Choose another saved feeypayer',
       value: 'alternateCachedFeepayer',

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -127,7 +127,10 @@ async function config() {
   }
 
   if (initialPromptResponse?.feepayer === 'create') {
-    feepayerAliasResponse = await prompt(feepayerAliasPrompt);
+    console.log('inside create if');
+    feepayerAliasResponse = await prompt(
+      feepayerAliasPrompt(cachedFeepayerAliases)
+    );
   }
 
   if (initialPromptResponse.feepayer === 'other') {

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -254,6 +254,20 @@ async function config() {
     recoverFeepayerResponse = await prompt(recoverFeepayerPrompts);
   }
 
+  let otherFeepayerResponse;
+  if (initialPromptResponse.feepayer === 'other') {
+    otherFeepayerResponse = await prompt([
+      {
+        type: 'select',
+        name: 'feepayer',
+        choices: getFeepayorChoices(cachedFeepayerAliases),
+        result() {
+          return this.focused.value;
+        },
+      },
+    ]);
+  }
+
   // If user presses "ctrl + c" during interactive prompt, exit.
   const { deployAliasName, url, fee, feepayerAliasName } = response;
 

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -65,7 +65,7 @@ async function config() {
   }
 
   // Build table of existing deploy aliases found in their config.json
-  let tableData = [[bold('Name'), bold('Url'), bold('Smart Contract')]];
+  let tableData = [[bold('Name'), bold('URL'), bold('Smart Contract')]];
   for (const deployAliasName in config.deployAliases) {
     const { url, smartContract } = config.deployAliases[deployAliasName];
     tableData.push([

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -117,7 +117,7 @@ async function config() {
     return state.cancelled ? red(state.symbols.cross) : state.symbols.check;
   }
 
-  let response = await prompt([
+  const deployAliasPrompts = [
     {
       type: 'input',
       name: 'deployAliasName',
@@ -166,6 +166,10 @@ async function config() {
       },
       result: (val) => val.trim().replace(/ /, ''),
     },
+  ];
+
+  let response = await prompt([
+    ...deployAliasPrompts,
     {
       type: 'select',
       name: 'feepayer',
@@ -361,6 +365,7 @@ function getExplorerName(graphQLUrl) {
     .split('.')
     .filter((item) => item === 'minascan' || item === 'minaexplorer')?.[0];
 }
+
 module.exports = {
   config,
 };

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -168,7 +168,7 @@ async function config() {
     },
   ];
 
-  const initialFeePayorPrompts = [
+  const initialFeepayerPrompts = [
     {
       type: 'select',
       name: 'feepayer',
@@ -217,10 +217,42 @@ async function config() {
     },
   ];
 
-  let response = await prompt([
+  const initialPromptResponse = await prompt([
     ...deployAliasPrompts,
-    ...initialFeePayorPrompts,
+    ...initialFeepayerPrompts,
   ]);
+
+  const recoverFeepayerPrompts = [
+    {
+      type: 'input',
+      name: 'feepayerKey',
+      message: (state) => {
+        const style = state.submitted && !state.cancelled ? green : reset;
+        return style('Account private key (base58):');
+      },
+      skip() {
+        return this.state.answers.feepayer !== 'create';
+      },
+    },
+    {
+      type: 'input',
+      name: 'feepayerAliasName',
+      message: (state) => {
+        const style = state.submitted && !state.cancelled ? green : reset;
+        return style('Choose an alias for this account');
+      },
+      validate: async (val) => {
+        val = val.toLowerCase().trim().replace(' ', '-');
+        if (!val) return red('Fee-payer alias is required.');
+        return true;
+      },
+    },
+  ];
+
+  let recoverFeepayerResponse;
+  if (initialPromptResponse.feepayer === 'recover') {
+    recoverFeepayerResponse = await prompt(recoverFeepayerPrompts);
+  }
 
   // If user presses "ctrl + c" during interactive prompt, exit.
   const { deployAliasName, url, fee, feepayerAliasName } = response;

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -36,12 +36,20 @@ async function config() {
   }
 
   let isFeepayerCached = false;
-  let cachedFeePayerAlias;
+  let defaultFeePayerAlias;
   let cachedFeepayerAliases;
-  let cachedFeePayerAddress;
+  let defaultFeePayerAddress;
 
   try {
-    cachedFeepayerAliases = getCachedFeePayerAlias(HOME_DIR);
+    cachedFeepayerAliases = getCachedFeePayerAliases(HOME_DIR);
+    defaultFeePayerAlias = cachedFeepayerAliases[0];
+    defaultFeePayerAddress = getCachedFeePayerAddress(
+      HOME_DIR,
+      defaultFeePayerAlias
+    );
+
+    console.log('cachedFeepayerAliases', cachedFeepayerAliases);
+    console.log('default feepayer', defaultFeePayerAddress);
     isFeepayerCached = true;
   } catch (err) {
     if (err.code !== 'ENOENT') {
@@ -163,7 +171,7 @@ async function config() {
       name: 'feepayer',
       choices: [
         {
-          name: `Use stored account ${cachedFeePayerAlias} (public key: ${cachedFeePayerAddress}) `,
+          name: `Use stored account ${defaultFeePayerAlias} (public key: ${defaultFeePayerAddress}) `,
           value: 'cache',
         },
         {
@@ -292,13 +300,21 @@ async function config() {
 }
 
 // Check if feepayer alias/aliases are stored on users machine and returns an array of them.
-function getCachedFeePayerAlias(directory) {
+function getCachedFeePayerAliases(directory) {
   let aliases = fs.readdirSync(`${directory}/.cache/zkapp-cli/keys/`);
 
   aliases = aliases
     .filter((fileName) => fileName.includes('json'))
     .map((name) => name.slice(0, -5));
   return aliases;
+}
+
+function getCachedFeePayerAddress(directory, feePayorAlias) {
+  const address = fs.readJSONSync(
+    `${directory}/.cache/zkapp-cli/keys/${feePayorAlias}.json`
+  ).publicKey;
+
+  return address;
 }
 
 function createKeyPair(network) {

--- a/src/lib/deploy.js
+++ b/src/lib/deploy.js
@@ -198,7 +198,7 @@ async function deploy({ alias, yes }) {
   if (process.platform === 'win32') {
     snarkyjsImportPath = 'file://' + snarkyjsImportPath;
   }
-  let { PrivateKey, Mina, Bool } = await import(snarkyjsImportPath);
+  let { PrivateKey, Mina } = await import(snarkyjsImportPath);
 
   const graphQLUrl = config.deployAliases[alias]?.url ?? DEFAULT_GRAPHQL;
 
@@ -379,14 +379,7 @@ async function deploy({ alias, yes }) {
     Mina.setActiveInstance(Network);
     let tx = await Mina.transaction({ sender: zkAppAddress, fee }, () => {
       let zkapp = new zkApp(zkAppAddress);
-      zkapp.deploy({ verificationKey, zkappKey: zkAppPrivateKey });
-      // manually patch the tx (TODO: have this implemented properly in snarkyjs)
-      // remove the nonce precondition
-      zkapp.self.body.preconditions.account.nonce.isSome = Bool(false);
-      // don't increment the nonce
-      zkapp.self.body.incrementNonce = Bool(false);
-      // use full commitment (means with include the fee payer in the signature, so we're protected against replays)
-      zkapp.self.body.useFullCommitment = Bool(true);
+      zkapp.deploy({ verificationKey });
     });
     return { tx, json: tx.sign([zkAppPrivateKey]).toJSON() };
   });

--- a/src/lib/deploy.js
+++ b/src/lib/deploy.js
@@ -1,7 +1,6 @@
 const sh = require('child_process').execSync;
 const fs = require('fs-extra');
 const path = require('path');
-const os = require('os');
 const findPrefix = require('find-npm-prefix');
 const { prompt } = require('enquirer');
 const { table, getBorderCharacters } = require('table');
@@ -25,8 +24,6 @@ const DEFAULT_GRAPHQL = 'https://proxy.berkeley.minaexplorer.com/graphql'; // Th
 async function deploy({ alias, yes }) {
   // Get project root, so the CLI command can be run anywhere inside their proj.
   const DIR = await findPrefix(process.cwd());
-  // Get users home directory path.
-  const HOME_DIR = os.homedir();
 
   let config;
   try {
@@ -286,7 +283,7 @@ async function deploy({ alias, yes }) {
   }
 
   try {
-    privateKey = fs.readJSONSync(
+    zkAppPrivateKeyBase58 = fs.readJSONSync(
       `${DIR}/${config.deployAliases[alias].keyPath}`
     ).privateKey;
   } catch (_) {

--- a/src/lib/deploy.js
+++ b/src/lib/deploy.js
@@ -283,8 +283,8 @@ async function deploy({ alias, yes }) {
   }
 
   try {
-    zkAppPrivateKeyBase58 = fs.readJSONSync(
-      `${DIR}/keys/${alias}.json`
+    privateKey = fs.readJSONSync(
+      `${DIR}/${config.deployAliases[alias].keyPath}`
     ).privateKey;
   } catch (_) {
     log(

--- a/src/lib/deploy.js
+++ b/src/lib/deploy.js
@@ -198,7 +198,7 @@ async function deploy({ alias, yes }) {
   if (process.platform === 'win32') {
     snarkyjsImportPath = 'file://' + snarkyjsImportPath;
   }
-  let { PrivateKey, Mina } = await import(snarkyjsImportPath);
+  let { PrivateKey, Mina, AccountUpdate } = await import(snarkyjsImportPath);
 
   const graphQLUrl = config.deployAliases[alias]?.url ?? DEFAULT_GRAPHQL;
 
@@ -378,6 +378,7 @@ async function deploy({ alias, yes }) {
     let Network = Mina.Network(graphQLUrl);
     Mina.setActiveInstance(Network);
     let tx = await Mina.transaction({ sender: feepayerAddress, fee }, () => {
+      AccountUpdate.fundNewAccount(feepayerAddress);
       let zkapp = new zkApp(zkAppAddress);
       zkapp.deploy({ verificationKey });
     });

--- a/src/lib/deploy.js
+++ b/src/lib/deploy.js
@@ -381,7 +381,10 @@ async function deploy({ alias, yes }) {
       let zkapp = new zkApp(zkAppAddress);
       zkapp.deploy({ verificationKey });
     });
-    return { tx, json: tx.sign([zkAppPrivateKey]).toJSON() };
+    return {
+      tx,
+      json: tx.sign([zkAppPrivateKey, feepayorPrivateKey]).toJSON(),
+    };
   });
 
   if (isInitMethod) {
@@ -391,7 +394,9 @@ async function deploy({ alias, yes }) {
         await transaction.tx.prove();
         return {
           tx: transaction.tx,
-          json: transaction.tx.sign([zkAppPrivateKey]).toJSON(),
+          json: transaction.tx
+            .sign([zkAppPrivateKey, feepayorPrivateKey])
+            .toJSON(),
         };
       }
     );

--- a/src/lib/deploy.js
+++ b/src/lib/deploy.js
@@ -1,6 +1,7 @@
 const sh = require('child_process').execSync;
 const fs = require('fs-extra');
 const path = require('path');
+const os = require('os');
 const findPrefix = require('find-npm-prefix');
 const { prompt } = require('enquirer');
 const { table, getBorderCharacters } = require('table');
@@ -24,6 +25,8 @@ const DEFAULT_GRAPHQL = 'https://proxy.berkeley.minaexplorer.com/graphql'; // Th
 async function deploy({ alias, yes }) {
   // Get project root, so the CLI command can be run anywhere inside their proj.
   const DIR = await findPrefix(process.cwd());
+  // Get users home directory path.
+  const HOME_DIR = os.homedir();
 
   let config;
   try {

--- a/src/lib/deploy.js
+++ b/src/lib/deploy.js
@@ -401,7 +401,7 @@ async function deploy({ alias, yes }) {
   const settings = [
     [bold('Deploy Alias'), reset(alias)],
     [bold('Fee-Payer Alias'), reset(feepayerAliasName)],
-    [bold('Url'), reset(config.deployAliases[alias].url)],
+    [bold('URL'), reset(config.deployAliases[alias].url)],
     [bold('Smart Contract'), reset(contractName)],
   ];
 

--- a/src/lib/deploy.js
+++ b/src/lib/deploy.js
@@ -377,7 +377,7 @@ async function deploy({ alias, yes }) {
   let transaction = await step('Build transaction', async () => {
     let Network = Mina.Network(graphQLUrl);
     Mina.setActiveInstance(Network);
-    let tx = await Mina.transaction({ sender: zkAppAddress, fee }, () => {
+    let tx = await Mina.transaction({ sender: feepayerAddress, fee }, () => {
       let zkapp = new zkApp(zkAppAddress);
       zkapp.deploy({ verificationKey });
     });

--- a/src/lib/helpers.js
+++ b/src/lib/helpers.js
@@ -19,6 +19,7 @@ async function step(str, fn) {
   } catch (err) {
     spin.fail(str);
     console.error('  ' + red(err)); // maintain expected indentation
+    console.log(err);
     process.exit(1);
   }
 }

--- a/src/lib/prompts.js
+++ b/src/lib/prompts.js
@@ -139,7 +139,7 @@ const prompts = {
   recoverFeepayerPrompts: (cachedFeepayerAliases) => [
     {
       type: 'input',
-      name: 'feepayerAliasName',
+      name: 'feepayerAlias',
       message: (state) => {
         const style = state.submitted && !state.cancelled ? green : reset;
         return style('Create an alias for this account');
@@ -185,7 +185,7 @@ const prompts = {
   feepayerAliasPrompt: (cachedFeepayerAliases) => [
     {
       type: 'input',
-      name: 'feepayerAliasName',
+      name: 'feepayerAlias',
       message: (state) => {
         const style = state.submitted && !state.cancelled ? green : reset;
         return style('Create an alias for this account');

--- a/src/lib/prompts.js
+++ b/src/lib/prompts.js
@@ -149,7 +149,9 @@ const prompts = {
       name: 'feepayerKey',
       message: (state) => {
         const style = state.submitted && !state.cancelled ? green : reset;
-        return style('Account private key (base58):');
+        return style(`Account private key (base58):
+  NOTE: the private key will be stored in plain text on this computer.
+  Do NOT use an account which holds a substantial amount of MINA.`);
       },
     },
   ],

--- a/src/lib/prompts.js
+++ b/src/lib/prompts.js
@@ -66,8 +66,8 @@ const prompts = {
   ],
 
   initialFeepayerPrompts: (
-    defaultFeePayerAlias,
-    defaultFeePayerAddress,
+    defaultFeepayerAlias,
+    defaultFeepayerAddress,
     isFeepayerCached
   ) => [
     {
@@ -103,7 +103,7 @@ const prompts = {
       name: 'feepayer',
       choices: [
         {
-          name: `Use stored account ${defaultFeePayerAlias} (public key: ${defaultFeePayerAddress}) `,
+          name: `Use stored account ${defaultFeepayerAlias} (public key: ${defaultFeepayerAddress}) `,
           value: 'defaultCache',
         },
         {
@@ -122,6 +122,7 @@ const prompts = {
         // Workaround for a bug in enquirer that returns the first value of choices when the
         // question is skipped https://github.com/enquirer/enquirer/issues/340 .
         // This returns the previous prompt value if prompt is skipped.
+        this.state.feepayerAlias;
         if (!isFeepayerCached) {
           return this.state.answers.feepayer;
         }

--- a/src/lib/prompts.js
+++ b/src/lib/prompts.js
@@ -84,11 +84,18 @@ const prompts = {
         const style = state.submitted && !state.cancelled ? green : reset;
         return style('Choose an account to pay transaction fees:');
       },
-      result() {
-        return this.focused.value;
-      },
+
       skip() {
         return isFeepayerCached; // The prompt is only displayed if a feepayor has not been previously cached
+      },
+      result() {
+        // Workaround for a bug in enquirer that returns the first value of choices when the
+        // question is skipped https://github.com/enquirer/enquirer/issues/340 .
+        // This returns the previous prompt value if prompt is skipped.
+        if (isFeepayerCached) {
+          return this.state.answers.feepayer;
+        }
+        return this.focused.value;
       },
     },
     {
@@ -108,11 +115,17 @@ const prompts = {
         const style = state.submitted && !state.cancelled ? green : reset;
         return style('Choose an account to pay transaction fees:');
       },
-      result() {
-        return this.focused.value;
-      },
       skip() {
-        return !isFeepayerCached; // Only display this prompt question if feeyper is cached
+        return !isFeepayerCached; // Only display this prompt question if feeypayer is cached
+      },
+      result() {
+        // Workaround for a bug in enquirer that returns the first value of choices when the
+        // question is skipped https://github.com/enquirer/enquirer/issues/340 .
+        // This returns the previous prompt value if prompt is skipped.
+        if (!isFeepayerCached) {
+          return this.state.answers.feepayer;
+        }
+        return this.focused.value;
       },
     },
   ],
@@ -126,6 +139,15 @@ const prompts = {
       },
       skip() {
         return this.state.answers.feepayer !== 'create';
+      },
+      result() {
+        // Workaround for a bug in enquirer that returns the first value of choices when the
+        // question is skipped https://github.com/enquirer/enquirer/issues/340 .
+        // This returns the previous prompt value if prompt is skipped.
+        if (this.state.answers.feepayer !== 'create') {
+          return this.state.answers.feepayer;
+        }
+        return this.focused.value;
       },
     },
     {

--- a/src/lib/prompts.js
+++ b/src/lib/prompts.js
@@ -75,28 +75,6 @@ const prompts = {
       name: 'feepayer',
       choices: [
         {
-          name: `Recover fee-payer account from an existing base58 private key`,
-          value: 'recover',
-        },
-        { name: 'Create a new feepayer key pair', value: 'create' },
-      ],
-      message: (state) => {
-        const style = state.submitted && !state.cancelled ? green : reset;
-        return style('Choose an account to pay transaction fees:');
-      },
-      result() {
-        return this.focused.value;
-      },
-      skip() {
-        return isFeepayerCached; // The prompt is only displayed if a feepayor has not been previously cached
-      },
-    },
-
-    {
-      type: 'select',
-      name: 'feepayer',
-      choices: [
-        {
           name: `Use stored account ${defaultFeePayerAlias} (public key: ${defaultFeePayerAddress}) `,
           value: 'defaultCache',
         },
@@ -114,6 +92,27 @@ const prompts = {
       },
       skip() {
         return !isFeepayerCached; // Only display this prompt question if feeyper is cached
+      },
+    },
+    {
+      type: 'select',
+      name: 'feepayer',
+      choices: [
+        {
+          name: `Recover fee-payer account from an existing base58 private key`,
+          value: 'recover',
+        },
+        { name: 'Create a new feepayer key pair', value: 'create' },
+      ],
+      message: (state) => {
+        const style = state.submitted && !state.cancelled ? green : reset;
+        return style('Choose an account to pay transaction fees:');
+      },
+      result() {
+        return this.focused.value;
+      },
+      skip() {
+        return isFeepayerCached; // The prompt is only displayed if a feepayor has not been previously cached
       },
     },
   ],

--- a/src/lib/prompts.js
+++ b/src/lib/prompts.js
@@ -75,7 +75,7 @@ const prompts = {
       name: 'feepayer',
       choices: [
         {
-          name: `Recover fee-payer account from an existing base58 private key`,
+          name: `Recover feepayer account from an existing base58 private key`,
           value: 'recover',
         },
         { name: 'Create a new feepayer key pair', value: 'create' },
@@ -159,7 +159,7 @@ const prompts = {
       },
       validate: async (val) => {
         val = val.toLowerCase().trim().replace(' ', '-');
-        if (!val) return red('Fee-payer alias is required.');
+        if (!val) return red('Feepayer alias is required.');
         return true;
       },
     },

--- a/src/lib/prompts.js
+++ b/src/lib/prompts.js
@@ -146,7 +146,7 @@ const prompts = {
       },
       validate: async (val) => {
         val = val.toLowerCase().trim().split(' ').join('-');
-        if (cachedFeepayerAliases.includes(val))
+        if (cachedFeepayerAliases?.includes(val))
           return red(`Fee payer alias ${val} already exists`);
         if (!val) return red('Fee payer alias is required.');
         return true;
@@ -184,7 +184,7 @@ const prompts = {
       },
       validate: async (val) => {
         val = val.toLowerCase().trim().split(' ').join('-');
-        if (cachedFeepayerAliases.includes(val))
+        if (cachedFeepayerAliases?.includes(val))
           return red(`Fee payer alias ${val} already exists`);
         if (!val) return red('Fee payer alias is required.');
         return true;

--- a/src/lib/prompts.js
+++ b/src/lib/prompts.js
@@ -1,0 +1,6 @@
+const { green, red, bold, gray, reset } = require('chalk');
+
+const prompts = {};
+module.exports = {
+  prompts,
+};

--- a/src/lib/prompts.js
+++ b/src/lib/prompts.js
@@ -78,7 +78,11 @@ const prompts = {
           name: `Recover fee payer account from an existing base58 private key`,
           value: 'recover',
         },
-        { name: 'Create a new fee payer key pair', value: 'create' },
+        {
+          name: `Create a new fee payer key pair
+  NOTE: the private key will be stored in plain text on this computer.`,
+          value: 'create',
+        },
       ],
       message: (state) => {
         const style = state.submitted && !state.cancelled ? green : reset;
@@ -201,7 +205,11 @@ function getFeepayorChoices(cachedFeepayerAliases) {
       name: `Recover fee payer account from an existing base58 private key`,
       value: 'recover',
     },
-    { name: 'Create a new fee payer key pair', value: 'create' },
+    {
+      name: `Create a new fee payer key pair
+  NOTE: the private key will be stored in plain text on this computer.`,
+      value: 'create',
+    },
   ];
 
   // Displays an additional prompt to select a different feepayer if more than one feepayer is cached

--- a/src/lib/prompts.js
+++ b/src/lib/prompts.js
@@ -75,10 +75,10 @@ const prompts = {
       name: 'feepayer',
       choices: [
         {
-          name: `Recover feepayer account from an existing base58 private key`,
+          name: `Recover fee payer account from an existing base58 private key`,
           value: 'recover',
         },
-        { name: 'Create a new feepayer key pair', value: 'create' },
+        { name: 'Create a new fee payer key pair', value: 'create' },
       ],
       message: (state) => {
         const style = state.submitted && !state.cancelled ? green : reset;
@@ -159,7 +159,7 @@ const prompts = {
       },
       validate: async (val) => {
         val = val.toLowerCase().trim().replace(' ', '-');
-        if (!val) return red('Feepayer alias is required.');
+        if (!val) return red('Fee payer alias is required.');
         return true;
       },
     },

--- a/src/lib/prompts.js
+++ b/src/lib/prompts.js
@@ -1,4 +1,5 @@
-const { green, red, reset } = require('chalk');
+const chalk = require('chalk');
+const { green, red, reset } = chalk;
 
 function formatPrefixSymbol(state) {
   // Shows a cyan question mark when not submitted.
@@ -107,7 +108,7 @@ const prompts = {
       name: 'feepayer',
       choices: [
         {
-          name: `Use stored account ${defaultFeepayerAlias} (public key: ${defaultFeepayerAddress}) `,
+          name: chalk`Use stored account {bold ${defaultFeepayerAlias}} (public key: {bold ${defaultFeepayerAddress}}) `,
           value: 'defaultCache',
         },
         {

--- a/src/lib/prompts.js
+++ b/src/lib/prompts.js
@@ -1,5 +1,6 @@
 const chalk = require('chalk');
 const { green, red, reset } = chalk;
+const { PrivateKey } = require('snarkyjs');
 
 function formatPrefixSymbol(state) {
   // Shows a cyan question mark when not submitted.
@@ -144,11 +145,11 @@ const prompts = {
         return style('Create an alias for this account');
       },
       validate: async (val) => {
-        val = val.toLowerCase().trim().spilt(' ').join('-');
+        val = val.toLowerCase().trim().split(' ').join('-');
         if (!val) return red('Fee payer alias is required.');
         return true;
       },
-      result: (val) => val.toLowerCase().trim().spilt(' ').join('-'),
+      result: (val) => val.toLowerCase().trim().split(' ').join('-'),
     },
     {
       type: 'input',
@@ -159,6 +160,16 @@ const prompts = {
   NOTE: the private key will be stored in plain text on this computer.
   Do NOT use an account which holds a substantial amount of MINA.`);
       },
+      validate: async (val) => {
+        val = val.trim();
+        try {
+          PrivateKey.fromBase58(val);
+        } catch (err) {
+          return red('Enter a valid private key.');
+        }
+        return true;
+      },
+      result: (val) => val.trim(),
     },
   ],
   feepayerAliasPrompt: [
@@ -170,11 +181,11 @@ const prompts = {
         return style('Create an alias for this account');
       },
       validate: async (val) => {
-        val = val.toLowerCase().trim().spilt(' ').join('-');
+        val = val.toLowerCase().trim().split(' ').join('-');
         if (!val) return red('Fee payer alias is required.');
         return true;
       },
-      result: (val) => val.toLowerCase().trim().spilt(' ').join('-'),
+      result: (val) => val.toLowerCase().trim().split(' ').join('-'),
     },
   ],
 

--- a/src/lib/prompts.js
+++ b/src/lib/prompts.js
@@ -122,7 +122,7 @@ const prompts = {
         // Workaround for a bug in enquirer that returns the first value of choices when the
         // question is skipped https://github.com/enquirer/enquirer/issues/340 .
         // This returns the previous prompt value if prompt is skipped.
-        this.state.feepayerAlias;
+
         if (!isFeepayerCached) {
           return this.state.answers.feepayer;
         }

--- a/src/lib/prompts.js
+++ b/src/lib/prompts.js
@@ -145,13 +145,21 @@ const prompts = {
         return style('Create an alias for this account');
       },
       validate: async (val) => {
-        val = val.toLowerCase().trim().split(' ').join('-');
+        val
+          .toLowerCase()
+          .trim()
+          .replace(/\s{1,}/g, '-');
+
         if (cachedFeepayerAliases?.includes(val))
           return red(`Fee payer alias ${val} already exists`);
         if (!val) return red('Fee payer alias is required.');
         return true;
       },
-      result: (val) => val.toLowerCase().trim().split(' ').join('-'),
+      result: (val) =>
+        val
+          .toLowerCase()
+          .trim()
+          .replace(/\s{1,}/g, '-'),
     },
     {
       type: 'input',
@@ -183,13 +191,21 @@ const prompts = {
         return style('Create an alias for this account');
       },
       validate: async (val) => {
-        val = val.toLowerCase().trim().split(' ').join('-');
+        val
+          .toLowerCase()
+          .trim()
+          .replace(/\s{1,}/g, '-');
+
         if (cachedFeepayerAliases?.includes(val))
           return red(`Fee payer alias ${val} already exists`);
         if (!val) return red('Fee payer alias is required.');
         return true;
       },
-      result: (val) => val.toLowerCase().trim().split(' ').join('-'),
+      result: (val) =>
+        val
+          .toLowerCase()
+          .trim()
+          .replace(/\s{1,}/g, '-'),
     },
   ],
 

--- a/src/lib/prompts.js
+++ b/src/lib/prompts.js
@@ -26,14 +26,21 @@ const prompts = {
       },
       prefix: formatPrefixSymbol,
       validate: async (val) => {
-        val = val.toLowerCase().trim().replace(' ', '-');
+        val = val
+          .toLowerCase()
+          .trim()
+          .replace(/\s{1,}/g, '-');
         if (!val) return red('Name is required.');
         if (Object.keys(config.deployAliases).includes(val)) {
           return red('Name already exists.');
         }
         return true;
       },
-      result: (val) => val.toLowerCase().trim().replace(' ', '-'),
+      result: (val) =>
+        val
+          .toLowerCase()
+          .trim()
+          .replace(/\s{1,}/g, '-'),
     },
     {
       type: 'input',

--- a/src/lib/prompts.js
+++ b/src/lib/prompts.js
@@ -132,24 +132,27 @@ const prompts = {
   recoverFeepayerPrompts: [
     {
       type: 'input',
+      name: 'feepayerAliasName',
+      message: (state) => {
+        const style = state.submitted && !state.cancelled ? green : reset;
+        return style('Create an alias for this account');
+      },
+      validate: async (val) => {
+        val = val.toLowerCase().trim().replace(' ', '-');
+        if (!val) return red('Fee payer alias is required.');
+        return true;
+      },
+    },
+    {
+      type: 'input',
       name: 'feepayerKey',
       message: (state) => {
         const style = state.submitted && !state.cancelled ? green : reset;
         return style('Account private key (base58):');
       },
-      skip() {
-        return this.state.answers.feepayer !== 'create';
-      },
-      result() {
-        // Workaround for a bug in enquirer that returns the first value of choices when the
-        // question is skipped https://github.com/enquirer/enquirer/issues/340 .
-        // This returns the previous prompt value if prompt is skipped.
-        if (this.state.answers.feepayer !== 'create') {
-          return this.state.answers.feepayer;
-        }
-        return this.focused.value;
-      },
     },
+  ],
+  feepayerAliasPrompt: [
     {
       type: 'input',
       name: 'feepayerAliasName',

--- a/src/lib/prompts.js
+++ b/src/lib/prompts.js
@@ -1,6 +1,70 @@
 const { green, red, bold, gray, reset } = require('chalk');
 
-const prompts = {};
+function formatPrefixSymbol(state) {
+  // Shows a cyan question mark when not submitted.
+  // Shows a green check mark when submitted.
+  // Shows a red "x" if ctrl+C is pressed.
+
+  // Can't override the validating prefix or styling unfortunately
+  // https://github.com/enquirer/enquirer/blob/8d626c206733420637660ac7c2098d7de45e8590/lib/prompt.js#L125
+  // if (state.validating) return ''; // use no symbol, instead of pointer
+
+  if (!state.submitted) return state.symbols.question;
+  return state.cancelled ? red(state.symbols.cross) : state.symbols.check;
+}
+
+const prompts = {
+  deployAliasPrompts: (config) => [
+    {
+      type: 'input',
+      name: 'deployAliasName',
+      message: (state) => {
+        const style = state.submitted && !state.cancelled ? green : reset;
+        return style('Choose a name (can be anything):');
+      },
+      prefix: formatPrefixSymbol,
+      validate: async (val) => {
+        val = val.toLowerCase().trim().replace(' ', '-');
+        if (!val) return red('Name is required.');
+        if (Object.keys(config.deployAliases).includes(val)) {
+          return red('Name already exists.');
+        }
+        return true;
+      },
+      result: (val) => val.toLowerCase().trim().replace(' ', '-'),
+    },
+    {
+      type: 'input',
+      name: 'url',
+      message: (state) => {
+        const style = state.submitted && !state.cancelled ? green : reset;
+        return style('Set the Mina GraphQL API URL to deploy to:');
+      },
+      prefix: formatPrefixSymbol,
+      validate: (val) => {
+        if (!val) return red('Url is required.');
+        return true;
+      },
+      result: (val) => val.trim().replace(/ /, ''),
+    },
+    {
+      type: 'input',
+      name: 'fee',
+      message: (state) => {
+        const style = state.submitted && !state.cancelled ? green : reset;
+        return style('Set transaction fee to use when deploying (in MINA):');
+      },
+      prefix: formatPrefixSymbol,
+      validate: (val) => {
+        if (!val) return red('Fee is required.');
+        if (isNaN(val)) return red('Fee must be a number.');
+        if (val < 0) return red("Fee can't be negative.");
+        return true;
+      },
+      result: (val) => val.trim().replace(/ /, ''),
+    },
+  ],
+};
 module.exports = {
   prompts,
 };

--- a/src/lib/prompts.js
+++ b/src/lib/prompts.js
@@ -143,10 +143,11 @@ const prompts = {
         return style('Create an alias for this account');
       },
       validate: async (val) => {
-        val = val.toLowerCase().trim().replace(' ', '-');
+        val = val.toLowerCase().trim().spilt(' ').join('-');
         if (!val) return red('Fee payer alias is required.');
         return true;
       },
+      result: (val) => val.toLowerCase().trim().spilt(' ').join('-'),
     },
     {
       type: 'input',
@@ -168,10 +169,11 @@ const prompts = {
         return style('Create an alias for this account');
       },
       validate: async (val) => {
-        val = val.toLowerCase().trim().replace(' ', '-');
+        val = val.toLowerCase().trim().spilt(' ').join('-');
         if (!val) return red('Fee payer alias is required.');
         return true;
       },
+      result: (val) => val.toLowerCase().trim().spilt(' ').join('-'),
     },
   ],
 

--- a/src/lib/prompts.js
+++ b/src/lib/prompts.js
@@ -20,7 +20,7 @@ const prompts = {
       name: 'deployAliasName',
       message: (state) => {
         const style = state.submitted && !state.cancelled ? green : reset;
-        return style('Choose a name (can be anything):');
+        return style('Create a name (can be anything):');
       },
       prefix: formatPrefixSymbol,
       validate: async (val) => {
@@ -75,6 +75,27 @@ const prompts = {
       name: 'feepayer',
       choices: [
         {
+          name: `Recover fee-payer account from an existing base58 private key`,
+          value: 'recover',
+        },
+        { name: 'Create a new feepayer key pair', value: 'create' },
+      ],
+      message: (state) => {
+        const style = state.submitted && !state.cancelled ? green : reset;
+        return style('Choose an account to pay transaction fees:');
+      },
+      result() {
+        return this.focused.value;
+      },
+      skip() {
+        return isFeepayerCached; // The prompt is only displayed if a feepayor has not been previously cached
+      },
+    },
+    {
+      type: 'select',
+      name: 'feepayer',
+      choices: [
+        {
           name: `Use stored account ${defaultFeePayerAlias} (public key: ${defaultFeePayerAddress}) `,
           value: 'defaultCache',
         },
@@ -92,27 +113,6 @@ const prompts = {
       },
       skip() {
         return !isFeepayerCached; // Only display this prompt question if feeyper is cached
-      },
-    },
-    {
-      type: 'select',
-      name: 'feepayer',
-      choices: [
-        {
-          name: `Recover fee-payer account from an existing base58 private key`,
-          value: 'recover',
-        },
-        { name: 'Create a new feepayer key pair', value: 'create' },
-      ],
-      message: (state) => {
-        const style = state.submitted && !state.cancelled ? green : reset;
-        return style('Choose an account to pay transaction fees:');
-      },
-      result() {
-        return this.focused.value;
-      },
-      skip() {
-        return isFeepayerCached; // The prompt is only displayed if a feepayor has not been previously cached
       },
     },
   ],

--- a/src/lib/prompts.js
+++ b/src/lib/prompts.js
@@ -1,4 +1,4 @@
-const { green, red, bold, gray, reset } = require('chalk');
+const { green, red, reset } = require('chalk');
 
 function formatPrefixSymbol(state) {
   // Shows a cyan question mark when not submitted.

--- a/src/lib/prompts.js
+++ b/src/lib/prompts.js
@@ -155,7 +155,7 @@ const prompts = {
       name: 'feepayerAliasName',
       message: (state) => {
         const style = state.submitted && !state.cancelled ? green : reset;
-        return style('Choose an alias for this account');
+        return style('Create an alias for this account');
       },
       validate: async (val) => {
         val = val.toLowerCase().trim().replace(' ', '-');

--- a/src/lib/prompts.js
+++ b/src/lib/prompts.js
@@ -64,6 +64,85 @@ const prompts = {
       result: (val) => val.trim().replace(/ /, ''),
     },
   ],
+
+  initialFeepayerPrompts: (
+    defaultFeePayerAlias,
+    defaultFeePayerAddress,
+    isFeepayerCached
+  ) => [
+    {
+      type: 'select',
+      name: 'feepayer',
+      choices: [
+        {
+          name: `Recover fee-payer account from an existing base58 private key`,
+          value: 'recover',
+        },
+        { name: 'Create a new feepayer key pair', value: 'create' },
+      ],
+      message: (state) => {
+        const style = state.submitted && !state.cancelled ? green : reset;
+        return style('Choose an account to pay transaction fees:');
+      },
+      result() {
+        return this.focused.value;
+      },
+      skip() {
+        return isFeepayerCached; // The prompt is only displayed if a feepayor has not been previously cached
+      },
+    },
+
+    {
+      type: 'select',
+      name: 'feepayer',
+      choices: [
+        {
+          name: `Use stored account ${defaultFeePayerAlias} (public key: ${defaultFeePayerAddress}) `,
+          value: 'defaultCache',
+        },
+        {
+          name: 'Use a different account (select to see options)',
+          value: 'other',
+        },
+      ],
+      message: (state) => {
+        const style = state.submitted && !state.cancelled ? green : reset;
+        return style('Choose an account to pay transaction fees:');
+      },
+      result() {
+        return this.focused.value;
+      },
+      skip() {
+        return !isFeepayerCached; // Only display this prompt question if feeyper is cached
+      },
+    },
+  ],
+  recoverFeepayerPrompts: [
+    {
+      type: 'input',
+      name: 'feepayerKey',
+      message: (state) => {
+        const style = state.submitted && !state.cancelled ? green : reset;
+        return style('Account private key (base58):');
+      },
+      skip() {
+        return this.state.answers.feepayer !== 'create';
+      },
+    },
+    {
+      type: 'input',
+      name: 'feepayerAliasName',
+      message: (state) => {
+        const style = state.submitted && !state.cancelled ? green : reset;
+        return style('Choose an alias for this account');
+      },
+      validate: async (val) => {
+        val = val.toLowerCase().trim().replace(' ', '-');
+        if (!val) return red('Fee-payer alias is required.');
+        return true;
+      },
+    },
+  ],
 };
 module.exports = {
   prompts,

--- a/src/lib/prompts.js
+++ b/src/lib/prompts.js
@@ -168,7 +168,49 @@ const prompts = {
       },
     },
   ],
+
+  otherFeepayerPrompts: (cachedFeepayerAliases) => [
+    {
+      type: 'select',
+      name: 'feepayer',
+      choices: getFeepayorChoices(cachedFeepayerAliases),
+      result() {
+        return this.focused.value;
+      },
+    },
+    {
+      type: 'select',
+      name: 'alternateCachedFeepayerAlias',
+      choices: cachedFeepayerAliases,
+      message: (state) => {
+        const style = state.submitted && !state.cancelled ? green : reset;
+        return style('Choose another saved fee payer:');
+      },
+      skip() {
+        return this.state.answers.feepayer !== 'alternateCachedFeepayer';
+      },
+    },
+  ],
 };
+
+function getFeepayorChoices(cachedFeepayerAliases) {
+  const choices = [
+    {
+      name: `Recover fee payer account from an existing base58 private key`,
+      value: 'recover',
+    },
+    { name: 'Create a new fee payer key pair', value: 'create' },
+  ];
+
+  // Displays an additional prompt to select a different feepayer if more than one feepayer is cached
+  if (cachedFeepayerAliases?.length > 1)
+    choices.push({
+      name: 'Choose another saved fee payer',
+      value: 'alternateCachedFeepayer',
+    });
+
+  return choices;
+}
 module.exports = {
   prompts,
 };

--- a/src/lib/prompts.js
+++ b/src/lib/prompts.js
@@ -136,7 +136,7 @@ const prompts = {
       },
     },
   ],
-  recoverFeepayerPrompts: [
+  recoverFeepayerPrompts: (cachedFeepayerAliases) => [
     {
       type: 'input',
       name: 'feepayerAliasName',
@@ -146,6 +146,8 @@ const prompts = {
       },
       validate: async (val) => {
         val = val.toLowerCase().trim().split(' ').join('-');
+        if (cachedFeepayerAliases.includes(val))
+          return red(`Fee payer alias ${val} already exists`);
         if (!val) return red('Fee payer alias is required.');
         return true;
       },
@@ -172,7 +174,7 @@ const prompts = {
       result: (val) => val.trim(),
     },
   ],
-  feepayerAliasPrompt: [
+  feepayerAliasPrompt: (cachedFeepayerAliases) => [
     {
       type: 'input',
       name: 'feepayerAliasName',
@@ -182,6 +184,8 @@ const prompts = {
       },
       validate: async (val) => {
         val = val.toLowerCase().trim().split(' ').join('-');
+        if (cachedFeepayerAliases.includes(val))
+          return red(`Fee payer alias ${val} already exists`);
         if (!val) return red('Fee payer alias is required.');
         return true;
       },

--- a/templates/project-ts/src/interact.ts
+++ b/templates/project-ts/src/interact.ts
@@ -40,10 +40,16 @@ type Config = {
 };
 let configJson: Config = JSON.parse(await fs.readFile('config.json', 'utf8'));
 let config = configJson.deployAliases[deployAlias];
-let key: { privateKey: string } = JSON.parse(
+let feepayerKeyBase58: { privateKey: string } = JSON.parse(
+  await fs.readFile(config.feepayerKeyPath, 'utf8')
+).privateKey;
+
+let zkAppKeyBase58: { privateKey: string } = JSON.parse(
   await fs.readFile(config.keyPath, 'utf8')
-);
-let zkAppKey = PrivateKey.fromBase58(key.privateKey);
+).privateKey;
+
+let feepayerKey = PrivateKey.fromBase58(feepayerKeyBase58.privateKey);
+let zkAppKey = PrivateKey.fromBase58(zkAppKeyBase58.privateKey);
 
 // set up Mina instance and contract we interact with
 const Network = Mina.Network(config.url);

--- a/templates/project-ts/src/interact.ts
+++ b/templates/project-ts/src/interact.ts
@@ -69,7 +69,7 @@ let tx = await Mina.transaction({ sender: feepayerAddress, fee: 0.1e9 }, () => {
 });
 await tx.prove();
 console.log('send transaction...');
-let sentTx = await tx.sign([zkAppKey]).send();
+let sentTx = await tx.sign([feepayerKey]).send();
 
 if (sentTx.hash() !== undefined) {
   console.log(`

--- a/templates/project-ts/src/interact.ts
+++ b/templates/project-ts/src/interact.ts
@@ -40,20 +40,21 @@ type Config = {
 };
 let configJson: Config = JSON.parse(await fs.readFile('config.json', 'utf8'));
 let config = configJson.deployAliases[deployAlias];
-let feepayerKeyBase58: { privateKey: string } = JSON.parse(
+let feepayerKeysBase58: { privateKey: string } = JSON.parse(
   await fs.readFile(config.feepayerKeyPath, 'utf8')
-).privateKey;
+);
 
-let zkAppKeyBase58: { privateKey: string } = JSON.parse(
+let zkAppKeysBase58: { privateKey: string } = JSON.parse(
   await fs.readFile(config.keyPath, 'utf8')
-).privateKey;
+);
 
-let feepayerKey = PrivateKey.fromBase58(feepayerKeyBase58.privateKey);
-let zkAppKey = PrivateKey.fromBase58(zkAppKeyBase58.privateKey);
+let feepayerKey = PrivateKey.fromBase58(feepayerKeysBase58.privateKey);
+let zkAppKey = PrivateKey.fromBase58(zkAppKeysBase58.privateKey);
 
 // set up Mina instance and contract we interact with
 const Network = Mina.Network(config.url);
 Mina.setActiveInstance(Network);
+let feepayerAddress = feepayerKey.toPublicKey();
 let zkAppAddress = zkAppKey.toPublicKey();
 let zkApp = new Add(zkAppAddress);
 
@@ -63,7 +64,7 @@ await Add.compile();
 
 // call update() and send transaction
 console.log('build transaction and create proof...');
-let tx = await Mina.transaction({ sender: zkAppAddress, fee: 0.1e9 }, () => {
+let tx = await Mina.transaction({ sender: feepayerAddress, fee: 0.1e9 }, () => {
   zkApp.update();
 });
 await tx.prove();

--- a/templates/project-ts/src/interact.ts
+++ b/templates/project-ts/src/interact.ts
@@ -60,20 +60,23 @@ let feepayerAddress = feepayerKey.toPublicKey();
 let zkAppAddress = zkAppKey.toPublicKey();
 let zkApp = new Add(zkAppAddress);
 
+let sentTx;
 // compile the contract to create prover keys
 console.log('compile the contract...');
 await Add.compile();
-
-// call update() and send transaction
-console.log('build transaction and create proof...');
-let tx = await Mina.transaction({ sender: feepayerAddress, fee }, () => {
-  zkApp.update();
-});
-await tx.prove();
-console.log('send transaction...');
-let sentTx = await tx.sign([feepayerKey]).send();
-
-if (sentTx.hash() !== undefined) {
+try {
+  // call update() and send transaction
+  console.log('build transaction and create proof...');
+  let tx = await Mina.transaction({ sender: feepayerAddress, fee }, () => {
+    zkApp.update();
+  });
+  await tx.prove();
+  console.log('send transaction...');
+  sentTx = await tx.sign([feepayerKey]).send();
+} catch (err) {
+  console.log(err);
+}
+if (sentTx?.hash() !== undefined) {
   console.log(`
 Success! Update transaction sent.
 

--- a/templates/project-ts/src/interact.ts
+++ b/templates/project-ts/src/interact.ts
@@ -28,7 +28,15 @@ Error.stackTraceLimit = 1000;
 
 // parse config and private key from file
 type Config = {
-  deployAliases: Record<string, { url: string; keyPath: string }>;
+  deployAliases: Record<
+    string,
+    {
+      url: string;
+      keyPath: string;
+      feepayerKeyPath: string;
+      feepayerAliasName: string;
+    }
+  >;
 };
 let configJson: Config = JSON.parse(await fs.readFile('config.json', 'utf8'));
 let config = configJson.deployAliases[deployAlias];

--- a/templates/project-ts/src/interact.ts
+++ b/templates/project-ts/src/interact.ts
@@ -34,7 +34,7 @@ type Config = {
       url: string;
       keyPath: string;
       feepayerKeyPath: string;
-      feepayerAliasName: string;
+      feepayerAlias: string;
     }
   >;
 };


### PR DESCRIPTION
closes #129 #429 #435 

### Background

Currently, the zkApp cli creates a keypair for the zkApp account after running the `zk config` command.  The cli assumes that this zkApp account has funds to pay fees, and uses it as fee payer. 
 
There are two reasons why the flow above is insufficient:

**Incompatible with permissions**  
- A zkApp is deployed with `send: proof` permissions by default which means you need to provide a proof (of running a smart contract method) as authorization to send MINA away from the zkApp account. 
- A fee payer tries to pay the fee using signature authorization (proofs are not supported). If the zkApp account is used as fee payer after deployment, the transaction will get rejected because the permissions of the account will be violated. This currently breaks all re-deployments and the `interact.ts` script in the template project.

**Unnecessary work to fund zkApp**
- Having to fund each zkApp account before deploying, just for using it to pay fees, is cumbersome. 
- It would save time to just have a developer account, which is funded and can always pay fees immediately.

### Approach

After entering `zk config`, new steps are added to create or select a fee payer account. 

```
✔ Create a name (can be anything): · berkeley
✔ Set the Mina GraphQL API URL to deploy to: · https://proxy.berkeley.minaexplorer.com/graphql
✔ Set transaction fee to use when deploying (in MINA): · .1
? Choose an account to pay transaction fees: …
❯ Recover fee payer account from an existing base58 private key
  Create a new fee payer key pair
```
The first time a user enters `zk config`, they will be shown two option prompts.

```
❯ Recover fee payer account from an existing base58 private key
  Create a new fee payer key pair
```

After selecting one of these options, there is an additional step to add an alias for this fee payer account.

`? Create an alias for this account : `  

This base58 private key can be exported from a wallet or from any other existing account.

Every other time a use runs `zk config`,  an option will be shown to use a stored account as a fee payer and an option to use a different account. 

```
❯ Use stored account dev (public key: B62qkw6ZCxKgMkxegegq8Z6mGibvsMUc5TopqwztpkseU7n2cDF4iEo)
  Use a different account (select to see options)
```

If a user selects to use a different account they will see the previous options to recover a fee payor account or create a new one.

```
  Recover fee-payer account from an existing base58 private key
❯ Create a new fee payer key pair
```
 
If a user has more than one fee payor account stored on their machine, an additional option is shown to choose another saved fee payer

```
   Recover fee-payer account from an existing base58 private key
   Create a new fee payer key pair
  ❯ Choose another saved fee payer
```

```
? Choose another saved fee payer: …
❯ berkeley
  dev
  mainnet
```

The fee payer alias and corresponding keypair is stored globally on a users machine in the form of `<os specific cache directory>/zkapp-cli/keys/<fee payor alias>.json`. These fee payer accounts can be used across multiple projects.

The `feepayerKeyPath` and `feepayerAliasName` are also added to the `config.json`.
```
{

  "version": 1,
  "deployAliases": {
    "berkeley": {
      "url": "https://berkeley.minascan.io/graphql",
      "keyPath": "keys/berkeley.json",
      "feepayerKeyPath": "<os specific cache directory>/zkapp-cli/keys/dev.json",
      "feepayerAliasName": "dev",
      "fee": ".1"
    }
  }
}
```
The `interact.ts` script from the template was also updated to work with the third party fee payer.


See the discussion for [more details](https://github.com/o1-labs/zkapp-cli/issues/129).