### PR TITLE
Update Changelog to be consistent with the o1js changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,7 +63,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   - o1js minor version dependency updated in cli package.json to 0.14.\*.
   - o1js minor version peer dependency updated in template/example contract package.json to 0.14.\*.
 
-## [0.13.2] - 2023-10-22
+## [0.13.2](https://github.com/o1-labs/zkapp-cli/compare/v0.13.0...v13.2) - 2023-10-22
 
 ### Changed
 
@@ -75,7 +75,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - This PR removes Husky and the pre-commit hooks from the project templates to remove friction and create a better DX when building zkApps. [#505](https://github.com/o1-labs/zkapp-cli/pull/505).
 
-## [0.13.0] - 2023-09-14
+## [0.13.0](https://github.com/o1-labs/zkapp-cli/compare/v0.12.1...v0.13.0) - 2023-09-14
 
 ### Changed
 
@@ -83,7 +83,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   - o1js minor version dependency updated in cli package.json to 0.13.\*.
   - o1js minor version peer dependency updated in template/example contract package.json to 0.13.\*.
 
-## [0.12.1] - 2023-09-09
+## [0.12.1](https://github.com/o1-labs/zkapp-cli/compare/v0.12.0...v0.12.1) - 2023-09-09
 
 ### Changed
 
@@ -93,7 +93,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - Fix to allow the zkApp-cli to be used from a projects local node_modules[#448](https://github.com/o1-labs/zkapp-cli/pull/448).
 
-## [0.12.0] - 2023-09-09
+## [0.12.0](https://github.com/o1-labs/zkapp-cli/compare/v0.11.2...v0.12.0) - 2023-09-09
 
 ### Changed
 
@@ -103,7 +103,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - E2E tests for critical user flows against mocked and real networks [#447](https://github.com/o1-labs/zkapp-cli/pull/447).
 
-## [0.11.2] - 2023-09-05
+## [0.11.2](https://github.com/o1-labs/zkapp-cli/compare/v0.11.0...v0.11.2) - 2023-09-05
 
 ### Changed
 
@@ -119,7 +119,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - A fix to deploy a NextJS UI project to GitHub Pages without manual configuration by running `npm run deploy` [#468](https://github.com/o1-labs/zkapp-cli/pull/468)
 
-## [0.11.0] - 2023-07-14
+## [0.11.0](https://github.com/o1-labs/zkapp-cli/compare/v0.10.2...v0.11.0) - 2023-07-14
 
 ### Changed
 
@@ -127,7 +127,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   - o1js minor version dependency updated in cli package.json to 0.12.\*.
   - o1js minor version peer dependency updated in template/example contract package.json to 0.12.\*.
 
-## [0.10.2] - 2023-07-09
+## [0.10.2](https://github.com/o1-labs/zkapp-cli/compare/v0.10.1...v0.10.2) - 2023-07-09
 
 ### Changed
 
@@ -137,13 +137,13 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - Fix for zkApp project generation with `Nuxt` UI framework issue ([#449](https://github.com/o1-labs/zkapp-cli/issues/449))
 
-## [0.10.1] - 2023-06-22
+## [0.10.1](https://github.com/o1-labs/zkapp-cli/compare/v0.10.0...v0.10.1) - 2023-06-22
 
 ### Changed
 
 - Update cli prompt language and upgrade version instructions [#437](https://github.com/o1-labs/zkapp-cli/pull/437) & [#438](https://github.com/o1-labs/zkapp-cli/pull/438)
 
-## [0.10.0] - 2023-06-20
+## [0.10.0](https://github.com/o1-labs/zkapp-cli/compare/v0.9.1...v0.10.0) - 2023-06-20
 
 ## Added
 
@@ -154,7 +154,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - A fee payer tries to pay the fee using signature authorization (proofs are not supported). If the zkApp account is used as fee payer after deployment, the transaction was rejected because the permissions of the account would be violated, breaking all re-deployments and the interact.ts script in the template project. [#424](https://github.com/o1-labs/zkapp-cli/pull/424)
 
-## [0.9.1] - 2023-06-17
+## [0.9.1](https://github.com/o1-labs/zkapp-cli/compare/v0.1.4...v0.9.1) - 2023-06-17
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - Fix to allow a deployment to Github Pages using the npm run deploy command in a NextJS UI project[#534](https://github.com/o1-labs/zkapp-cli/pull/534).
 
-## [0.15.2] - 2023-12-04
+## [0.15.2](https://github.com/o1-labs/zkapp-cli/compare/v15.2...v15.1) - 2023-12-04
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## Unreleased
 
-## [0.16.0] - 2023-12-11
+## [0.16.0](https://github.com/o1-labs/zkapp-cli/compare/v15.2...v16.0) - 2023-12-11
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,31 +31,31 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - Fix to allow a deployment to Github Pages using the npm run deploy command in a NextJS UI project[#534](https://github.com/o1-labs/zkapp-cli/pull/534).
 
-## [0.15.2](https://github.com/o1-labs/zkapp-cli/compare/v15.2...v15.1) - 2023-12-04
+## [0.15.2](https://github.com/o1-labs/zkapp-cli/compare/v15.1...v15.2) - 2023-12-04
 
 ### Added
 
 - Lightnet sub-commands implementation (`explorer`). [#521](https://github.com/o1-labs/zkapp-cli/pull/521)
 
-## [0.15.1] - 2023-11-29
+## [0.15.1](https://github.com/o1-labs/zkapp-cli/compare/v15.0...v15.1) - 2023-11-29
 
 ### Added
 
 - Lightnet sub-commands implementation (`logs`). [#520](https://github.com/o1-labs/zkapp-cli/pull/520)
 
-## [0.15.0] - 2023-11-07
+## [0.15.0](https://github.com/o1-labs/zkapp-cli/compare/v14.1...v15.0) - 2023-11-07
 
 ### Added
 
 - Lightnet sub-commands implementation (`start`/`stop`/`status`). [#510](https://github.com/o1-labs/zkapp-cli/pull/510)
 
-## [0.14.1] - 2023-11-03
+## [0.14.1](https://github.com/o1-labs/zkapp-cli/compare/v14.0...v14.1) - 2023-11-03
 
 ### Changed
 
 - Explorer links for deployment and interaction transactions. [#516](https://github.com/o1-labs/zkapp-cli/pull/516)
 
-## [0.14.0] - 2023-10-31
+## [0.14.0](https://github.com/o1-labs/zkapp-cli/compare/v13.2...v14.0) - 2023-10-31
 
 ### Changed
 

--- a/update-changelog.sh
+++ b/update-changelog.sh
@@ -20,6 +20,6 @@ echo "Current date: $current_date"
 
 # Step 5: Update the CHANGELOG
 # Insert a new version section with an additional newline for spacing
-sed -i "/## Unreleased/a \\\n## [$new_version] - $current_date" CHANGELOG.md
+sed -i "/## Unreleased/a \\\n## [$new_version]($comparison_url) - $current_date" CHANGELOG.md
 
 echo "CHANGELOG updated with version $new_version"

--- a/update-changelog.sh
+++ b/update-changelog.sh
@@ -10,11 +10,15 @@ let version_parts[2]+=1
 new_version="${version_parts[0]}.${version_parts[1]}.${version_parts[2]}"
 echo "New version: $new_version"
 
-# Step 3: Capture the current date
+# Step 3: Construct the version comparison URL
+comparison_url="https://github.com/o1-labs/zkapp-cli/compare/${latest_version}...${new_version}"
+echo "Comparison URL: $comparison_url"
+
+# Step 4: Capture the current date
 current_date=$(date +%Y-%m-%d)
 echo "Current date: $current_date"
 
-# Step 4: Update the CHANGELOG
+# Step 5: Update the CHANGELOG
 # Insert a new version section with an additional newline for spacing
 sed -i "/## Unreleased/a \\\n## [$new_version] - $current_date" CHANGELOG.md
 


### PR DESCRIPTION
# Description

This PR formalizes the changelog to be consistent with the [o1js changelog](https://github.com/o1-labs/o1js/blob/main/CHANGELOG.md) by adding branch comparison links for each release version.

closes #540
