### PR TITLE
[Lightnet] Mina processes logging level configuration exposure.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## Unreleased
 
+### Added
+
+- Possibility to configure the `lightnet` Mina processes logging level. [#521](https://github.com/o1-labs/zkapp-cli/pull/521)
+
 ## [0.15.2] - 2023-12-04
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
-- Possibility to configure the `lightnet` Mina processes logging level. [#521](https://github.com/o1-labs/zkapp-cli/pull/521)
+- Possibility to configure the `lightnet` Mina processes logging level. [#536](https://github.com/o1-labs/zkapp-cli/pull/536)
 
 ## [0.15.2] - 2023-12-04
 

--- a/src/bin/index.js
+++ b/src/bin/index.js
@@ -123,7 +123,7 @@ yargs(hideBin(process.argv))
       yargs
         .command(
           [
-            'start [mode] [type] [proof-level] [mina-branch] [archive] [sync] [pull] [debug]',
+            'start [mode] [type] [proof-level] [mina-branch] [archive] [sync] [pull] [mina-log-level] [debug]',
           ],
           'Start the lightweight Mina blockchain network Docker container.',
           {
@@ -193,6 +193,15 @@ yargs(hideBin(process.argv))
               default: true,
               description:
                 'Whether to pull the latest version of the Docker image from the Docker Hub.',
+            },
+            'mina-log-level': {
+              alias: 'l',
+              demand: false,
+              string: true,
+              hidden: false,
+              choices: Constants.lightnetMinaProcessesLogLevels,
+              default: 'Trace',
+              description: 'Mina processes logging level to use.',
             },
             ...commonOptions,
           },

--- a/src/lib/constants.js
+++ b/src/lib/constants.js
@@ -8,8 +8,9 @@ import path from 'path';
  * @typedef {'fast' | 'real'} LightnetType
  * @typedef {'none' | 'full'} LightnetProofLevel
  * @typedef {'o1js-main' | 'berkeley' | 'develop'} LightnetMinaBranch
+ * @typedef {'Spam' | 'Trace' | 'Debug' | 'Info' | 'Warn' | 'Error' | 'Fatal'} LightnetMinaLogLevel
  *
- * @type {{ uiTypes: UiType[], exampleTypes: ExampleType[], feePayerCacheDir: string, lightnetWorkDir: string, lightnetModes: LightnetMode[], lightnetTypes: LightnetType[], lightnetProofLevels: LightnetProofLevel[], lightnetMinaBranches: LightnetMinaBranch[], lightnetProcessToLogFileMapping: Map<string, string> }}
+ * @type {{ uiTypes: UiType[], exampleTypes: ExampleType[], feePayerCacheDir: string, lightnetWorkDir: string, lightnetModes: LightnetMode[], lightnetTypes: LightnetType[], lightnetProofLevels: LightnetProofLevel[], lightnetMinaBranches: LightnetMinaBranch[], lightnetProcessToLogFileMapping: Map<string, string>, lightnetMinaProcessesLogLevels: LightnetMinaLogLevel[] }}
  */
 const Constants = Object.freeze({
   uiTypes: ['next', 'svelte', 'nuxt', 'empty', 'none'],
@@ -32,6 +33,15 @@ const Constants = Object.freeze({
     ['Whale BP #1', 'whale_0/log.txt'],
     ['Whale BP #2', 'whale_1/log.txt'],
   ]),
+  lightnetMinaProcessesLogLevels: [
+    'Spam',
+    'Trace',
+    'Debug',
+    'Info',
+    'Warn',
+    'Error',
+    'Fatal',
+  ],
 });
 
 export default Constants;

--- a/src/lib/lightnet.js
+++ b/src/lib/lightnet.js
@@ -59,6 +59,7 @@ if (process.platform === 'win32') {
  * @param {boolean} argv.archive - Whether to start the Mina Archive process and the Archive-Node-API application.
  * @param {boolean} argv.sync - Whether to wait for the network to sync.
  * @param {boolean} argv.pull - Whether to pull the latest version of the Docker image from the Docker Hub.
+ * @param {string}  argv.minaLogLevel - Mina processes logging level to use.
  * @param {boolean} argv.debug - Whether to print the debug information.
  * @returns {Promise<void>}
  */
@@ -70,6 +71,7 @@ export async function lightnetStart({
   archive,
   sync,
   pull,
+  minaLogLevel,
   debug,
 }) {
   isDebug = debug;
@@ -104,6 +106,7 @@ export async function lightnetStart({
         `docker run --name ${lightnetDockerContainerName} --pull=missing -id ` +
           `--env NETWORK_TYPE="${mode}" ` +
           `--env PROOF_LEVEL="${proofLevel}" ` +
+          `--env LOG_LEVEL="${minaLogLevel}" ` +
           `--env RUN_ARCHIVE_NODE="${archive}" ` +
           '-p 3085:3085 ' +
           '-p 4001:4001 ' +


### PR DESCRIPTION
- Today all the Mina processes are configured to use the `Trace` logging level. This might be too much for certain cases and hence, It will be good to have an ability to change the Mina processes logging level in use.
- Corresponding `lightnet` [images](https://hub.docker.com/r/o1labs/mina-local-network) will be updated with the next build&publishing job.

---

Closes #524 