### PR TITLE
Remove Husky configuration from UI project scaffold generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.13.1] - 2023-10-20
+## [0.13.2] - 2023-10-22
+
+### Changed
+
+- The husky pre-commit hooks configuration steps during project generation with an accompanying UI project were removed. [#507](https://github.com/o1-labs/zkapp-cli/pull/507).
+
+## [0.13.1] - 2022-10-20
 
 ### Changed
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zkapp-cli",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "zkapp-cli",
-      "version": "0.13.1",
+      "version": "0.13.2",
       "license": "Apache-2.0",
       "dependencies": {
         "chalk": "^5.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zkapp-cli",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "description": "CLI to create zkApps (zero-knowledge apps) for Mina Protocol",
   "homepage": "https://github.com/o1-labs/zkapp-cli/",
   "keywords": [

--- a/src/lib/example.js
+++ b/src/lib/example.js
@@ -54,8 +54,6 @@ export async function example(example) {
   // Set dir for shell commands. Doesn't change user's dir in their CLI.
   shell.cd(dir);
 
-  // Git must be initialized before running `npm install` b/c Husky runs an
-  // NPM `prepare` script to set up its pre-commit hook within `.git`.
   if (!shell.which('git')) {
     console.error(chalk.red('Please ensure Git is installed, then try again.'));
     return;
@@ -63,7 +61,6 @@ export async function example(example) {
 
   await step('Initialize Git repo', 'git init -q');
 
-  // `/dev/null` on linux or 'NUL' on windows is the only way to silence Husky's install log msg.
   await step(
     'NPM install',
     `npm install --silent > ${isWindows ? 'NUL' : '"/dev/null" 2>&1'}`
@@ -72,7 +69,6 @@ export async function example(example) {
   // process.cwd() is full path to user's terminal + path/to/name.
   await setProjectName(process.cwd());
 
-  // `-n` (no verify) skips Husky's pre-commit hooks.
   await step(
     'Git init commit',
     'git add . && git commit -m "Init commit" -q -n && git branch -m main'

--- a/src/lib/project.js
+++ b/src/lib/project.js
@@ -35,9 +35,6 @@ export async function project({ name, ui }) {
     return;
   }
 
-  // Git must be initialized before running `npm install` b/c Husky runs an
-  // NPM `prepare` script to set up its pre-commit hook within `.git`.
-  // Check before fetching project template, to not leave crud on user's system.
   if (!shell.which('git')) {
     console.error(chalk.red('Please ensure Git is installed, then try again.'));
     return;
@@ -138,7 +135,6 @@ export async function project({ name, ui }) {
 
   if (ui) shell.cd('..'); // back to project root
 
-  // `-n` (no verify) skips Husky's pre-commit hooks.
   await step(
     'Git init commit',
     'git add . && git commit -m "Init commit" -q -n && git branch -m main'

--- a/src/lib/project.js
+++ b/src/lib/project.js
@@ -126,30 +126,6 @@ export async function project({ name, ui }) {
   }
   if (!(await fetchProjectTemplate())) return;
 
-  // Make Husky work if using a monorepo. It needs some changes to work when
-  // .git lives one dir level above package.json. Note that Husky's pre-commit
-  // checks only apply to the contracts project, not to the UI, unless the dev
-  // set that up themselves. It's more valuable for the smart contract.
-  // Source: https://github.com/typicode/husky/issues/348#issuecomment-899344732
-  if (ui) {
-    // https://github.com/o1-labs/zkapp-cli/blob/main/templates/project-ts/package.json#L20
-    let x = fs.readJsonSync(`package.json`);
-    x.scripts.prepare = `cd .. && husky install ${path.join(
-      'contracts',
-      '.husky'
-    )}`;
-    fs.writeJSONSync(`package.json`, x, { spaces: 2 });
-
-    // https://github.com/o1-labs/zkapp-cli/blob/main/templates/project-ts/.husky/pre-commit#L3
-    let y = fs.readFileSync(`${path.join('.husky', 'pre-commit')}`, 'utf-8');
-    const targetStr = 'husky.sh"\n';
-    y = y.replace(targetStr, targetStr + '\ncd contracts');
-    fs.writeFileSync(`${path.join('.husky', 'pre-commit')}`, y, 'utf-8');
-  }
-
-  // `/dev/null` on Mac or Linux and 'NUL' on Windows is the only way to silence
-  // Husky's install log msg.
-
   await step(
     'NPM install',
     `npm install --silent > ${isWindows ? 'NUL' : '"/dev/null" 2>&1'}`


### PR DESCRIPTION
**Description**
Closes #506 

This PR removes husky pre-commit hooks configuration steps during project generation with an accompanying UI project. The husky pre-commit hooks were removed from the project templates in this [PR](https://github.com/o1-labs/zkapp-cli/pull/505)

**Tested**

This was tested using the complete end to end testing suite using `npm run e2e:test` .