### PR TITLE
add Lightnet to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,12 +173,23 @@ zk deploy <alias>
 zk deploy // shows a list of aliases in your project to choose from
 ```
 
-_**Deployment is supported only to Berkeley Testnet and Testworld Mission 2.0, the Protocol Performance Testing program.
-zkApp programmability is not yet available on the Mina Mainnet.**_
+_**Deployment is supported only to Berkeley Testnet until zkApp programmability is available on Mina Mainnet.**_
 
 After you run `zk config`, the `zk deploy` command allows you to deploy a smart contract to a specified deploy alias.
 
 Note: When you deploy to an alias for the first time, you are prompted to choose which smart contract you want to deploy from those that exist as _named_ exports in your project. The name of the smart contract that you choose is remembered by being saved into your `config.json` for this alias. For safety, the next time you run `zk deploy <alias>` this _same_ smart contract automatically deploys to this alias. See [Tutorial 3: Deploy to a Live Network](https://docs.minaprotocol.com/zkapps/tutorials/deploying-to-a-network).
+
+## Testing your zkApp
+
+To test your zkApps, you first create automated tests for your smart contract and test with a simulated local blockchain. See [Testing zkApps Locally](https://docs.minaprotocol.com/zkapps/testing-zkapps-locally).
+
+Before you test with a live network, use Lightnet to test your zkApp locally on an accurate representation of a Mina blockchain. 
+
+```sh
+zk lightnet
+```
+
+See [Testing zkApps with Lightnet](https://docs.minaprotocol.com/zkapps/testing-zkapps-lightnet).
 
 ## License
 


### PR DESCRIPTION
We have basic getting started zk commands in the README, so let's add zk lightnet with links to the docs