### PR TITLE
Fix TypeScript error while using SvelteKit.

### DIFF
--- a/src/lib/project.js
+++ b/src/lib/project.js
@@ -13,6 +13,10 @@ import customNuxtIndex from '../lib/ui/nuxt/customNuxtIndex.js';
 import nuxtGradientBackground from '../lib/ui/nuxt/nuxtGradientBackground.js';
 import customLayoutSvelte from '../lib/ui/svelte/customLayoutSvelte.js';
 import customPageSvelte from '../lib/ui/svelte/customPageSvelte.js';
+import {
+  serverHooksSvelteJavaScript,
+  serverHooksSvelteTypeScript,
+} from '../lib/ui/svelte/serverHooksSvelte.js';
 import Constants from './constants.js';
 import gradientBackground from './ui/svelte/gradientBackground.js';
 
@@ -263,11 +267,6 @@ function scaffoldSvelte() {
     shell: true,
   });
 
-  shell.cp(
-    path.join(__dirname, 'ui', 'svelte', 'hooks.server.js'),
-    path.join('ui', 'src')
-  );
-
   const customTsConfig = ` {
   "extends": "./.svelte-kit/tsconfig.json",
   "compilerOptions": {
@@ -327,6 +326,19 @@ function scaffoldSvelte() {
   );
 
   fs.writeFileSync(path.join('ui', viteConfigFileName), customViteConfig);
+
+  const serverHooksSvelteFileName = useTypescript
+    ? 'hooks.server.ts'
+    : 'hooks.server.js';
+
+  const serverHooksSvelte = useTypescript
+    ? serverHooksSvelteTypeScript
+    : serverHooksSvelteJavaScript;
+
+  fs.writeFileSync(
+    path.join('ui', 'src', serverHooksSvelteFileName),
+    serverHooksSvelte
+  );
 
   // Remove Sveltekit demo pages and components if found
   fs.emptyDirSync(path.join('ui', 'src', 'routes'));

--- a/src/lib/ui/svelte/hooks.server.js
+++ b/src/lib/ui/svelte/hooks.server.js
@@ -1,9 +1,0 @@
-// To enable o1js for the web, we must set the COOP and COEP headers.
-// See here for more information: https://docs.minaprotocol.com/zkapps/how-to-write-a-zkapp-ui#enabling-coop-and-coep-headers
-/** @type {import('@sveltejs/kit').Handle} */
-export async function handle({ event, resolve }) {
-  const response = await resolve(event);
-  response.headers.set('Cross-Origin-Opener-Policy', 'same-origin');
-  response.headers.set('Cross-Origin-Embedder-Policy', 'require-corp');
-  return response;
-}

--- a/src/lib/ui/svelte/serverHooksSvelte.js
+++ b/src/lib/ui/svelte/serverHooksSvelte.js
@@ -1,0 +1,24 @@
+export const serverHooksSvelteJavaScript = `
+// To enable o1js for the web, we must set the COOP and COEP headers.
+// See here for more information: https://docs.minaprotocol.com/zkapps/how-to-write-a-zkapp-ui#enabling-coop-and-coep-headers
+/** @type {import('@sveltejs/kit').Handle} */
+export async function handle({ event, resolve }) {
+  const response = await resolve(event);
+  response.headers.set('Cross-Origin-Opener-Policy', 'same-origin');
+  response.headers.set('Cross-Origin-Embedder-Policy', 'require-corp');
+  return response;
+}
+`;
+
+export const serverHooksSvelteTypeScript = `
+import type { Handle } from "@sveltejs/kit";
+
+// To enable o1js for the web, we must set the COOP and COEP headers.
+// See here for more information: https://docs.minaprotocol.com/zkapps/how-to-write-a-zkapp-ui#enabling-coop-and-coep-headers
+export const handle: Handle = async ({ event, resolve }) => {
+  const response = await resolve(event);
+  response.headers.set('Cross-Origin-Opener-Policy', 'same-origin');
+  response.headers.set('Cross-Origin-Embedder-Policy', 'require-corp');
+  return response;
+}
+`;


### PR DESCRIPTION
Hey, everyone!

## Problem
When SvelteKit is chosen as an accompanying UI project, the CLI produces a template project with a TypeScript error.


## What this pull request does
This pull request solves the problem by creating `hooks.server.ts` file instead of `hooks.server.js` file when the accompanying UI project uses TypeScript.

If the project doesn't use TypeScript, it still creates `hooks.server.js` file as before.


## To reproduce the error:

1 - Install `zkapp-cli` globally by running the command below.
```shell
npm install --global zkapp-cli
```

2 - Create a project by running the command below.
```shell
zk project my-test-project
```

3 - Choose `svelte` option as an accompanying UI project.

4 - Choose `Skeleton project` option as Svelte app template.

5 - Choose `Yes, using TypeScript syntax` option.

6 - Choose any additional options you want.

7 - Open `ui/tsconfig.json` file and you will see the error message.


## Screenshot
<img width="958" alt="Capture" src="https://github.com/o1-labs/zkapp-cli/assets/106833240/fa53a779-5574-493c-b1d7-0506cf24fccc">
