### PR TITLE
Handle global cli version detection failure message

### DIFF
--- a/src/lib/deploy.js
+++ b/src/lib/deploy.js
@@ -42,6 +42,16 @@ export async function deploy({ alias, yes }) {
   const latestCliVersion = await getLatestCliVersion();
   const installedCliVersion = getInstalledCliVersion();
 
+  if (!installedCliVersion) {
+    log(
+      chalk.red(
+        `Failed to detect the installed zkapp-cli version. This might be possible if you are using Volta to manage your Node versions.`
+      )
+    );
+    log(chalk.red('As a workaround, you can as zkapp-cli as a local dependency by running `npm install zkapp-cli`'));
+    return;
+  }
+  
   // Checks if developer has the legacy networks or deploy aliases in config.json
   if (!Object.prototype.hasOwnProperty.call(config, 'deployAliases'))
     config.deployAliases = config?.networks;

--- a/src/lib/deploy.js
+++ b/src/lib/deploy.js
@@ -45,10 +45,10 @@ export async function deploy({ alias, yes }) {
   if (!installedCliVersion) {
     log(
       chalk.red(
-        `Failed to detect the installed zkapp-cli version. This might be possible if you are using Volta to manage your Node versions.`
+        `Failed to detect the installed zkapp-cli version. This might be possible if you are using Volta or something similar to manage your Node versions.`
       )
     );
-    log(chalk.red('As a workaround, you can as zkapp-cli as a local dependency by running `npm install zkapp-cli`'));
+    log(chalk.red('As a workaround, you can install zkapp-cli as a local dependency by running `npm install zkapp-cli`'));
     return;
   }
   


### PR DESCRIPTION
#550 

#Issue Description

Sometimes deploy script fails to detect the global cli version. it happens if user has installed **Node** via [Volta] (https://volta.sh/) or something similar. In that case `npm list -g --depth 0 --json --silent` doesn't include `zkapp-cli`. 

If that happens, `getInstalledCliVersion` method returns `undefined` and code breaks.

**Changes summary**

To fix this, check the return value of `getInstalledCliVersion` and if is undefined, show a relevant message to user.