### PR TITLE
Feepayer permissions error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## Unreleased
 
 ### Changed
-- Improve error handling for zk deploy when fee payer has insufficient permissions. [#580](https://github.com/o1-labs/zkapp-cli/pull/580)
+- Improve error handling for zk deploy when feepayer has insufficient permissions. [#580](https://github.com/o1-labs/zkapp-cli/pull/580)
 
 - Allow to use locally available lightweight Mina explorer in case of network issues. [#577](https://github.com/o1-labs/zkapp-cli/pull/577)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## Unreleased
 
 ### Changed
+- Improve error handling for zk deploy when fee payer has insufficient permissions. [#580](https://github.com/o1-labs/zkapp-cli/pull/580)
 
 - Allow to use locally available lightweight Mina explorer in case of network issues. [#577](https://github.com/o1-labs/zkapp-cli/pull/577)
 

--- a/src/lib/deploy.js
+++ b/src/lib/deploy.js
@@ -322,8 +322,6 @@ export async function deploy({ alias, yes }) {
   const zkAppAddress = zkAppPrivateKey.toPublicKey(); //  The public key of the zkApp
   const feepayerPrivateKey = PrivateKey.fromBase58(feepayerPrivateKeyBase58); //  The private key of the feepayer
   const feepayerAddress = feepayerPrivateKey.toPublicKey(); //  The public key of the feepayer
-  console.log('feepayerAddress', feepayerAddress.toBase58());
-  console.log('zkAppAddress', zkAppAddress.toBase58());
 
   // guide user to choose a feepayer account that is different from the zkApp account
   if (feepayerAddress.toBase58() === zkAppAddress.toBase58()) {

--- a/src/lib/deploy.js
+++ b/src/lib/deploy.js
@@ -322,9 +322,16 @@ export async function deploy({ alias, yes }) {
   const zkAppAddress = zkAppPrivateKey.toPublicKey(); //  The public key of the zkApp
   const feepayerPrivateKey = PrivateKey.fromBase58(feepayerPrivateKeyBase58); //  The private key of the feepayer
   const feepayerAddress = feepayerPrivateKey.toPublicKey(); //  The public key of the feepayer
+  console.log('feepayerAddress', feepayerAddress.toBase58());
+  console.log('zkAppAddress', zkAppAddress.toBase58());
 
-  if (feepayerAddress === zkAppAddress) {
-    console.log('feepayer is the same as the zkAppAddress');
+  // guide user to choose a feepayer account that is different from the zkApp account
+  if (feepayerAddress.toBase58() === zkAppAddress.toBase58()) {
+    log(
+      chalk.red(
+        `  The feepayer account is the same as the zkapp account.\n  Please use a different feepayer account or generate a new one by entering zk config.`
+      )
+    );
   }
 
   // figure out if the zkApp has a @method init() - in that case we need to create a proof,

--- a/src/lib/deploy.js
+++ b/src/lib/deploy.js
@@ -323,6 +323,10 @@ export async function deploy({ alias, yes }) {
   const feepayerPrivateKey = PrivateKey.fromBase58(feepayerPrivateKeyBase58); //  The private key of the feepayer
   const feepayerAddress = feepayerPrivateKey.toPublicKey(); //  The public key of the feepayer
 
+  if (feepayerAddress === zkAppAddress) {
+    console.log('feepayer is the same as the zkAppAddress');
+  }
+
   // figure out if the zkApp has a @method init() - in that case we need to create a proof,
   // so we need to compile no matter what, and we show a separate step to create the proof
   let isInitMethod = zkApp._methods?.some((intf) => intf.methodName === 'init');

--- a/src/lib/deploy.js
+++ b/src/lib/deploy.js
@@ -327,7 +327,7 @@ export async function deploy({ alias, yes }) {
   if (feepayerAddress.toBase58() === zkAppAddress.toBase58()) {
     log(
       chalk.red(
-        `  The feepayer account is the same as the zkapp account.\n  Please use a different feepayer account or generate a new one by entering zk config.`
+        `  The feepayer account is the same as the zkApp account.\n  Please use a different feepayer account or generate a new one by entering zk config.`
       )
     );
     process.exit(1);

--- a/src/lib/deploy.js
+++ b/src/lib/deploy.js
@@ -330,6 +330,7 @@ export async function deploy({ alias, yes }) {
         `  The feepayer account is the same as the zkapp account.\n  Please use a different feepayer account or generate a new one by entering zk config.`
       )
     );
+    process.exit(1);
   }
 
   // figure out if the zkApp has a @method init() - in that case we need to create a proof,


### PR DESCRIPTION
# Description 
Closes #331

This PR improves the error handling for `zk deploy` when the  feepayer has insufficient permissions. A helpful error message is shown to guide a user to use a different feepayer or generate a new one with `zk config`.
