### PR TITLE
CLI Release 0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Update SnarkyJS cli minor version dependancy and template peer dependency to `0.11.*` [#426](https://github.com/o1-labs/zkapp-cli/pull/426)
+- Release `0.9.0` [#426](https://github.com/o1-labs/zkapp-cli/pull/426)
+ - SnarkyJS minor version dependency updated in cli package.json to 0.11.*.
+ - SnarkyJS minor version peer dependency updated in template/example contract package.json to 0.11.*.
+ - Replace deprecated `Circuit.if` with `Provable.if` in the `tictactoe` example.
+ - Replace deprecated `Circuit.array` with `Provable.Array` in the `sudoku` example.
 
 ## [0.8.2] - 2023-05-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.8.2] - 2023-05-12
-
-- Clean up deploy and log full errors to the console. [#408](https://github.com/o1-labs/zkapp-cli/pull/408)
+## [0.9.0] - 2023-06-06
 
 ### Changed
+
+- Update SnarkyJS cli minor version dependancy and template peer dependency to `0.11.*` [#426](https://github.com/o1-labs/zkapp-cli/pull/426)
+
+## [0.8.2] - 2023-05-12
+
+### Changed
+
+- Clean up deploy and log full errors to the console. [#408](https://github.com/o1-labs/zkapp-cli/pull/408)
 
 ## [0.8.1] - 2023-05-03
 

--- a/examples/sudoku/ts/src/sudoku.ts
+++ b/examples/sudoku/ts/src/sudoku.ts
@@ -7,13 +7,13 @@ import {
   State,
   Poseidon,
   Struct,
-  Circuit,
+  Provable,
 } from 'snarkyjs';
 
 export { Sudoku, SudokuZkApp };
 
 class Sudoku extends Struct({
-  value: Circuit.array(Circuit.array(Field, 9), 9),
+  value: Provable.Array(Provable.Array(Field, 9), 9),
 }) {
   static from(value: number[][]) {
     return new Sudoku({ value: value.map((row) => row.map(Field)) });

--- a/examples/tictactoe/ts/src/tictactoe.ts
+++ b/examples/tictactoe/ts/src/tictactoe.ts
@@ -12,22 +12,27 @@ import {
   Bool,
   Provable,
   Signature,
+  Struct,
 } from 'snarkyjs';
 
 export { Board, TicTacToe };
 
-class Optional<T> {
-  isSome: Bool;
-  value: T;
+function Optional<T>(type: Provable<T>) {
+  return class Optional_ extends Struct({ isSome: Bool, value: type }) {
+    constructor(isSome: boolean | Bool, value: T) {
+      super({ isSome: Bool(isSome), value });
+    }
 
-  constructor(isSome: Bool, value: T) {
-    this.isSome = isSome;
-    this.value = value;
-  }
+    toFields() {
+      return Optional_.toFields(this);
+    }
+  };
 }
 
+class OptionalBool extends Optional(Bool) {}
+
 class Board {
-  board: Optional<Bool>[][];
+  board: OptionalBool[][];
 
   constructor(serializedBoard: Field) {
     const bits = serializedBoard.toBits(18);
@@ -37,7 +42,7 @@ class Board {
       for (let j = 0; j < 3; j++) {
         const isPlayed = bits[i * 3 + j];
         const player = bits[i * 3 + j + 9];
-        row.push(new Optional(isPlayed, player));
+        row.push(new OptionalBool(isPlayed, player));
       }
       board.push(row);
     }
@@ -68,7 +73,7 @@ class Board {
         // copy the board (or update if this is the cell the player wants to play)
         this.board[i][j] = Provable.if(
           toUpdate,
-          new Optional(new Bool(true), playerToken),
+          new OptionalBool(true, playerToken),
           this.board[i][j]
         );
       }

--- a/examples/tictactoe/ts/src/tictactoe.ts
+++ b/examples/tictactoe/ts/src/tictactoe.ts
@@ -10,7 +10,7 @@ import {
   state,
   method,
   Bool,
-  Circuit,
+  Provable,
   Signature,
 } from 'snarkyjs';
 
@@ -66,7 +66,7 @@ class Board {
         toUpdate.and(this.board[i][j].isSome).assertEquals(false);
 
         // copy the board (or update if this is the cell the player wants to play)
-        this.board[i][j] = Circuit.if(
+        this.board[i][j] = Provable.if(
           toUpdate,
           new Optional(new Bool(true), playerToken),
           this.board[i][j]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zkapp-cli",
-  "version": "0.8.2",
+  "version": "0.9.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "zkapp-cli",
-      "version": "0.8.2",
+      "version": "0.9.0",
       "license": "Apache-2.0",
       "dependencies": {
         "chalk": "^4.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "mina-signer": "^1.1.0",
         "ora": "^5.4.1",
         "shelljs": "^0.8.5",
-        "snarkyjs": "0.10.*",
+        "snarkyjs": "0.11.*",
         "table": "^6.8.0",
         "yargs": "^17.5.1"
       },
@@ -6026,9 +6026,9 @@
       }
     },
     "node_modules/snarkyjs": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/snarkyjs/-/snarkyjs-0.10.0.tgz",
-      "integrity": "sha512-YFvMMUUfcStBrIkDVUhg6lgV7FYZ1y+FX6pRysHlSomytCJ8/QeapTXkF/4oQGNiFemgbTLdr6E/wzsdtoLfyg==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/snarkyjs/-/snarkyjs-0.11.0.tgz",
+      "integrity": "sha512-RM35YPGJY5ssWJcKjTYH+5NBwP3CigHPBNKV3sgYiHANAdi9NturBI3Z1tcNgXOFRZrIEfldwjPDBJvUDjmSWw==",
       "dependencies": {
         "blakejs": "1.2.1",
         "detect-gpu": "^5.0.5",
@@ -11282,9 +11282,9 @@
       }
     },
     "snarkyjs": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/snarkyjs/-/snarkyjs-0.10.0.tgz",
-      "integrity": "sha512-YFvMMUUfcStBrIkDVUhg6lgV7FYZ1y+FX6pRysHlSomytCJ8/QeapTXkF/4oQGNiFemgbTLdr6E/wzsdtoLfyg==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/snarkyjs/-/snarkyjs-0.11.0.tgz",
+      "integrity": "sha512-RM35YPGJY5ssWJcKjTYH+5NBwP3CigHPBNKV3sgYiHANAdi9NturBI3Z1tcNgXOFRZrIEfldwjPDBJvUDjmSWw==",
       "requires": {
         "blakejs": "1.2.1",
         "detect-gpu": "^5.0.5",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "mina-signer": "^1.1.0",
     "ora": "^5.4.1",
     "shelljs": "^0.8.5",
-    "snarkyjs": "0.10.*",
+    "snarkyjs": "0.11.*",
     "table": "^6.8.0",
     "yargs": "^17.5.1"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zkapp-cli",
-  "version": "0.8.2",
+  "version": "0.9.0",
   "description": "CLI to create a zkApp (\"zero-knowledge app\") for Mina Protocol.",
   "keywords": [
     "cli",

--- a/templates/project-ts/package.json
+++ b/templates/project-ts/package.json
@@ -45,6 +45,8 @@
     "typescript": "^4.7.2"
   },
   "peerDependencies": {
-    "snarkyjs": "0.10.*"
+    "snarkyjs": "0.11.*"
   }
 }
+
+


### PR DESCRIPTION
Closes #425 

This PR is the corresponding zkApp cli release to the SnarkyJS release of [version 0.11.0](https://github.com/o1-labs/snarkyjs/pull/938/).

- SnarkyJS minor version dependency updated in cli package.json to 0.11.*.
- SnarkyJS minor version peer dependency updated in template/example contract package.json to 0.11.*.
- Replace deprecated `Circuit.if` with `Provable.if` in the `tictactoe` example.
- Replace deprecated `Circuit.array` with `Provable.Array` in the `sudoku` example.

**Tested**

This was tested by generating projects with various cli flows. The template [add](https://berkeley.minaexplorer.com/transaction/5JuTv2pbkwpyZyJ739xEoc9uxAnbe3MMGUmZVnwthr6WM9wwPPX3) contract, [sudoku](https://berkeley.minaexplorer.com/transaction/5JuLmfBCHsyLERT49MAWoBsyw8nqpWxsRZPsXCM2nhsqYq4zdjZu), and [tictactoe](https://berkeley.minaexplorer.com/transaction/5Ju1v26HeZB2xW92tVx7a4oXjfEmZW5mdurL3iqcfmCqbC5Rf6Fm) examples were all successfully deployed.