### PR TITLE
Streamline process to deploy to Github Pages

### DIFF
--- a/src/lib/project.js
+++ b/src/lib/project.js
@@ -605,7 +605,7 @@ async function scaffoldNext(projectName) {
       isWindows
         ? `type nul > ${path.join('out', '.nojekyll')}`
         : `touch ${path.join('out', '.nojekyll')}`
-    }  && git add -f out && git commit -m "Deploy gh-pages" && cd .. && git subtree push --prefix ui/out origin gh-pages`;
+    } && node ./ghp-postbuild && git add -f out && git commit -m "Deploy gh-pages" && cd .. && git subtree push --prefix ui/out origin gh-pages`;
     x.scripts['deploy'] = deployScript;
     fs.writeJSONSync(path.join('ui', 'package.json'), x, { spaces: 2 });
 

--- a/src/lib/project.js
+++ b/src/lib/project.js
@@ -678,8 +678,13 @@ loadCOIServiceWorker();
 `
     );
 
-   let ghpPostInstallScript = fs.readFileSync(path.join(__dirname, 'ui', 'next', 'ghp-postbuild.js')); 
-   ghpPostInstallScript = ghpPostInstallScript.replace(`let repoURL = '';`, `let repoURL = ${projectName};`)
+   let ghpPostInstallScript = fs.readFileSync(path.join(__dirname, 'ui', 'next', 'ghp-postbuild.js'),'utf8'); 
+   ghpPostInstallScript = ghpPostInstallScript.replace(`let repoURL = '';`, `let repoURL = ${projectName};`);
+
+   fs.writeFileSync(
+    path.join('ui', 'next', 'ghp-postbuild.js'),
+    ghpPostInstallScript
+   );
 
   }
 }

--- a/src/lib/project.js
+++ b/src/lib/project.js
@@ -677,6 +677,9 @@ function loadCOIServiceWorker() {
 loadCOIServiceWorker();
 `
     );
+    
+   let ghpPostInstallScript = fs.readFileSync(path.join(__dirname, 'ui', 'next', 'ghp-postbuild.js')); 
+  
   }
 }
 

--- a/src/lib/project.js
+++ b/src/lib/project.js
@@ -677,9 +677,10 @@ function loadCOIServiceWorker() {
 loadCOIServiceWorker();
 `
     );
-    
+
    let ghpPostInstallScript = fs.readFileSync(path.join(__dirname, 'ui', 'next', 'ghp-postbuild.js')); 
-  
+   ghpPostInstallScript = ghpPostInstallScript.replace(`let repoURL = '';`, `let repoURL = ${projectName};`)
+
   }
 }
 

--- a/src/lib/ui/next/ghp-postbuild.js
+++ b/src/lib/ui/next/ghp-postbuild.js
@@ -1,0 +1,35 @@
+const fs = require('fs');
+const path = require('path');
+
+// This script modifies the built CSS files and prepends the repo-name to the asset URLs.
+// to be compatible with github pages deployment.
+const cssDir = path.join(__dirname, '/.next/static/css');
+// Add your repository name here.
+let repoURL = '';
+fs.readdir(cssDir, (err, files) => {
+  if (err) {
+    console.error(err);
+    process.exit(1);
+  }
+
+  files.forEach(file => {
+    if (path.extname(file) === '.css') {
+      const filePath = path.join(cssDir, file);
+      fs.readFile(filePath, 'utf8', (err, data) => {
+        if (err) {
+          console.error(err);
+          process.exit(1);
+        }
+        
+        const result = data.replace(/url\(\//g, `url(/${repoURL}/`);
+
+        fs.writeFile(filePath, result, 'utf8', err => {
+          if (err) {
+            console.error(err);
+            process.exit(1);
+          }
+        });
+      });
+    }
+  });
+});


### PR DESCRIPTION
Closes
#467 

**Problem**

Currently a user needs to manually modify their CSS asset urls for them to work with GitHub Pages deployment.

**Solution**

Add a post build script to prepend css asset URLs with the projects repo name so they are correctly deployed to GitHub Pages. The post build script is run along with other GitHub Pages deployment steps when a user enters `npm run deploy` in a UI project.