### PR TITLE
Fix for the deployment procedure of zkApps that use `o1js` of version < `v1.0.1` and that use local imports without the `.js` extension.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## Unreleased
 
+## [0.21.3](https://github.com/o1-labs/zkapp-cli/compare/0.21.2...0.21.3) - 2024-05-20
+
+### Fixed
+
+- Fixed the deployment procedure for zkApps that use `o1js` of version < `v1.0.1` and that use local imports without '.js' extension. [#654](https://github.com/o1-labs/zkapp-cli/pull/654)
+
 ## [0.21.2](https://github.com/o1-labs/zkapp-cli/compare/0.21.0...0.21.2) - 2024-05-20
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
-- Fixed the deployment procedure for zkApps that use `o1js` of version < `v1.0.1` and that use local imports without '.js' extension. [#654](https://github.com/o1-labs/zkapp-cli/pull/654)
+- Fixed the deployment procedure for zkApps that use `o1js` of version < `v1.0.1` and that use local imports without the `.js` extension. [#654](https://github.com/o1-labs/zkapp-cli/pull/654)
 
 ## [0.21.2](https://github.com/o1-labs/zkapp-cli/compare/0.21.0...0.21.2) - 2024-05-20
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zkapp-cli",
-  "version": "0.21.2",
+  "version": "0.21.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zkapp-cli",
-      "version": "0.21.2",
+      "version": "0.21.3",
       "license": "Apache-2.0",
       "dependencies": {
         "acorn": "^8.11.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zkapp-cli",
-  "version": "0.21.2",
+  "version": "0.21.3",
   "description": "CLI to create zkApps (zero-knowledge apps) for Mina Protocol",
   "homepage": "https://github.com/o1-labs/zkapp-cli/",
   "keywords": [

--- a/src/lib/helpers.js
+++ b/src/lib/helpers.js
@@ -224,15 +224,27 @@ function resolveModulePath(moduleName, basePath) {
 
   // Resolve relative or absolute paths based on the current file's directory
   if (path.isAbsolute(moduleName) || moduleName.startsWith('.')) {
-    return path.resolve(basePath, moduleName);
+    let modulePath = path.resolve(basePath, moduleName);
+    if (!fs.existsSync(modulePath)) {
+      // If the modulePath doesn't exist and doesn't already end with '.js'
+      if (!modulePath.endsWith('.js')) {
+        modulePath += '.js';
+      }
+    }
+    return path.resolve(modulePath);
   } else {
     // Module is a node_modules dependency
     const packagePath = path.join('node_modules', moduleName);
     const packageJsonPath = path.join(packagePath, 'package.json');
 
+    // Try to resolve the main file using the package.json
     if (fs.existsSync(packageJsonPath)) {
       const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'));
-      // Try to resolve the main file using the package.json
+      // Skip the primary entry point for the 'o1js' module
+      // This is necessary if the 'o1js' module is of < v1.0.1
+      if (moduleName === 'o1js') {
+        delete packageJson['main'];
+      }
       let mainFile =
         packageJson.main || packageJson?.exports?.node?.import || 'index.js';
       return path.join(packagePath, mainFile);

--- a/src/lib/helpers.js
+++ b/src/lib/helpers.js
@@ -225,13 +225,10 @@ function resolveModulePath(moduleName, basePath) {
   // Resolve relative or absolute paths based on the current file's directory
   if (path.isAbsolute(moduleName) || moduleName.startsWith('.')) {
     let modulePath = path.resolve(basePath, moduleName);
-    if (!fs.existsSync(modulePath)) {
-      // If the modulePath doesn't exist and doesn't already end with '.js'
-      if (!modulePath.endsWith('.js')) {
-        modulePath += '.js';
-      }
+    if (!fs.existsSync(modulePath) && !modulePath.endsWith('.js')) {
+      modulePath += '.js';
     }
-    return path.resolve(modulePath);
+    return modulePath;
   } else {
     // Module is a node_modules dependency
     const packagePath = path.join('node_modules', moduleName);


### PR DESCRIPTION
Closes #653
