### PR TITLE
Update project scaffold tsconfig to handle esnext and es2022 targets

### DIFF
--- a/templates/project-ts/tsconfig.json
+++ b/templates/project-ts/tsconfig.json
@@ -17,7 +17,8 @@
     "declaration": true,
     "sourceMap": true,
     "noFallthroughCasesInSwitch": true,
-    "allowSyntheticDefaultImports": true
+    "allowSyntheticDefaultImports": true,
+    "useDefineForClassFields": false,
   },
-  "include": ["./src"]
+  "include": ["./src"],
 }


### PR DESCRIPTION
**Description**
Closes #569 

**Problem**
Invoking  the`SmartContract.compile` method  when `compilerOptions.target` in the `tsconfig` is set to `"ES2022"` or `"ESNext"` causes the following error.

```
Error: get can only be called when the State is assigned to a SmartContract @state.
    at Object.get (o1js/dist/node/lib/state.js:135:23)
    at Object.getAndRequireEquals (o1js/dist/node/lib/state.js:193:30)
```
See the [issue ](https://github.com/o1-labs/o1js/issues/1380)reported in the o1js repo for more details.

**Solution**
This error was fixed by setting the `useDefineForClassFields` to `false` in the project scaffold `tsconfig`.

**Tested**
This was manualy tested by first reproducing the error, and then setting the `useDefineForClassFields` to `false` in the project scaffold `tsconfig` to verify the error was resolved.