### PR TITLE
Address the 'zk system' issue on Windows.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,11 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Changed
 
 - Add support to deploy smart contracts that verify ZkProgram proofs. [#547](https://github.com/o1-labs/zkapp-cli/pull/547)
-
 - Remove `node-fetch` dependency in favor of NodeJS native fetch. [#602](https://github.com/o1-labs/zkapp-cli/pull/602)
+
+### Fixed
+
+- Issue when `zk system` command did not reported the `zkapp-cli` version. [#612](https://github.com/o1-labs/zkapp-cli/pull/612)
 
 ## [0.18.0](https://github.com/o1-labs/zkapp-cli/compare/v17.2...v18.0) - 2024-03-06
 
@@ -53,9 +56,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Changed
 
 - Update `getCachedFeepayerAliases()` logic to prevent edge case bugs. [#581](https://github.com/o1-labs/zkapp-cli/pull/581)
-
 - Improve error handling for zk deploy when fee payer has insufficient permissions. [#580](https://github.com/o1-labs/zkapp-cli/pull/580)
-
 - Automate "zk config" if Lightnet is in use. [#579](https://github.com/o1-labs/zkapp-cli/pull/579)
   - The `--lightnet` option was added to `zk config` in order to automatically configures zkApp project's deploy aliases.
   - The [Lightnet](https://docs.minaprotocol.com/zkapps/testing-zkapps-lightnet) should be up and running before executing the `zk config --lightnet` command.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
-- Issue when `zk system` command did not reported the `zkapp-cli` version. [#612](https://github.com/o1-labs/zkapp-cli/pull/612)
+- Issue when `zk system` command did not reported the `zkapp-cli` version on Windows. [#612](https://github.com/o1-labs/zkapp-cli/pull/612)
 
 ## [0.18.0](https://github.com/o1-labs/zkapp-cli/compare/v17.2...v18.0) - 2024-03-06
 

--- a/src/lib/system.js
+++ b/src/lib/system.js
@@ -2,8 +2,10 @@ import { execSync } from 'child_process';
 import envinfo from 'envinfo';
 
 function system() {
-  const installedO1jsVersion = getInstalledPackageVersion();
-  const installedZkAppCliVersion = getInstalledPackageVersion({
+  const installedO1jsVersion = getInstalledNpmPackageVersion({
+    packageName: 'o1js',
+  });
+  const installedZkAppCliVersion = getInstalledNpmPackageVersion({
     packageName: 'zkapp-cli',
     isGlobal: true,
   });
@@ -37,8 +39,8 @@ function system() {
     .then((env) => console.log(env));
 }
 
-function getInstalledPackageVersion(
-  options = { packageName: 'o1js', isGlobal: false }
+function getInstalledNpmPackageVersion(
+  options = { packageName: '', isGlobal: false }
 ) {
   const { packageName, isGlobal } = options;
   const maybeGlobalArg = isGlobal ? '-g' : '';

--- a/src/lib/system.js
+++ b/src/lib/system.js
@@ -2,7 +2,11 @@ import { execSync } from 'child_process';
 import envinfo from 'envinfo';
 
 function system() {
-  const installedO1jsVersion = getInstalledO1jsVersion();
+  const installedO1jsVersion = getInstalledPackageVersion();
+  const installedZkAppCliVersion = getInstalledPackageVersion({
+    packageName: 'zkapp-cli',
+    isGlobal: true,
+  });
   console.log(
     'Be sure to include the following system information when submitting a GitHub issue:'
   );
@@ -23,15 +27,29 @@ function system() {
         `o1js: ${installedO1jsVersion || 'Not Found (not in a project)'}`
       );
     })
+    .then((env) => {
+      const str = 'zkapp-cli: Not Found';
+      return env.replace(
+        str,
+        `zkapp-cli: ${installedZkAppCliVersion || 'Not Found'}`
+      );
+    })
     .then((env) => console.log(env));
 }
 
-function getInstalledO1jsVersion() {
-  const installedPkgs = execSync('npm list --all --depth 0 --json', {
-    encoding: 'utf-8',
-  });
+function getInstalledPackageVersion(
+  options = { packageName: 'o1js', isGlobal: false }
+) {
+  const { packageName, isGlobal } = options;
+  const maybeGlobalArg = isGlobal ? '-g' : '';
+  const installedPkgs = execSync(
+    `npm list ${maybeGlobalArg} --all --depth 0 --json`,
+    {
+      encoding: 'utf-8',
+    }
+  );
 
-  return JSON.parse(installedPkgs)['dependencies']?.['o1js']?.['version'];
+  return JSON.parse(installedPkgs).dependencies?.[packageName]?.version;
 }
 
 export default system;

--- a/src/lib/system.js
+++ b/src/lib/system.js
@@ -40,7 +40,7 @@ function system() {
 }
 
 function getInstalledNpmPackageVersion(
-  options = { packageName: '', isGlobal: false }
+  options = { packageName: null, isGlobal: false }
 ) {
   const { packageName, isGlobal } = options;
   const maybeGlobalArg = isGlobal ? '-g' : '';


### PR DESCRIPTION
Closes #66 

---

This is odd because `envinfo` issue still exists (when it shows correct data when executed in CLI but fails to find global packages on Windows while invoked via API) despite Windows fixed delivered. 
Fixing it using the `npm` invocation.