### PR TITLE
Change the way sources are fetched during the project generation.

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,4 @@
 node_modules
 build
 reports
+coverage

--- a/.npmignore
+++ b/.npmignore
@@ -3,3 +3,29 @@
 
 # System
 .DS_Store
+
+# Ignore the following only in the root directory
+/.git
+/.github
+/.husky
+/playwright.config.ts
+/jest.config.js
+/.prettierrc
+/.prettierignore
+/.npmignore
+/.gitignore
+/.gitattributes
+/.eslintrc
+/.eslintignore
+/tsconfig.json
+/src/lib/**/*.test.js
+/src/lib/**/*.test.ts
+/update-changelog.sh
+
+# Allow everything within the templates/project-ts
+!/templates/project-ts/**
+
+# Ignore the following globally
+node_modules
+coverage
+tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,13 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## Unreleased
 
+## [0.21.4](https://github.com/o1-labs/zkapp-cli/compare/0.21.3...0.21.4) - 2024-06-03
+
+### Changed
+
+- Improves the NPM packaging and changed the way sources are fetched during the project generation. [#662](https://github.com/o1-labs/zkapp-cli/pull/662)
+  - Generic project and example templates are now fetched from the locally installed `zkapp-cli` package (file-system copy).
+
 ## [0.21.3](https://github.com/o1-labs/zkapp-cli/compare/0.21.2...0.21.3) - 2024-05-20
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Changed
 
-- Improves the NPM packaging and changed the way sources are fetched during the project generation. [#662](https://github.com/o1-labs/zkapp-cli/pull/662)
-  - Generic project and example templates are now fetched from the locally installed `zkapp-cli` package (file-system copy).
+- Improved the NPM packaging and changed the way sources are fetched during the project generation. [#662](https://github.com/o1-labs/zkapp-cli/pull/662)
+  - Generic project and example templates are now fetched from the locally installed `zkapp-cli` package path (local file system copy).
 
 ## [0.21.3](https://github.com/o1-labs/zkapp-cli/compare/0.21.2...0.21.3) - 2024-05-20
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zkapp-cli",
-  "version": "0.21.4",
+  "version": "0.21.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zkapp-cli",
-      "version": "0.21.4",
+      "version": "0.21.5",
       "license": "Apache-2.0",
       "dependencies": {
         "acorn": "^8.11.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zkapp-cli",
-  "version": "0.21.3",
+  "version": "0.21.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zkapp-cli",
-      "version": "0.21.3",
+      "version": "0.21.4",
       "license": "Apache-2.0",
       "dependencies": {
         "acorn": "^8.11.3",
@@ -19,7 +19,6 @@
         "fast-glob": "^3.3.2",
         "find-npm-prefix": "^1.0.2",
         "fs-extra": "^11.2.0",
-        "gittar": "^0.1.1",
         "mina-signer": "^3.0.7",
         "o1js": "^1.*",
         "opener": "^1.5.2",
@@ -2565,11 +2564,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/chownr": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
-    },
     "node_modules/ci-info": {
       "version": "3.9.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
@@ -3660,14 +3654,6 @@
         "node": ">=14.14"
       }
     },
-    "node_modules/fs-minipass": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.7.tgz",
-      "integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
-      "dependencies": {
-        "minipass": "^2.6.0"
-      }
-    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -3742,18 +3728,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/gittar": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/gittar/-/gittar-0.1.1.tgz",
-      "integrity": "sha512-p+XuqWJpW9ahUuNTptqeFjudFq31o6Jd+maMBarkMAR5U3K9c7zJB4sQ4BV8mIqrTOV29TtqikDhnZfCD4XNfQ==",
-      "dependencies": {
-        "mkdirp": "^0.5.1",
-        "tar": "^4.4.1"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/glob": {
@@ -6047,31 +6021,16 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/minipass": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
-      "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
-      "dependencies": {
-        "safe-buffer": "^5.1.2",
-        "yallist": "^3.0.0"
-      }
-    },
-    "node_modules/minizlib": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.3.3.tgz",
-      "integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
-      "dependencies": {
-        "minipass": "^2.9.0"
       }
     },
     "node_modules/mkdirp": {
       "version": "0.5.6",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
       "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "dev": true,
       "dependencies": {
         "minimist": "^1.2.6"
       },
@@ -7440,23 +7399,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/tar": {
-      "version": "4.4.19",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.19.tgz",
-      "integrity": "sha512-a20gEsvHnWe0ygBY8JbxoM4w3SJdhc7ZAuxkLqh+nvNQN2IOt0B5lLgM490X5Hl8FF0dl0tOf2ewFYAlIFgzVA==",
-      "dependencies": {
-        "chownr": "^1.1.4",
-        "fs-minipass": "^1.2.7",
-        "minipass": "^2.9.0",
-        "minizlib": "^1.3.3",
-        "mkdirp": "^0.5.5",
-        "safe-buffer": "^5.2.1",
-        "yallist": "^3.1.1"
-      },
-      "engines": {
-        "node": ">=4.5"
-      }
-    },
     "node_modules/tar-stream": {
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.2.tgz",
@@ -7971,7 +7913,8 @@
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true
     },
     "node_modules/yaml": {
       "version": "2.3.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zkapp-cli",
-  "version": "0.21.3",
+  "version": "0.21.4",
   "description": "CLI to create zkApps (zero-knowledge apps) for Mina Protocol",
   "homepage": "https://github.com/o1-labs/zkapp-cli/",
   "keywords": [
@@ -60,7 +60,6 @@
     "fast-glob": "^3.3.2",
     "find-npm-prefix": "^1.0.2",
     "fs-extra": "^11.2.0",
-    "gittar": "^0.1.1",
     "mina-signer": "^3.0.7",
     "o1js": "^1.*",
     "opener": "^1.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zkapp-cli",
-  "version": "0.21.4",
+  "version": "0.21.5",
   "description": "CLI to create zkApps (zero-knowledge apps) for Mina Protocol",
   "homepage": "https://github.com/o1-labs/zkapp-cli/",
   "keywords": [

--- a/src/lib/example.js
+++ b/src/lib/example.js
@@ -53,13 +53,12 @@ export async function example(example) {
   }
 
   const dir = findUniqueDir(example);
-  const lang = 'ts';
   const isWindows = process.platform === 'win32';
 
-  if (!(await setupProject(path.join(shell.pwd().toString(), dir), lang))) {
+  if (!(await setupProject(path.join(shell.pwd().toString(), dir)))) {
     shell.exit(1);
   }
-  if (!(await updateExampleSources(example, dir, lang))) {
+  if (!(await updateExampleSources(example, dir))) {
     shell.exit(1);
   }
 
@@ -179,10 +178,10 @@ export function kebabCase(str) {
  * Updates the example sources.
  * @param {string} example     Name of the example.
  * @param {string} name        Destination dir name.
- * @param {string} lang        ts or js
+ * @param {string} lang        ts (default) or js
  * @returns {Promise<boolean>} True if successful; false if not.
  */
-export async function updateExampleSources(example, name, lang) {
+export async function updateExampleSources(example, name, lang = 'ts') {
   const step = 'Update example sources';
   const spin = ora(`${step}...`).start();
 

--- a/src/lib/example.js
+++ b/src/lib/example.js
@@ -207,7 +207,7 @@ export async function updateExampleSources(example, name, lang) {
     // Delete the project template's `src` & use the example's `src` instead.
     const srcPath = path.resolve(name, 'src');
     shell.rm('-r', srcPath);
-    // node:fs.cpSync instead of shell.cp because ShellJS does not implement `cp -a`
+    // `node:fs.cpSync` instead of the `shell.cp` because `ShellJS` does not implement `cp -a`
     // https://github.com/shelljs/shelljs/issues/79#issuecomment-30821277
     fs.cpSync(`${examplePath}/`, `${srcPath}/`, { recursive: true });
     spin.succeed(chalk.green(step));

--- a/src/lib/example.js
+++ b/src/lib/example.js
@@ -183,7 +183,7 @@ export function kebabCase(str) {
  * @returns {Promise<boolean>} True if successful; false if not.
  */
 export async function updateExampleSources(example, name, lang) {
-  const step = 'Prepare example sources';
+  const step = 'Update example sources';
   const spin = ora(`${step}...`).start();
 
   try {

--- a/src/lib/example.js
+++ b/src/lib/example.js
@@ -207,6 +207,8 @@ export async function updateExampleSources(example, name, lang) {
     // Delete the project template's `src` & use the example's `src` instead.
     const srcPath = path.resolve(name, 'src');
     shell.rm('-r', srcPath);
+    // node:fs.cpSync instead of shell.cp because ShellJS does not implement `cp -a`
+    // https://github.com/shelljs/shelljs/issues/79#issuecomment-30821277
     fs.cpSync(`${examplePath}/`, `${srcPath}/`, { recursive: true });
     spin.succeed(chalk.green(step));
     return true;

--- a/src/lib/helpers.js
+++ b/src/lib/helpers.js
@@ -69,7 +69,7 @@ export async function setupProject(destination, lang) {
     const destDir = path.resolve(destination);
     shell.mkdir('-p', destDir);
     shell.cd(destDir);
-    // node:fs.cpSync instead of shell.cp because ShellJS does not implement `cp -a`
+    // `node:fs.cpSync` instead of the `shell.cp` because `ShellJS` does not implement `cp -a`
     // https://github.com/shelljs/shelljs/issues/79#issuecomment-30821277
     fs.cpSync(`${templatePath}/`, `${destDir}/`, { recursive: true });
     shell.mv(

--- a/src/lib/helpers.js
+++ b/src/lib/helpers.js
@@ -49,10 +49,10 @@ async function step(str, fn) {
 /**
  * Sets up the new project from the template.
  * @param {string} destination Destination dir path.
- * @param {string} lang        ts or js
+ * @param {string} lang        ts (default) or js
  * @returns {Promise<boolean>} True if successful; false if not.
  */
-export async function setupProject(destination, lang) {
+export async function setupProject(destination, lang = 'ts') {
   const currentDir = shell.pwd().toString();
   const projectName = lang === 'ts' ? 'project-ts' : 'project';
   const templatePath = path.resolve(

--- a/src/lib/helpers.js
+++ b/src/lib/helpers.js
@@ -69,6 +69,8 @@ export async function setupProject(destination, lang) {
     const destDir = path.resolve(destination);
     shell.mkdir('-p', destDir);
     shell.cd(destDir);
+    // node:fs.cpSync instead of shell.cp because ShellJS does not implement `cp -a`
+    // https://github.com/shelljs/shelljs/issues/79#issuecomment-30821277
     fs.cpSync(`${templatePath}/`, `${destDir}/`, { recursive: true });
     shell.mv(
       path.resolve(destDir, '_.gitignore'),

--- a/src/lib/project.js
+++ b/src/lib/project.js
@@ -2,7 +2,6 @@ import chalk from 'chalk';
 import { spawnSync } from 'child_process';
 import enquirer from 'enquirer';
 import fs from 'fs-extra';
-import gittar from 'gittar';
 import ora from 'ora';
 import path from 'path';
 import shell from 'shelljs';
@@ -14,6 +13,7 @@ import nuxtGradientBackground from '../lib/ui/nuxt/nuxtGradientBackground.js';
 import customLayoutSvelte from '../lib/ui/svelte/customLayoutSvelte.js';
 import customPageSvelte from '../lib/ui/svelte/customPageSvelte.js';
 import Constants from './constants.js';
+import { setupProject } from './helpers.js';
 import gradientBackground from './ui/svelte/gradientBackground.js';
 
 const __filename = url.fileURLToPath(import.meta.url);
@@ -40,6 +40,7 @@ export async function project({ name, ui }) {
     shell.exit(1);
   }
 
+  const lang = 'ts';
   let res;
   if (!ui) {
     try {
@@ -121,7 +122,9 @@ export async function project({ name, ui }) {
     shell.mkdir('contracts');
     shell.cd('contracts');
   }
-  if (!(await fetchProjectTemplate())) shell.exit(1);
+  if (!(await setupProject(shell.pwd().toString(), lang))) {
+    shell.exit(1);
+  }
 
   await step(
     'NPM install',
@@ -149,50 +152,6 @@ export async function project({ name, ui }) {
 
   console.log(chalk.green(str));
   process.exit(0);
-}
-
-/**
- * Fetch project template.
- * @returns {Promise<boolean>} - True if successful; false if not.
- */
-async function fetchProjectTemplate() {
-  const projectName = 'project-ts';
-
-  const step = 'Set up project';
-  const spin = ora({ text: `${step}...`, discardStdin: true }).start();
-
-  try {
-    const src = 'github:o1-labs/zkapp-cli#main';
-    await gittar.fetch(src, { force: true });
-
-    // Note: Extract will overwrite any existing dir's contents. Ensure
-    // destination does not exist before this.
-    const TEMP = '.gittar-temp-dir';
-    await gittar.extract(src, TEMP, {
-      filter(path) {
-        return path.includes(`templates/${projectName}/`);
-      },
-    });
-
-    // Copy files into current working dir
-    shell.cp(
-      '-r',
-      `${path.join(TEMP, 'templates', projectName)}${path.sep}.`,
-      '.'
-    );
-    shell.rm('-r', TEMP);
-
-    // Create a keys dir because it's not part of the project scaffolding given
-    // we have `keys` in our .gitignore.
-    shell.mkdir('keys');
-
-    spin.succeed(chalk.green(step));
-    return true;
-  } catch (err) {
-    spin.fail(step);
-    console.error(err);
-    return false;
-  }
 }
 
 /**

--- a/src/lib/project.js
+++ b/src/lib/project.js
@@ -40,7 +40,6 @@ export async function project({ name, ui }) {
     shell.exit(1);
   }
 
-  const lang = 'ts';
   let res;
   if (!ui) {
     try {
@@ -122,7 +121,7 @@ export async function project({ name, ui }) {
     shell.mkdir('contracts');
     shell.cd('contracts');
   }
-  if (!(await setupProject(shell.pwd().toString(), lang))) {
+  if (!(await setupProject(shell.pwd().toString()))) {
     shell.exit(1);
   }
 

--- a/templates/project-ts/_.gitignore
+++ b/templates/project-ts/_.gitignore
@@ -1,6 +1,6 @@
 # NodeJS
-node_modules
 build
+node_modules
 coverage
 
 # Editor

--- a/templates/project-ts/_.npmignore
+++ b/templates/project-ts/_.npmignore
@@ -1,5 +1,8 @@
-# TypeScript files
+# Source files
 src
+
+node_modules
+coverage
 
 # Editor
 .vscode

--- a/tests/utils/common-utils.ts
+++ b/tests/utils/common-utils.ts
@@ -327,15 +327,11 @@ export function getZkAppSmartContractNameFromAlias(
 
 export async function checkSmartContractsFilesystem(
   path: string,
-  checkKeysExistence: boolean,
   listFilesystemFn: CLITestEnvironment['ls'],
   existsOnFilesystemFn: CLITestEnvironment['exists']
 ): Promise<void> {
   expect(await existsOnFilesystemFn(path)).toBe(true);
   expect((await listFilesystemFn(path)).length).toBeGreaterThan(0);
-  if (checkKeysExistence) {
-    expect(await existsOnFilesystemFn(`${path}/keys`)).toBe(true);
-  }
   expect(await existsOnFilesystemFn(`${path}/config.json`)).toBe(true);
   expect(await existsOnFilesystemFn(`${path}/package.json`)).toBe(true);
 }

--- a/tests/utils/example-utils.ts
+++ b/tests/utils/example-utils.ts
@@ -7,10 +7,7 @@ import {
   executeInteractiveCommand,
   generateInputsForOptionSelection,
 } from './cli-utils.js';
-import {
-  checkSmartContractsFilesystem,
-  getBooleanFromString,
-} from './common-utils.js';
+import { checkSmartContractsFilesystem } from './common-utils.js';
 
 export async function zkExample(
   exampleType: ExampleType,
@@ -20,12 +17,6 @@ export async function zkExample(
   const cliArgs = skipInteractiveSelection ? `--name ${exampleType}` : '';
   const command = `example ${cliArgs}`.replace(/\s{2,}/g, ' ');
   let interactiveDialog = {};
-
-  if (getBooleanFromString(process.env.CI)) {
-    // Because of the way how it behaves in CI
-    // https://github.com/o1-labs/zkapp-cli/blob/f977c91ac11fe333b86317d6092c7a0d151a9529/src/lib/example.js#L113
-    delete process.env.CI;
-  }
 
   if (!skipInteractiveSelection) {
     interactiveDialog = {

--- a/tests/utils/example-utils.ts
+++ b/tests/utils/example-utils.ts
@@ -56,7 +56,6 @@ export async function checkZkExample(
   expect(stdOut).toContain('Next steps:');
   await checkSmartContractsFilesystem(
     path,
-    false,
     listFilesystemFn,
     existsOnFilesystemFn
   );

--- a/tests/utils/project-utils.ts
+++ b/tests/utils/project-utils.ts
@@ -108,7 +108,6 @@ export async function checkZkProject(
     case 'nuxt': {
       await checkSmartContractsFilesystem(
         contractsPath,
-        true,
         listFilesystemFn,
         existsOnFilesystemFn
       );
@@ -118,7 +117,6 @@ export async function checkZkProject(
     case 'empty': {
       await checkSmartContractsFilesystem(
         contractsPath,
-        true,
         listFilesystemFn,
         existsOnFilesystemFn
       );
@@ -129,7 +127,6 @@ export async function checkZkProject(
     case 'none': {
       await checkSmartContractsFilesystem(
         `./${projectName}`,
-        true,
         listFilesystemFn,
         existsOnFilesystemFn
       );


### PR DESCRIPTION
Closes #615
E2E testing results: https://github.com/o1-labs/zkapp-cli/actions/runs/9331728280

---

- The NPM package content has been improved (you can check it locally with the `npm pack` and compare with the [currently published one](https://www.npmjs.com/package/zkapp-cli?activeTab=code)).
- We now use `templates` and `examples` from file system of installed application.
- We no longer depend on `gittat` dependency (which also has some vulnerabilities as of time of writing).
- We had to rename `templates/project-ts/.gitignore` and `templates/project-ts/.npmignore` by adding the `_` prefix because these configs were recursively applied upon the publishing to NPM and there is no other way to skip their application except of having them with wrong names but rename them once projects/examples generated.
- We don't need to explicitly create the `keys` dir because it will be handled by the `zk config` and there is no issue not having the folder created while having the `.gitignore` entry for it.
- Tested on `Windows`, `Linux` and `macOS`.
- The `TODO` in CI config: `# TODO: Add successful e2e smoke testing to preconditions after the https://github.com/o1-labs/zkapp-cli/issues/615 is resolved` will be addressed in more general CI config refactoring that is part of the https://github.com/o1-labs/zkapp-cli/pull/661.