### PR TITLE
Improve error handling when smart contract is not found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,9 +19,12 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Changed
 
-- Improve error handling for zk deploy when feepayer has insufficient permissions. [#580](https://github.com/o1-labs/zkapp-cli/pull/580)
+- Improve error handling when imported smart contract is not found. [#586](https://github.com/o1-labs/zkapp-cli/pull/586)
 
 - Update `getCachedFeepayerAliases()` logic to prevent edge case bugs. [#581](https://github.com/o1-labs/zkapp-cli/pull/581)
+
+- Improve error handling for zk deploy when feepayer has insufficient permissions. [#580](https://github.com/o1-labs/zkapp-cli/pull/580)
+
 
 - Automate "zk config" if Lightnet is in use. [#579](https://github.com/o1-labs/zkapp-cli/pull/579)
   - The `--lightnet` option was added to `zk config` in order to automatically configures zkApp project's deploy aliases.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,14 +17,17 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## Unreleased
 
+### Changed
+
+- Improve error handling when imported smart contract is not found. [#586](https://github.com/o1-labs/zkapp-cli/pull/586)
+
 ## [0.17.1](https://github.com/o1-labs/zkapp-cli/compare/v17.0...v17.1) - 2024-02-17
 
 ### Changed
 
-- Improve error handling when imported smart contract is not found. [#586](https://github.com/o1-labs/zkapp-cli/pull/586)
 - Update `getCachedFeepayerAliases()` logic to prevent edge case bugs. [#581](https://github.com/o1-labs/zkapp-cli/pull/581)
 
-- Improve error handling for zk deploy when feepayer has insufficient permissions. [#580](https://github.com/o1-labs/zkapp-cli/pull/580)
+- Improve error handling for zk deploy when fee payer has insufficient permissions. [#580](https://github.com/o1-labs/zkapp-cli/pull/580)
 
 
 - Automate "zk config" if Lightnet is in use. [#579](https://github.com/o1-labs/zkapp-cli/pull/579)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,6 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - Improve error handling for zk deploy when fee payer has insufficient permissions. [#580](https://github.com/o1-labs/zkapp-cli/pull/580)
 
-
 - Automate "zk config" if Lightnet is in use. [#579](https://github.com/o1-labs/zkapp-cli/pull/579)
   - The `--lightnet` option was added to `zk config` in order to automatically configures zkApp project's deploy aliases.
   - The [Lightnet](https://docs.minaprotocol.com/zkapps/testing-zkapps-lightnet) should be up and running before executing the `zk config --lightnet` command.

--- a/src/lib/deploy.js
+++ b/src/lib/deploy.js
@@ -247,9 +247,6 @@ export async function deploy({ alias, yes }) {
     }
     smartContractImports = await import(smartContractImportPath);
   } catch (error) {
-    if (!smartContractImports) {
-      throw error;
-    }
     log(
       chalk.red(
         `  Failed to find the "${contractName}" smart contract in your build directory.\n  Please confirm that your config.json contains the name of the smart contract that you want to deploy to this deploy alias.`

--- a/src/lib/deploy.js
+++ b/src/lib/deploy.js
@@ -250,7 +250,7 @@ export async function deploy({ alias, yes }) {
   if (smartContractImports && !(contractName in smartContractImports)) {
     log(
       chalk.red(
-        `  Failed to find the "${contractName}" smart contract in your build directory.\n  Please confirm that your config.json contains the name of the smart \n  contract that you want to deploy to this deploy alias, and check that\n  you have exported your smart contract class using a named export and try again.`
+        `  Failed to find the "${contractName}" smart contract in your build directory.\n  Please confirm that your config.json contains the name of the smart \n  contract that you want to deploy using this deploy alias, check that\n  you have exported your smart contract class using a named export and try again.`
       )
     );
 

--- a/src/lib/deploy.js
+++ b/src/lib/deploy.js
@@ -249,10 +249,12 @@ export async function deploy({ alias, yes }) {
   } catch (error) {
     // Attempt to import the smart contract class to deploy from the user's file.
     // If we cannot find the named export log an error message and return early.
+    console.log('contractName', contractName);
+    // console.log('smartContractImports', smartContractImports);
     if (smartContractImports && !(contractName in smartContractImports)) {
       log(
         chalk.red(
-          `  Failed to find the "${contractName}" smart contract in your build directory.\n  Please confirm that your config.json contains the name of the smart contract that you want to deploy to this deploy alias\n and check that you have exported your smart contract class using a named export and try again.`
+          `  Failed to find the "${contractName}" smart contract in your build directory.\n  Please confirm that your config.json contains the name of the smart \n  contract that you want to deploy to this deploy alias and check that\n  you have exported your smart contract class using a named export and try again.`
         )
       );
 

--- a/src/lib/deploy.js
+++ b/src/lib/deploy.js
@@ -249,7 +249,7 @@ export async function deploy({ alias, yes }) {
   } catch (error) {
     // Attempt to import the smart contract class to deploy from the user's file.
     // If we cannot find the named export log an error message and return early.
-    if (!(contractName in smartContractImports)) {
+    if (smartContractImports && !(contractName in smartContractImports)) {
       log(
         chalk.red(
           `  Failed to find the "${contractName}" smart contract in your build directory.\n  Please confirm that your config.json contains the name of the smart contract that you want to deploy to this deploy alias\n and check that you have exported your smart contract class using a named export and try again.`

--- a/src/lib/deploy.js
+++ b/src/lib/deploy.js
@@ -247,18 +247,12 @@ export async function deploy({ alias, yes }) {
     }
     smartContractImports = await import(smartContractImportPath);
   } catch (error) {
-    log(
-      chalk.red(
-        `  Failed to find the "${contractName}" smart contract in your build directory.\n  Please confirm that your config.json contains the name of the smart contract that you want to deploy to this deploy alias.`
-      )
-    );
-
     // Attempt to import the smart contract class to deploy from the user's file.
     // If we cannot find the named export log an error message and return early.
     if (!(contractName in smartContractImports)) {
       log(
         chalk.red(
-          `  Failed to find the "${contractName}" smart contract in your build directory.\n  Check that you have exported your smart contract class using a named export and try again.`
+          `  Failed to find the "${contractName}" smart contract in your build directory.\n  Please confirm that your config.json contains the name of the smart contract that you want to deploy to this deploy alias\n and check that you have exported your smart contract class using a named export and try again.`
         )
       );
 

--- a/src/lib/deploy.js
+++ b/src/lib/deploy.js
@@ -246,7 +246,8 @@ export async function deploy({ alias, yes }) {
       smartContractImportPath = 'file://' + smartContractImportPath;
     }
     smartContractImports = await import(smartContractImportPath);
-  } catch (_) {
+  } catch (error) {
+    throw error;
     log(
       chalk.red(
         `  Failed to find the "${contractName}" smart contract in your build directory.\n  Please confirm that your config.json contains the name of the smart contract that you want to deploy to this deploy alias.`

--- a/src/lib/deploy.js
+++ b/src/lib/deploy.js
@@ -239,28 +239,22 @@ export async function deploy({ alias, yes }) {
     contractName
   );
 
-  let smartContractImports;
-  try {
-    let smartContractImportPath = `${projectRoot}/build/src/${smartContractFile}`;
-    if (process.platform === 'win32') {
-      smartContractImportPath = 'file://' + smartContractImportPath;
-    }
-    smartContractImports = await import(smartContractImportPath);
-  } catch (error) {
-    // Attempt to import the smart contract class to deploy from the user's file.
-    // If we cannot find the named export log an error message and return early.
-    console.log('contractName', contractName);
-    // console.log('smartContractImports', smartContractImports);
-    if (smartContractImports && !(contractName in smartContractImports)) {
-      log(
-        chalk.red(
-          `  Failed to find the "${contractName}" smart contract in your build directory.\n  Please confirm that your config.json contains the name of the smart \n  contract that you want to deploy to this deploy alias and check that\n  you have exported your smart contract class using a named export and try again.`
-        )
-      );
+  let smartContractImportPath = `${projectRoot}/build/src/${smartContractFile}`;
+  if (process.platform === 'win32') {
+    smartContractImportPath = 'file://' + smartContractImportPath;
+  }
+  // Attempt to import the smart contract class to deploy from the user's file.
+  const smartContractImports = await import(smartContractImportPath);
 
-      process.exit(1);
-    }
-    throw error;
+  // If we cannot find the named export log an error message and return early.
+  if (smartContractImports && !(contractName in smartContractImports)) {
+    log(
+      chalk.red(
+        `  Failed to find the "${contractName}" smart contract in your build directory.\n  Please confirm that your config.json contains the name of the smart \n  contract that you want to deploy to this deploy alias, and check that\n  you have exported your smart contract class using a named export and try again.`
+      )
+    );
+
+    process.exit(1);
   }
 
   // Attempt to import the zkApp private key from the `keys` directory and the feepayer private key. These keys will be used to deploy the zkApp.

--- a/src/lib/deploy.js
+++ b/src/lib/deploy.js
@@ -250,7 +250,7 @@ export async function deploy({ alias, yes }) {
   if (smartContractImports && !(contractName in smartContractImports)) {
     log(
       chalk.red(
-        `  Failed to find the "${contractName}" smart contract in your build directory.\n  Please confirm that your config.json contains the name of the smart \n  contract that you want to deploy using this deploy alias, check that\n  you have exported your smart contract class using a named export and try again.`
+        `  Failed to find the "${contractName}" smart contract in your build directory.\n  Please confirm that your config.json contains the name of the smart \n  contract that you want to deploy to this deploy alias, and check that\n  you have exported your smart contract class using a named export and try again.`
       )
     );
 

--- a/src/lib/deploy.js
+++ b/src/lib/deploy.js
@@ -247,25 +247,26 @@ export async function deploy({ alias, yes }) {
     }
     smartContractImports = await import(smartContractImportPath);
   } catch (error) {
-    throw error;
+    if (!smartContractImports) {
+      throw error;
+    }
     log(
       chalk.red(
         `  Failed to find the "${contractName}" smart contract in your build directory.\n  Please confirm that your config.json contains the name of the smart contract that you want to deploy to this deploy alias.`
       )
     );
 
-    process.exit(1);
-  }
+    // Attempt to import the smart contract class to deploy from the user's file.
+    // If we cannot find the named export log an error message and return early.
+    if (!(contractName in smartContractImports)) {
+      log(
+        chalk.red(
+          `  Failed to find the "${contractName}" smart contract in your build directory.\n  Check that you have exported your smart contract class using a named export and try again.`
+        )
+      );
 
-  // Attempt to import the smart contract class to deploy from the user's file.
-  // If we cannot find the named export log an error message and return early.
-  if (!(contractName in smartContractImports)) {
-    log(
-      chalk.red(
-        `  Failed to find the "${contractName}" smart contract in your build directory.\n  Check that you have exported your smart contract class using a named export and try again.`
-      )
-    );
-
+      process.exit(1);
+    }
     process.exit(1);
   }
 

--- a/src/lib/deploy.js
+++ b/src/lib/deploy.js
@@ -258,7 +258,7 @@ export async function deploy({ alias, yes }) {
 
       process.exit(1);
     }
-    process.exit(1);
+    throw error;
   }
 
   // Attempt to import the zkApp private key from the `keys` directory and the feepayer private key. These keys will be used to deploy the zkApp.


### PR DESCRIPTION
# Description 
Closes #329  

Previously when an error occurred while importing a smart contract from the build directory during the deploy step, the `zkApp CLI` would swallow the error and display the message.

```
  Failed to find the "Add" smart contract in your build directory.
  Please confirm that your config.json contains the name of the smart contract that you desire to deploy to this deploy alias.
```
There are many different errors that can happen while importing a smart contract. This caused a poor DX, and made it extremely hard for user to find the source of the real errors.

# Solution
This PR improves the error handling for `zk deploy` when a smart contract is not found in the build directory. A custom error message is only shown to a user if the smart contract is not found in the build directory.  All other errors are thrown otherwise, enabling users to identify the cause of the error. 

Additionaly, the custom error message was improved to help a user troubleshoot the problem when a contract is not found in the build directory.