### PR TITLE
zk lightnet logs command implementation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.15.1] - 2023-XX-XX
+
+### Added
+
+- Lightnet sub-commands implementation (`logs`). [#5XX](https://github.com/o1-labs/zkapp-cli/pull/5XX)
+
 ## [0.15.0] - 2023-11-07
 
-### Changed
+### Added
 
-- Lightnet sub-commands implementation (start/stop/status). [#510](https://github.com/o1-labs/zkapp-cli/pull/510)
+- Lightnet sub-commands implementation (`start`/`stop`/`status`). [#510](https://github.com/o1-labs/zkapp-cli/pull/510)
 
 ## [0.14.1] - 2023-11-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.15.1] - 2023-11-XX
+## [0.15.1] - 2023-11-29
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.15.1] - 2023-XX-XX
+## [0.15.1] - 2023-11-XX
 
 ### Added
 
-- Lightnet sub-commands implementation (`logs`). [#5XX](https://github.com/o1-labs/zkapp-cli/pull/5XX)
+- Lightnet sub-commands implementation (`logs`). [#520](https://github.com/o1-labs/zkapp-cli/pull/520)
 
 ## [0.15.0] - 2023-11-07
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zkapp-cli",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "zkapp-cli",
-      "version": "0.15.0",
+      "version": "0.15.1",
       "license": "Apache-2.0",
       "dependencies": {
         "chalk": "^5.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zkapp-cli",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "CLI to create zkApps (zero-knowledge apps) for Mina Protocol",
   "homepage": "https://github.com/o1-labs/zkapp-cli/",
   "keywords": [

--- a/src/bin/index.js
+++ b/src/bin/index.js
@@ -257,7 +257,9 @@ yargs(hideBin(process.argv))
                     demand: false,
                     string: true,
                     hidden: false,
-                    choices: Object.values(Constants.lightnetProcessName),
+                    choices: [
+                      ...Constants.lightnetProcessToLogFileMapping.keys(),
+                    ],
                     description:
                       'The name of the Docker container process to follow the logs of.',
                   },

--- a/src/bin/index.js
+++ b/src/bin/index.js
@@ -12,9 +12,11 @@ import { deploy } from '../lib/deploy.js';
 import { example } from '../lib/example.js';
 import { file } from '../lib/file.js';
 import {
+  lightnetFollowLogs,
+  lightnetSaveLogs,
+  lightnetStart,
   lightnetStatus,
-  startLightnet,
-  stopLightnet,
+  lightnetStop,
 } from '../lib/lightnet.js';
 import { project } from '../lib/project.js';
 import system from '../lib/system.js';
@@ -193,7 +195,7 @@ yargs(hideBin(process.argv))
             },
             ...commonOptions,
           },
-          async (argv) => await startLightnet(argv)
+          async (argv) => await lightnetStart(argv)
         )
         .command(
           ['stop [save-logs] [clean-up] [debug]'],
@@ -219,7 +221,7 @@ yargs(hideBin(process.argv))
             },
             ...commonOptions,
           },
-          async (argv) => await stopLightnet(argv)
+          async (argv) => await lightnetStop(argv)
         )
         .command(
           ['status [debug]'],
@@ -232,6 +234,39 @@ yargs(hideBin(process.argv))
               preventDockerEngineAvailabilityCheck: false,
               debug: argv.debug,
             })
+        )
+        .command(
+          ['logs <sub-command> [options]'],
+          'Handle the lightweight Mina blockchain network Docker container processes logs.',
+          (yargs) => {
+            yargs
+              .command(
+                ['save [debug]'],
+                'Save the lightweight Mina blockchain network Docker container processes logs to the host file system.',
+                {
+                  ...commonOptions,
+                },
+                async (argv) => await lightnetSaveLogs(argv)
+              )
+              .command(
+                ['follow [process] [debug]'],
+                'Follow one of the lightweight Mina blockchain network Docker container processes logs.',
+                {
+                  process: {
+                    alias: 'p',
+                    demand: false,
+                    string: true,
+                    hidden: false,
+                    choices: Object.values(Constants.lightnetProcessName),
+                    description:
+                      'The name of the Docker container process to follow the logs of.',
+                  },
+                  ...commonOptions,
+                },
+                async (argv) => await lightnetFollowLogs(argv)
+              )
+              .demandCommand();
+          }
         )
         .demandCommand();
     }

--- a/src/lib/constants.js
+++ b/src/lib/constants.js
@@ -8,9 +8,8 @@ import path from 'path';
  * @typedef {'fast' | 'real'} LightnetType
  * @typedef {'none' | 'full'} LightnetProofLevel
  * @typedef {'o1js-main' | 'berkeley' | 'develop'} LightnetMinaBranch
- * @typedef {{ archiveNodeApi: string, minaArchive: string, minaSingleNodeDaemon: string, minaFish1: string, minaFollowing1: string, minaSeed1: string, minaSnarkCoordinator1: string, minaSnarkWorker1: string, minaWhale1: string, minaWhale2: string }} LightnetProcessName
  *
- * @type {{ uiTypes: UiType[], exampleTypes: ExampleType[], feePayerCacheDir: string, lightnetWorkDir: string, lightnetModes: LightnetMode[], lightnetTypes: LightnetType[], lightnetProofLevels: LightnetProofLevel[], lightnetMinaBranches: LightnetMinaBranch[], lightnetProcessName: LightnetProcessName }}
+ * @type {{ uiTypes: UiType[], exampleTypes: ExampleType[], feePayerCacheDir: string, lightnetWorkDir: string, lightnetModes: LightnetMode[], lightnetTypes: LightnetType[], lightnetProofLevels: LightnetProofLevel[], lightnetMinaBranches: LightnetMinaBranch[], lightnetProcessToLogFileMapping: Map<string, string> }}
  */
 const Constants = Object.freeze({
   uiTypes: ['next', 'svelte', 'nuxt', 'empty', 'none'],
@@ -21,18 +20,18 @@ const Constants = Object.freeze({
   lightnetTypes: ['fast', 'real'],
   lightnetProofLevels: ['none', 'full'],
   lightnetMinaBranches: ['o1js-main', 'berkeley', 'develop'],
-  lightnetProcessName: Object.freeze({
-    archiveNodeApi: 'Archive-Node-API application',
-    minaArchive: 'Mina Archive process',
-    minaSingleNodeDaemon: 'Mina multi-purpose Daemon',
-    minaFish1: 'Fish BP #1',
-    minaFollowing1: 'Non-consensus node #1',
-    minaSeed1: 'Seed node #1',
-    minaSnarkCoordinator1: 'SNARK coordinator #1',
-    minaSnarkWorker1: 'SNARK worker #1',
-    minaWhale1: 'Whale BP #1',
-    minaWhale2: 'Whale BP #2',
-  }),
+  lightnetProcessToLogFileMapping: new Map([
+    ['Archive-Node-API application', 'logs/archive-node-api.log'],
+    ['Mina Archive process', 'logs/archive-node.log,archive/log.txt'],
+    ['Mina multi-purpose Daemon', 'logs/single-node-network.log'],
+    ['Fish BP #1', 'fish_0/log.txt'],
+    ['Non-consensus node #1', 'node_0/log.txt'],
+    ['Seed node #1', 'seed/log.txt'],
+    ['SNARK coordinator #1', 'snark_coordinator/log.txt'],
+    ['SNARK worker #1', 'snark_workers/worker_0/log.txt'],
+    ['Whale BP #1', 'whale_0/log.txt'],
+    ['Whale BP #2', 'whale_1/log.txt'],
+  ]),
 });
 
 export default Constants;

--- a/src/lib/constants.js
+++ b/src/lib/constants.js
@@ -8,8 +8,9 @@ import path from 'path';
  * @typedef {'fast' | 'real'} LightnetType
  * @typedef {'none' | 'full'} LightnetProofLevel
  * @typedef {'rampup' | 'berkeley' | 'develop'} LightnetMinaBranch
+ * @typedef {{ archiveNodeApi: string, minaArchive: string, minaSingleNodeDaemon: string, minaFish1: string, minaFollowing1: string, minaSeed1: string, minaSnarkCoordinator1: string, minaSnarkWorker1: string, minaWhale1: string, minaWhale2: string }} LightnetProcessName
  *
- * @type {{ uiTypes: UiType[], exampleTypes: ExampleType[], feePayerCacheDir: string, lightnetWorkDir: string, lightnetModes: LightnetMode[], lightnetTypes: LightnetType[], lightnetProofLevels: LightnetProofLevel[], lightnetMinaBranches: LightnetMinaBranch[] }}
+ * @type {{ uiTypes: UiType[], exampleTypes: ExampleType[], feePayerCacheDir: string, lightnetWorkDir: string, lightnetModes: LightnetMode[], lightnetTypes: LightnetType[], lightnetProofLevels: LightnetProofLevel[], lightnetMinaBranches: LightnetMinaBranch[], lightnetProcessName: LightnetProcessName }}
  */
 const Constants = Object.freeze({
   uiTypes: ['next', 'svelte', 'nuxt', 'empty', 'none'],
@@ -20,6 +21,18 @@ const Constants = Object.freeze({
   lightnetTypes: ['fast', 'real'],
   lightnetProofLevels: ['none', 'full'],
   lightnetMinaBranches: ['rampup', 'berkeley', 'develop'],
+  lightnetProcessName: Object.freeze({
+    archiveNodeApi: 'Archive-Node-API application',
+    minaArchive: 'Mina Archive process',
+    minaSingleNodeDaemon: 'Mina multi-purpose Daemon',
+    minaFish1: 'Fish BP #1',
+    minaFollowing1: 'Non-consensus node #1',
+    minaSeed1: 'Seed node #1',
+    minaSnarkCoordinator1: 'SNARK coordinator #1',
+    minaSnarkWorker1: 'SNARK worker #1',
+    minaWhale1: 'Whale BP #1',
+    minaWhale2: 'Whale BP #2',
+  }),
 });
 
 export default Constants;

--- a/src/lib/lightnet.js
+++ b/src/lib/lightnet.js
@@ -611,7 +611,7 @@ function createLogsDirectory() {
 }
 
 function getLogFilePaths(mode) {
-  return Array.from(lightnetDockerProcessToLogFileMapping.values()).map(
+  return [...lightnetDockerProcessToLogFileMapping.values()].map(
     (value) => {
       const logFilePaths = value.split(',');
       return mode === 'single-node' || logFilePaths.length === 1

--- a/src/lib/lightnet.js
+++ b/src/lib/lightnet.js
@@ -168,7 +168,12 @@ export async function stopLightnet({ saveLogs, cleanUp, debug }) {
       await stopDockerContainer(lightnetDockerContainerName);
     }
   );
-  if (saveLogs && fs.existsSync(lightnetConfigFile)) {
+  if (
+    saveLogs &&
+    fs.existsSync(lightnetConfigFile) &&
+    DockerContainerState.NOT_FOUND !==
+      getDockerContainerState(lightnetDockerContainerName)
+  ) {
     await step('Preserving Docker container processes logs', async () => {
       logsDir = await saveDockerContainerProcessesLogs();
     });
@@ -745,7 +750,8 @@ function secondsToHms(seconds) {
   if (s > 0) {
     sDisplay = s + (s == 1 ? ' second' : ' seconds');
   }
-  return hDisplay + mDisplay + sDisplay;
+  const result = hDisplay + mDisplay + sDisplay;
+  return result.endsWith(', ') ? result.slice(0, -2) : result;
 }
 
 function printErrorIfDebug(error) {

--- a/src/lib/lightnet.js
+++ b/src/lib/lightnet.js
@@ -394,7 +394,7 @@ async function promptForDockerContainerProcess(processToLogFileMapping) {
   const response = await enquirer.prompt({
     type: 'select',
     name: 'selectedProcess',
-    [...processToLogFileMapping.keys()],
+    choices: [...processToLogFileMapping.keys()],
     message: () => {
       return chalk.reset(
         'Please select the Docker container process to follow the logs of'
@@ -611,14 +611,12 @@ function createLogsDirectory() {
 }
 
 function getLogFilePaths(mode) {
-  return [...lightnetDockerProcessToLogFileMapping.values()].map(
-    (value) => {
-      const logFilePaths = value.split(',');
-      return mode === 'single-node' || logFilePaths.length === 1
-        ? logFilePaths[0]
-        : logFilePaths[1];
-    }
-  );
+  return [...lightnetDockerProcessToLogFileMapping.values()].map((value) => {
+    const logFilePaths = value.split(',');
+    return mode === 'single-node' || logFilePaths.length === 1
+      ? logFilePaths[0]
+      : logFilePaths[1];
+  });
 }
 
 async function processSingleNodeLogs(logFilePaths, logsDir) {

--- a/src/lib/lightnet.js
+++ b/src/lib/lightnet.js
@@ -17,19 +17,9 @@ const lightnetDockerContainerName = 'mina-local-lightnet';
 const lightnetMinaDaemonGraphQlEndpoint = 'http://localhost:8080/graphql';
 const lightnetAccountsManagerEndpoint = 'http://localhost:8181';
 const lightnetArchiveNodeApiEndpoint = 'http://localhost:8282';
-const lightnetProcessName = Constants.lightnetProcessName;
-const lightnetDockerProcessToLogFileMapping = new Map([
-  [lightnetProcessName.archiveNodeApi, 'logs/archive-node-api.log'],
-  [lightnetProcessName.minaArchive, 'logs/archive-node.log,archive/log.txt'],
-  [lightnetProcessName.minaSingleNodeDaemon, 'logs/single-node-network.log'],
-  [lightnetProcessName.minaFish1, 'fish_0/log.txt'],
-  [lightnetProcessName.minaFollowing1, 'node_0/log.txt'],
-  [lightnetProcessName.minaSeed1, 'seed/log.txt'],
-  [lightnetProcessName.minaSnarkCoordinator1, 'snark_coordinator/log.txt'],
-  [lightnetProcessName.minaSnarkWorker1, 'snark_workers/worker_0/log.txt'],
-  [lightnetProcessName.minaWhale1, 'whale_0/log.txt'],
-  [lightnetProcessName.minaWhale2, 'whale_1/log.txt'],
-]);
+const archiveNodeApiProcessName = 'Archive-Node-API application';
+const minaArchiveProcessName = 'Mina Archive process';
+const multiPurposeMinaDaemonProcessName = 'Mina multi-purpose Daemon';
 const DockerContainerState = {
   RUNNING: 'running',
   NOT_FOUND: 'not-found',
@@ -360,7 +350,7 @@ export async function lightnetFollowLogs({ process, debug }) {
 }
 
 function getProcessToLogFileMapping({ mode, archive }) {
-  let mapping = new Map(lightnetDockerProcessToLogFileMapping);
+  let mapping = new Map(Constants.lightnetProcessToLogFileMapping);
   if (mode === 'single-node') {
     mapping = new Map([...mapping].slice(0, 3));
     mapping.forEach((value, key) => {
@@ -370,13 +360,13 @@ function getProcessToLogFileMapping({ mode, archive }) {
       );
     });
   } else {
-    mapping.delete(lightnetProcessName.minaSingleNodeDaemon);
+    mapping.delete(multiPurposeMinaDaemonProcessName);
     mapping.forEach((value, key) => {
       const logFilePaths = value.split(',');
       mapping.set(
         key,
         `${
-          lightnetProcessName.archiveNodeApi === key
+          archiveNodeApiProcessName === key
             ? ContainerLogFilesPrefix.SINGLE_NODE
             : ContainerLogFilesPrefix.MULTI_NODE
         }/${logFilePaths.length === 1 ? logFilePaths[0] : logFilePaths[1]}`
@@ -384,8 +374,8 @@ function getProcessToLogFileMapping({ mode, archive }) {
     });
   }
   if (!archive) {
-    mapping.delete(lightnetProcessName.archiveNodeApi);
-    mapping.delete(lightnetProcessName.minaArchive);
+    mapping.delete(archiveNodeApiProcessName);
+    mapping.delete(minaArchiveProcessName);
   }
   return mapping;
 }
@@ -611,12 +601,14 @@ function createLogsDirectory() {
 }
 
 function getLogFilePaths(mode) {
-  return [...lightnetDockerProcessToLogFileMapping.values()].map((value) => {
-    const logFilePaths = value.split(',');
-    return mode === 'single-node' || logFilePaths.length === 1
-      ? logFilePaths[0]
-      : logFilePaths[1];
-  });
+  return [...Constants.lightnetProcessToLogFileMapping.values()].map(
+    (value) => {
+      const logFilePaths = value.split(',');
+      return mode === 'single-node' || logFilePaths.length === 1
+        ? logFilePaths[0]
+        : logFilePaths[1];
+    }
+  );
 }
 
 async function processSingleNodeLogs(logFilePaths, logsDir) {
@@ -650,9 +642,7 @@ async function processMultiNodeLogs(logFilePaths, logsDir) {
 async function processArchiveNodeApiLogs(logsDir) {
   try {
     await copyContainerLogToHost(
-      lightnetDockerProcessToLogFileMapping.get(
-        lightnetProcessName.archiveNodeApi
-      ),
+      Constants.lightnetProcessToLogFileMapping.get(archiveNodeApiProcessName),
       logsDir,
       ContainerLogFilesPrefix.SINGLE_NODE
     );

--- a/src/lib/lightnet.js
+++ b/src/lib/lightnet.js
@@ -350,10 +350,13 @@ export async function lightnetFollowLogs({ process, debug }) {
   const selectedProcess =
     process || (await promptForDockerContainerProcess(processToLogFileMapping));
   const logFilePath = processToLogFileMapping.get(selectedProcess);
-  await streamDockerContainerFileContent(
-    lightnetDockerContainerName,
-    logFilePath
-  );
+
+  await step('Docker container file content streaming', async () => {
+    await streamDockerContainerFileContent(
+      lightnetDockerContainerName,
+      logFilePath
+    );
+  });
 }
 
 function getProcessToLogFileMapping({ mode, archive }) {
@@ -552,12 +555,13 @@ async function streamDockerContainerFileContent(containerName, filePath) {
   try {
     const border = getBorderCharacters('norc');
     console.log(
-      '\n' + chalk.reset.bold('Docker container file content streaming') + '\n'
-    );
-    console.log(
-      table([[chalk.reset('Use Ctrl+C to stop the file content streaming.')]], {
-        border,
-      })
+      '\n' +
+        table(
+          [[chalk.reset('Use Ctrl+C to stop the file content streaming.')]],
+          {
+            border,
+          }
+        )
     );
     await shellExec(`docker exec ${containerName} tail -n 50 -f ${filePath}`, {
       silent: false,

--- a/src/lib/lightnet.js
+++ b/src/lib/lightnet.js
@@ -394,7 +394,7 @@ async function promptForDockerContainerProcess(processToLogFileMapping) {
   const response = await enquirer.prompt({
     type: 'select',
     name: 'selectedProcess',
-    choices: Array.from(processToLogFileMapping.keys()),
+    [...processToLogFileMapping.keys()],
     message: () => {
       return chalk.reset(
         'Please select the Docker container process to follow the logs of'

--- a/src/lib/lightnet.js
+++ b/src/lib/lightnet.js
@@ -362,7 +362,7 @@ export async function lightnetFollowLogs({ process, debug }) {
 function getProcessToLogFileMapping({ mode, archive }) {
   let mapping = new Map(lightnetDockerProcessToLogFileMapping);
   if (mode === 'single-node') {
-    mapping = new Map(Array.from(mapping).slice(0, 3));
+    mapping = new Map([...mapping].slice(0, 3));
     mapping.forEach((value, key) => {
       mapping.set(
         key,


### PR DESCRIPTION
- `zk lightnet logs save` command does not provide any selection options, because usually it is good idea to grab all relevant logs at certain point in time.
- `zk lightnet logs follow` command, on the contrary, gives users an option to follow the logs of certain processes, well, because you can't simply follow several files without introducing additional complexity (logs from different sources pre-processing) and a bit of mess when you will also need to distinguish which entries are from what processes.

Closes #502 

---

As per the [RFC](https://github.com/o1-labs/rfcs/blob/522f295075068522f12cadbca46b7788e986f4bf/0010-zkapp-cli-lightnet-management.md).