### PR TITLE
Respect the updated branching strategy.

### DIFF
--- a/.github/workflows/nightly-e2e-ci-tests.yml
+++ b/.github/workflows/nightly-e2e-ci-tests.yml
@@ -9,7 +9,7 @@ on:
     - cron: '0 0 * * *'
   workflow_dispatch: {}
 jobs:
-  against-real-network-on-linux:
+  against-compatible-real-network-on-linux:
     timeout-minutes: 185
     runs-on: ${{ matrix.os }}
     strategy:
@@ -20,7 +20,44 @@ jobs:
         os: [ubuntu-latest]
     services:
       mina-local-network:
-        image: o1labs/mina-local-network:berkeley-latest-lightnet
+        image: o1labs/mina-local-network:compatible-latest-lightnet
+        env:
+          NETWORK_TYPE: 'single-node'
+          PROOF_LEVEL: 'none'
+        ports:
+          - 3085:3085
+          - 5432:5432
+          - 8080:8080
+          - 8181:8181
+          - 8282:8282
+        volumes:
+          - /tmp:/root/logs
+    steps:
+      - name: Wait for Mina network readiness
+        uses: o1-labs/wait-for-mina-network-action@v1
+        with:
+          mina-graphql-port: 8080
+          max-attempts: 60
+          polling-interval-ms: 10000
+      - uses: actions/checkout@v4
+      - name: Use shared E2E testing steps
+        uses: ./.github/actions/e2e-shared
+        with:
+          node-version: ${{ matrix.node }}
+          os-type: ${{ matrix.os }}
+          shell: bash
+  against-master-real-network-on-linux:
+    timeout-minutes: 185
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: true
+      matrix:
+        # https://github.com/shelljs/shelljs/issues/1133
+        node: [18, 20]
+        os: [ubuntu-latest]
+    services:
+      mina-local-network:
+        image: o1labs/mina-local-network:master-latest-lightnet
         env:
           NETWORK_TYPE: 'single-node'
           PROOF_LEVEL: 'none'

--- a/.github/workflows/smoke-e2e-ci-tests.yml
+++ b/.github/workflows/smoke-e2e-ci-tests.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
   workflow_dispatch: {}
 jobs:
-  against-real-network-on-linux:
+  against-compatible-real-network-on-linux:
     timeout-minutes: 30
     runs-on: ${{ matrix.os }}
     strategy:
@@ -15,7 +15,46 @@ jobs:
         os: [ubuntu-latest]
     services:
       mina-local-network:
-        image: o1labs/mina-local-network:berkeley-latest-lightnet
+        image: o1labs/mina-local-network:compatible-latest-lightnet
+        env:
+          NETWORK_TYPE: 'single-node'
+          PROOF_LEVEL: 'none'
+        ports:
+          - 3085:3085
+          - 5432:5432
+          - 8080:8080
+          - 8181:8181
+          - 8282:8282
+        volumes:
+          - /tmp:/root/logs
+    steps:
+      - name: Wait for Mina network readiness
+        uses: o1-labs/wait-for-mina-network-action@v1
+        with:
+          mina-graphql-port: 8080
+          max-attempts: 60
+          polling-interval-ms: 10000
+      - uses: actions/checkout@v4
+      - name: Use shared E2E testing steps
+        uses: ./.github/actions/e2e-shared
+        with:
+          node-version: ${{ matrix.node }}
+          os-type: ${{ matrix.os }}
+          shell: bash
+          test-script: 'npm run e2e:test:smoke'
+          artifacts-prefix: 'smoke-e2e-tests'
+  against-master-real-network-on-linux:
+    timeout-minutes: 30
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: true
+      matrix:
+        # https://github.com/shelljs/shelljs/issues/1133
+        node: [18, 20]
+        os: [ubuntu-latest]
+    services:
+      mina-local-network:
+        image: o1labs/mina-local-network:master-latest-lightnet
         env:
           NETWORK_TYPE: 'single-node'
           PROOF_LEVEL: 'none'

--- a/README.md
+++ b/README.md
@@ -149,12 +149,12 @@ Respond to the interactive command prompts to build or update a deploy alias.
 
 A deploy alias consists of:
 
-- A self-describing name. This tutorial uses `berkeley`. The deploy alias name can be anything and does not have to match the network name.
-- The Mina GraphQL API URL that defines the network that receives your deploy transaction and broadcasts it to the appropriate Mina network (Testnet, Devnet, Mainnet, and so on)
+- A self-describing name. This tutorial uses `devnet`. The deploy alias name can be anything and does not have to match the network name.
+- The Mina GraphQL API URL that defines the network that receives your deploy transaction and broadcasts it to the appropriate Mina network (Devnet, Mainnet, and so on)
 - The transaction fee (in MINA) to use when deploying
 - Two key pairs:
 
-  - A key pair for the zkApp account. Public and private keys to use in your application are automatically generated in `keys/berkeley.json`.
+  - A key pair for the zkApp account. Public and private keys to use in your application are automatically generated in `keys/devnet.json`.
 
   - A key pair to use as a fee payer account for updates and deployments. Public and private keys are stored on your local computer and can be used across multiple projects.
 
@@ -172,8 +172,6 @@ zk deploy <alias>
 // OR
 zk deploy // shows a list of aliases in your project to choose from
 ```
-
-_**Deployment is supported only to Berkeley Testnet until zkApp programmability is available on Mina Mainnet.**_
 
 After you run `zk config`, the `zk deploy` command allows you to deploy a smart contract to a specified deploy alias.
 

--- a/src/bin/index.js
+++ b/src/bin/index.js
@@ -210,7 +210,7 @@ function lightnetCli() {
               string: true,
               hidden: false,
               choices: Constants.lightnetMinaBranches,
-              default: 'berkeley',
+              default: 'compatible',
               description:
                 'One of the major Mina repository branches the Docker image artifacts were compiled against.',
             },

--- a/src/lib/constants.js
+++ b/src/lib/constants.js
@@ -8,7 +8,7 @@ import path from 'path';
  * @typedef {'single-node' | 'multi-node'} LightnetMode
  * @typedef {'fast' | 'real'} LightnetType
  * @typedef {'none' | 'full'} LightnetProofLevel
- * @typedef {'berkeley' | 'develop'} LightnetMinaBranch
+ * @typedef {'master' | 'compatible' | 'develop'} LightnetMinaBranch
  * @typedef {'Spam' | 'Trace' | 'Debug' | 'Info' | 'Warn' | 'Error' | 'Fatal'} LightnetMinaLogLevel
  *
  * @type {{ uiTypes: UiType[], exampleTypes: ExampleType[], feePayerCacheDir: string, networkIds: NetworkId[], lightnetWorkDir: string, lightnetModes: LightnetMode[], lightnetTypes: LightnetType[], lightnetProofLevels: LightnetProofLevel[], lightnetMinaBranches: LightnetMinaBranch[], lightnetProcessToLogFileMapping: Map<string, string>, lightnetMinaProcessesLogLevels: LightnetMinaLogLevel[], lightnetMinaDaemonGraphQlEndpoint: string, lightnetAccountManagerEndpoint: string, lightnetArchiveNodeApiEndpoint: string }}
@@ -22,7 +22,7 @@ const Constants = Object.freeze({
   lightnetModes: ['single-node', 'multi-node'],
   lightnetTypes: ['fast', 'real'],
   lightnetProofLevels: ['none', 'full'],
-  lightnetMinaBranches: ['berkeley', 'develop'],
+  lightnetMinaBranches: ['master', 'compatible', 'develop'],
   lightnetProcessToLogFileMapping: new Map([
     ['Archive-Node-API application', 'logs/archive-node-api.log'],
     ['Mina Archive process', 'logs/archive-node.log,archive/log.txt'],

--- a/templates/project-ts/.github/workflows/ci.yml
+++ b/templates/project-ts/.github/workflows/ci.yml
@@ -12,7 +12,34 @@ jobs:
       matrix:
         node: [18, 20]
         os: [ubuntu-latest]
+    #
+    # Enable the following block if you want to also use the Lightnet in your tests.
+    #
+    # services:
+    #   mina-local-network:
+    #     image: o1labs/mina-local-network:compatible-latest-lightnet
+    #     env:
+    #       NETWORK_TYPE: 'single-node'
+    #       PROOF_LEVEL: 'none'
+    #       LOG_LEVEL: 'Info'
+    #     ports:
+    #       - 3085:3085
+    #       - 5432:5432
+    #       - 8080:8080
+    #       - 8181:8181
+    #       - 8282:8282
+    #     volumes:
+    #       - /tmp:/root/logs
     steps:
+      #
+      # Enable the following block if you want to also use the Lightnet in your tests.
+      #
+      # - name: Wait for Mina network readiness
+      #   uses: o1-labs/wait-for-mina-network-action@v1
+      #   with:
+      #     mina-graphql-port: 8080
+      #     max-attempts: 60
+      #     polling-interval-ms: 10000
       - name: Set up NodeJS
         uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
Closes #665.

---

- We are going to execute E2E tests against the Mina's `master` **and** `compatible` branches.
- A bit of improvements here and there (slightly updated readme, added a commented out section for the template's CI to use the Lightnet is needed).