### PR TITLE
Release v22.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zkapp-cli",
-  "version": "0.21.8",
+  "version": "0.22.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zkapp-cli",
-      "version": "0.21.8",
+      "version": "0.22.0",
       "license": "Apache-2.0",
       "dependencies": {
         "acorn": "^8.12.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "find-npm-prefix": "^1.0.2",
         "fs-extra": "^11.2.0",
         "mina-signer": "^3.0.7",
-        "o1js": "^1.*",
+        "o1js": "^2.*",
         "opener": "^1.5.2",
         "ora": "^8.0.1",
         "semver": "^7.6.2",
@@ -6641,9 +6641,10 @@
       }
     },
     "node_modules/o1js": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/o1js/-/o1js-1.0.1.tgz",
-      "integrity": "sha512-af+HS1zdJeMwvXvsb4U7PgpuBDTB40ziQHGRQQXOUzOLCA+CyV+ouUDfg7P4DS2ocS0M+M2mQZkuuxXc5ZSM5w==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/o1js/-/o1js-2.0.0.tgz",
+      "integrity": "sha512-mYCxUkdCgmfF4v8JOTreYJP/PsAUXGkAbDZJn1uRxWlfZ+Eepls1O2fpTKQ5W9DC64vu0LlQZp9uqWKxW4lrVQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "blakejs": "1.2.1",
         "cachedir": "^2.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zkapp-cli",
-  "version": "0.21.8",
+  "version": "0.22.0",
   "description": "CLI to create zkApps (zero-knowledge apps) for Mina Protocol",
   "homepage": "https://github.com/o1-labs/zkapp-cli/",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "find-npm-prefix": "^1.0.2",
     "fs-extra": "^11.2.0",
     "mina-signer": "^3.0.7",
-    "o1js": "^1.*",
+    "o1js": "^2.*",
     "opener": "^1.5.2",
     "ora": "^8.0.1",
     "semver": "^7.6.2",

--- a/templates/project-ts/package.json
+++ b/templates/project-ts/package.json
@@ -36,7 +36,7 @@
     "typescript": "^5.4.5"
   },
   "peerDependencies": {
-    "o1js": "^1.*"
+    "o1js": "^2.*"
   },
   "engines": {
     "node": ">=18.14.0"


### PR DESCRIPTION
# Description

This PR releases version `0.22.0` of the `zkapp-CLI` which coincides with [release](https://github.com/o1-labs/o1js/pull/1873) version `2.0.0` of `o1js`.

The `o1js` major version dependency in the CLI `package.json` was updated to  `^2.*`. The o1js major version peer dependency was updated in `template/example` contracts `package.json `to `^2.*`. 


# Testing
The updates introduced in this PR have been tested with the full e2e suite.