### PR TITLE
chore(package.json): update template typescript, jest and ts-jest versions

### DIFF
--- a/templates/project-ts/jest.config.js
+++ b/templates/project-ts/jest.config.js
@@ -3,14 +3,9 @@ export default {
   verbose: true,
   preset: 'ts-jest/presets/default-esm',
   testEnvironment: 'node',
-  globals: {
-    'ts-jest': {
-      useESM: true,
-    },
-  },
   testTimeout: 1_000_000,
   transform: {
-    '^.+\\.(t)s$': 'ts-jest',
+    '^.+\\.(t)s$': ['ts-jest', { useESM: true }],
     '^.+\\.(j)s$': 'babel-jest',
   },
   resolver: '<rootDir>/jest-resolver.cjs',

--- a/templates/project-ts/package.json
+++ b/templates/project-ts/package.json
@@ -33,7 +33,7 @@
     "jest": "^28.1.3",
     "prettier": "^2.3.2",
     "ts-jest": "^28.0.8",
-    "typescript": "^5.1"
+    "typescript": "^5.4.5"
   },
   "peerDependencies": {
     "o1js": "^1.*"

--- a/templates/project-ts/package.json
+++ b/templates/project-ts/package.json
@@ -25,14 +25,14 @@
   "devDependencies": {
     "@babel/preset-env": "^7.16.4",
     "@babel/preset-typescript": "^7.16.0",
-    "@types/jest": "^27.0.3",
+    "@types/jest": "^29.5.12",
     "@typescript-eslint/eslint-plugin": "^5.5.0",
     "@typescript-eslint/parser": "^5.5.0",
     "eslint": "^8.7.0",
     "eslint-plugin-o1js": "^0.4.0",
-    "jest": "^28.1.3",
+    "jest": "^29.7.0",
     "prettier": "^2.3.2",
-    "ts-jest": "^28.0.8",
+    "ts-jest": "^29.2.4",
     "typescript": "^5.4.5"
   },
   "peerDependencies": {


### PR DESCRIPTION
Closes #672

This PR updates typescript version of template project to match with ts version of o1js. Jest and ts-jest are updated to typescript v5 compatible versions.