### PR TITLE
Explicitly use IPv4 comms since 'localhost' can be resolved differently.

### DIFF
--- a/src/lib/constants.js
+++ b/src/lib/constants.js
@@ -44,9 +44,9 @@ const Constants = Object.freeze({
     'Error',
     'Fatal',
   ],
-  lightnetMinaDaemonGraphQlEndpoint: 'http://localhost:8080/graphql',
-  lightnetAccountManagerEndpoint: 'http://localhost:8181',
-  lightnetArchiveNodeApiEndpoint: 'http://localhost:8282',
+  lightnetMinaDaemonGraphQlEndpoint: 'http://127.0.0.1:8080/graphql',
+  lightnetAccountManagerEndpoint: 'http://127.0.0.1:8181',
+  lightnetArchiveNodeApiEndpoint: 'http://127.0.0.1:8282',
 });
 
 export default Constants;

--- a/src/lib/lightnet.js
+++ b/src/lib/lightnet.js
@@ -1099,7 +1099,7 @@ function printUsefulUrls() {
     ]);
     urls.push([
       chalk.bold('PostgreSQL connection string'),
-      chalk.reset('postgresql://postgres:postgres@localhost:5432/archive'),
+      chalk.reset('postgresql://postgres:postgres@127.0.0.1:5432/archive'),
     ]);
   }
   console.log(boldTitle);

--- a/tests/mocks/mocked-endpoints.ts
+++ b/tests/mocks/mocked-endpoints.ts
@@ -7,7 +7,7 @@ import http, {
 import { TestConstants, generateRandomInt } from '../utils/common-utils.js';
 
 const applicationName = '⚡️[Mocked Endpoints Service]';
-const host = 'localhost';
+const host = '127.0.0.1';
 const port = Number(
   process.env.MOCKED_ENDPOINTS_SERVICE_PORT ??
     TestConstants.mockedEndpointsServicePort
@@ -16,7 +16,7 @@ const port = Number(
 // Start the mocked endpoints service.
 const server: Server = http.createServer(createRequestListener());
 server.listen(port, host, () => {
-  console.log(`${applicationName}: Is running on http://localhost:${port}`);
+  console.log(`${applicationName}: Is running on http://${host}:${port}`);
 });
 
 function createRequestListener(): RequestListener {

--- a/tests/ui/ui.spec.ts
+++ b/tests/ui/ui.spec.ts
@@ -33,7 +33,7 @@ test.describe('Users', () => {
       );
 
       const devServerPort = await portfinder.getPortPromise();
-      const devServerUrl = new URL(`http://localhost:${devServerPort}`);
+      const devServerUrl = new URL(`http://127.0.0.1:${devServerPort}`);
       const projectName = crypto.randomUUID();
       const { spawn, cleanup, path } = await prepareEnvironment();
       let devServerProcess: ProcessPromise | undefined; // eslint-disable-line

--- a/tests/utils/network-utils.ts
+++ b/tests/utils/network-utils.ts
@@ -10,14 +10,14 @@ import {
 import { TestConstants } from './common-utils.js';
 
 export function getMockedEndpointsServiceEndpoint(): string {
-  return `http://localhost:${
+  return `http://127.0.0.1:${
     process.env.MOCKED_ENDPOINTS_SERVICE_PORT ??
     TestConstants.mockedEndpointsServicePort
   }`;
 }
 
 export async function getMinaGraphQlEndpoint(): Promise<string> {
-  const minaGraphQlEndpoint = `http://localhost:${
+  const minaGraphQlEndpoint = `http://127.0.0.1:${
     process.env.MINA_GRAPHQL_PORT ?? TestConstants.minaGraphQlPort
   }/graphql`;
 
@@ -252,11 +252,11 @@ async function getMinaAccountsManagerEndpoint(
     ? 'acquire-account'
     : 'release-account';
   const endpointPort = (await isEndpointAvailable(
-    `http://localhost:${accountsManagerPort}`,
+    `http://127.0.0.1:${accountsManagerPort}`,
     false
   ))
     ? accountsManagerPort
     : mockedAccountsManagerPort;
 
-  return `http://localhost:${endpointPort}/${endpointAction}`;
+  return `http://127.0.0.1:${endpointPort}/${endpointAction}`;
 }


### PR DESCRIPTION
Sometimes, while switching between the NodeJS versions, it was noticed that `localhost` can be resolved to IPv6 address and fails the Lightnet communications.
Possibly related to: https://github.com/nodejs/node/issues/40702