### PR TITLE
Change the explorer link to respect different networks.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.14.1] - 2023-11-03
+
+### Changed
+
+- Explorer links for deployment and interaction transactions. [#516](https://github.com/o1-labs/zkapp-cli/pull/516)
+
 ## [0.14.0] - 2023-10-31
 
 ### Changed
@@ -25,7 +31,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - This PR removes Husky and the pre-commit hooks from the project templates to remove friction and create a better DX when building zkApps. [#505](https://github.com/o1-labs/zkapp-cli/pull/505).
 
-
 ## [0.13.0] - 2023-09-14
 
 ### Changed
@@ -40,7 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Both local and global installed versions are checked to determine if an update of the zkApp-cli is necessary[#448](https://github.com/o1-labs/zkapp-cli/pull/448).
 
-### Fixed 
+### Fixed
 
 - Fix to allow the zkApp-cli to be used from a projects local node_modules[#448](https://github.com/o1-labs/zkapp-cli/pull/448).
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zkapp-cli",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "CLI to create zkApps (zero-knowledge apps) for Mina Protocol",
   "homepage": "https://github.com/o1-labs/zkapp-cli/",
   "keywords": [

--- a/src/lib/deploy.js
+++ b/src/lib/deploy.js
@@ -207,10 +207,10 @@ export async function deploy({ alias, yes }) {
   }
   let { PrivateKey, Mina, AccountUpdate } = await import(o1jsImportPath);
 
-  const graphQLUrl = config.deployAliases[alias]?.url ?? DEFAULT_GRAPHQL;
+  const graphQlUrl = config.deployAliases[alias]?.url ?? DEFAULT_GRAPHQL;
 
   const { data: nodeStatus } = await sendGraphQL(
-    graphQLUrl,
+    graphQlUrl,
     `query {
       syncStatus
     }`
@@ -360,7 +360,7 @@ export async function deploy({ alias, yes }) {
 
   const feepayerAddressBase58 = feepayerAddress.toBase58();
   const accountQuery = getAccountQuery(feepayerAddressBase58);
-  const accountResponse = await sendGraphQL(graphQLUrl, accountQuery);
+  const accountResponse = await sendGraphQL(graphQlUrl, accountQuery);
 
   if (!accountResponse?.data?.account) {
     // No account is found, show an error message and return early
@@ -375,7 +375,7 @@ export async function deploy({ alias, yes }) {
   }
 
   let transaction = await step('Build transaction', async () => {
-    let Network = Mina.Network(graphQLUrl);
+    let Network = Mina.Network(graphQlUrl);
     Mina.setActiveInstance(Network);
     let tx = await Mina.transaction({ sender: feepayerAddress, fee }, () => {
       AccountUpdate.fundNewAccount(feepayerAddress);
@@ -468,7 +468,7 @@ export async function deploy({ alias, yes }) {
   const txn = await step('Send to network', async () => {
     const zkAppMutation = sendZkAppQuery(transactionJson);
     try {
-      return await sendGraphQL(graphQLUrl, zkAppMutation);
+      return await sendGraphQL(graphQlUrl, zkAppMutation);
     } catch (error) {
       return error;
     }
@@ -487,21 +487,21 @@ export async function deploy({ alias, yes }) {
     `\nNext step:` +
     `\n  Your smart contract will be live (or updated)` +
     `\n  as soon as the transaction is included in a block:` +
-    `\n  ${getTxnUrl(graphQLUrl, txn)}`;
+    `\n  ${getTxnUrl(graphQlUrl, txn)}`;
 
   log(chalk.green(str));
   process.exit(0);
 }
 
 // Get the specified blockchain explorer url with txn hash
-function getTxnUrl(graphQLUrl, txn) {
-  const explorerName = new URL(graphQLUrl).hostname
+function getTxnUrl(graphQlUrl, txn) {
+  const txnBroadcastServiceName = new URL(graphQlUrl).hostname
     .split('.')
     .filter((item) => item === 'minascan' || item === 'minaexplorer')?.[0];
-  const networkName = new URL(graphQLUrl).hostname
+  const networkName = new URL(graphQlUrl).hostname
     .split('.')
     .filter((item) => item === 'berkeley' || item === 'testworld')?.[0];
-  if (explorerName && networkName) {
+  if (txnBroadcastServiceName && networkName) {
     return `https://minascan.io/${networkName}/tx/${txn.data.sendZkapp.zkapp.hash}?type=zk-tx`;
   }
   return `Transaction hash: ${txn.data.sendZkapp.zkapp.hash}`;

--- a/src/lib/deploy.js
+++ b/src/lib/deploy.js
@@ -495,30 +495,16 @@ export async function deploy({ alias, yes }) {
 
 // Get the specified blockchain explorer url with txn hash
 function getTxnUrl(graphQLUrl, txn) {
-  const MINASCAN_BASE_URL = `https://minascan.io/berkeley/zk-transaction/`;
-  const MINA_EXPLORER_BASE_URL = `https://berkeley.minaexplorer.com/transaction/`;
-  const explorers = [MINASCAN_BASE_URL, MINA_EXPLORER_BASE_URL];
-  const randomExplorersIndex = Math.floor(Math.random() * explorers.length);
-
   const explorerName = new URL(graphQLUrl).hostname
     .split('.')
     .filter((item) => item === 'minascan' || item === 'minaexplorer')?.[0];
-  let txnBaseUrl;
-
-  switch (explorerName) {
-    case 'minascan':
-      txnBaseUrl = MINASCAN_BASE_URL;
-      break;
-    case 'minaexplorer':
-      txnBaseUrl = MINA_EXPLORER_BASE_URL;
-      break;
-    default:
-      // An explorer will be randomly selected from the available explorers if the developer doesn't specify
-      txnBaseUrl = explorers[randomExplorersIndex];
-      break;
+  const networkName = new URL(graphQLUrl).hostname
+    .split('.')
+    .filter((item) => item === 'berkeley' || item === 'testworld')?.[0];
+  if (explorerName && networkName) {
+    return `https://minascan.io/${networkName}/tx/${txn.data.sendZkapp.zkapp.hash}?type=zk-tx`;
   }
-
-  return `${txnBaseUrl}${txn.data.sendZkapp.zkapp.hash}`;
+  return `Transaction hash: ${txn.data.sendZkapp.zkapp.hash}`;
 }
 
 // Query npm registry to get the latest CLI version.

--- a/templates/project-ts/src/interact.ts
+++ b/templates/project-ts/src/interact.ts
@@ -87,13 +87,13 @@ ${getTxnUrl(config.url, sentTx.hash())}
 }
 
 function getTxnUrl(graphQlUrl: string, txnHash: string | undefined) {
-  const explorerName = new URL(graphQlUrl).hostname
+  const txnBroadcastServiceName = new URL(graphQlUrl).hostname
     .split('.')
     .filter((item) => item === 'minascan' || item === 'minaexplorer')?.[0];
   const networkName = new URL(graphQlUrl).hostname
     .split('.')
     .filter((item) => item === 'berkeley' || item === 'testworld')?.[0];
-  if (explorerName && networkName) {
+  if (txnBroadcastServiceName && networkName) {
     return `https://minascan.io/${networkName}/tx/${txnHash}?type=zk-tx`;
   }
   return `Transaction hash: ${txnHash}`;

--- a/templates/project-ts/src/interact.ts
+++ b/templates/project-ts/src/interact.ts
@@ -12,8 +12,8 @@
  * Build the project: `$ npm run build`
  * Run with node:     `$ node build/src/interact.js <deployAlias>`.
  */
-import { Mina, PrivateKey } from 'o1js';
 import fs from 'fs/promises';
+import { Mina, PrivateKey } from 'o1js';
 import { Add } from './Add.js';
 
 // check command line arg
@@ -82,6 +82,6 @@ Success! Update transaction sent.
 
 Your smart contract state will be updated
 as soon as the transaction is included in a block:
-https://berkeley.minaexplorer.com/transaction/${sentTx.hash()}
+Transaction hash: ${sentTx.hash()}
 `);
 }

--- a/templates/project-ts/src/interact.ts
+++ b/templates/project-ts/src/interact.ts
@@ -82,6 +82,19 @@ Success! Update transaction sent.
 
 Your smart contract state will be updated
 as soon as the transaction is included in a block:
-Transaction hash: ${sentTx.hash()}
+${getTxnUrl(config.url, sentTx.hash())}
 `);
+}
+
+function getTxnUrl(graphQlUrl: string, txnHash: string | undefined) {
+  const explorerName = new URL(graphQlUrl).hostname
+    .split('.')
+    .filter((item) => item === 'minascan' || item === 'minaexplorer')?.[0];
+  const networkName = new URL(graphQlUrl).hostname
+    .split('.')
+    .filter((item) => item === 'berkeley' || item === 'testworld')?.[0];
+  if (explorerName && networkName) {
+    return `https://minascan.io/${networkName}/tx/${txnHash}?type=zk-tx`;
+  }
+  return `Transaction hash: ${txnHash}`;
 }

--- a/tests/cli/interact.spec.ts
+++ b/tests/cli/interact.spec.ts
@@ -144,10 +144,11 @@ async function checkZkAppInteraction(
   exitCode: ExitCode | null,
   stdOut: string[]
 ): Promise<void> {
-  const blockchainExplorerLink =
+  let blockchainExplorerLink =
     stdOut.at(-1)!.trim().length === 0
       ? stdOut.at(-2)!.trim()
       : stdOut.at(-1)!.trim();
+  blockchainExplorerLink = blockchainExplorerLink.split('?')[0];
   const transactionHash = blockchainExplorerLink.substring(
     blockchainExplorerLink.length - 52
   );

--- a/tests/utils/deploy-utils.ts
+++ b/tests/utils/deploy-utils.ts
@@ -107,10 +107,11 @@ export async function checkZkDeploy(
   exitCode: ExitCode | null,
   stdOut: string[]
 ): Promise<void> {
-  const blockchainExplorerLink =
+  let blockchainExplorerLink =
     stdOut.at(-1)!.trim().length === 0
       ? stdOut.at(-2)!.trim()
       : stdOut.at(-1)!.trim();
+  blockchainExplorerLink = blockchainExplorerLink.split('?')[0];
   const transactionHash = blockchainExplorerLink.substring(
     blockchainExplorerLink.length - 52
   );


### PR DESCRIPTION
We need a way to also respect the network users deploy against (`berkeley`, `testworld`).
Since `MinaExplorer` does not provide the ITN (Testworld) explorer then all links go to `Minascan`.

---
https://minascan.io/berkeley/tx/5JuayhyNyrRUgkUmUvRRqrBk48ZnS4UGBzBzJtN99ruSyi6m8fyu?type=zk-tx
![image](https://github.com/o1-labs/zkapp-cli/assets/4096154/6247640a-ed72-437d-b78a-abbc711c7bef)

https://minascan.io/testworld/tx/5JuabVWKrCP1a8odXiVVVDNxrRVmEW9FMBGK9dNxYEEcFE4wtjEB?type=zk-tx
![image](https://github.com/o1-labs/zkapp-cli/assets/4096154/3e6098b1-23c6-42c5-8a99-b040694864fa)
