### PR TITLE
Mark o1js as an external dependency for next JS server config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Fixed
 
 - Fixed zkProgramFile to support nested paths. [#690](https://github.com/o1-labs/zkapp-cli/pull/690)
+- Fixed o1js dependency issue for next js server [#693](https://github.com/o1-labs/zkapp-cli/pull/693)
 
 ## [0.21.5](https://github.com/o1-labs/zkapp-cli/compare/0.21.4...0.21.5) - 2024-06-06
 

--- a/src/lib/project.js
+++ b/src/lib/project.js
@@ -362,6 +362,8 @@ const __dirname = path.dirname(__filename);
         ...config.resolve.alias,
         o1js: path.resolve(__dirname, 'node_modules/o1js/dist/web/index.js'),
       };
+    } else {
+      config.externals.push('o1js') // https://nextjs.org/docs/app/api-reference/next-config-js/serverExternalPackages
     }
     config.experiments = { ...config.experiments, topLevelAwait: true };
     return config;


### PR DESCRIPTION
## Summary

Thanks to @anarkrypto on this issue https://github.com/o1-labs/o1js/issues/1811 !  This added config fixes the `Error: ENOENT: no such file or directory, open '.../.../.next/server/vendor-chunks/plonk_wasm_bg.wasm` issue in next js server