### PR TITLE
Fix e2e tests and lock file, deps audit.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Changed
 
-- Release `0.22.0` corresponding with o1js [release](https://github.com/o1-labs/o1js/pull/1881) `2.0.0`. [#702](https://github.com/o1-labs/zkapp-cli/pull/702) 
+- Release `0.22.0` corresponding with o1js [release](https://github.com/o1-labs/o1js/pull/1881) `2.0.0`. [#702](https://github.com/o1-labs/zkapp-cli/pull/702)
   - o1js minor version dependency updated in cli package.json to `^2.*`\*.
   - o1js minor version peer dependency updated in template/example contract package.json to `^2.*`\*.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-## Contributing
+# Contributing
 
 Welcome to the zkApp CLI open source repository. Thank you for being a part of the Mina ecosystem and for your interest in contributing to the zkApp CLI project.
 
@@ -12,12 +12,11 @@ By contributing, you can help us improve the functionality and user experience o
 
 All contributors agree to respect and follow the Mina Protocol [Code of Conduct](https://github.com/MinaProtocol/mina/blob/develop/CODE_OF_CONDUCT.md).
 
-
 ## Did you find a bug?
 
 To see if others have also experienced the issue:
 
-- Ask questions in the Mina Protocol Discord in the  [#zkapps-developers](https://discord.com/channels/484437221055922177/915745847692636181) channel on Mina Protocol Discord. 
+- Ask questions in the Mina Protocol Discord in the [#zkapps-developers](https://discord.com/channels/484437221055922177/915745847692636181) channel on Mina Protocol Discord.
 - Check if the bug was already reported by searching on GitHub under [Issues](https://github.com/o1-labs/zkapp-cli/issues).
 
 If you don't find an open issue addressing the problem, open a new one. Be sure to include a title and clear description, as much relevant information as possible, and the output of the `zk system` command. This information includes your OS, NodeJS, and zkapp-cli versions to help us reproduce the issue.
@@ -56,7 +55,7 @@ Make your changes and commit:
 git push origin <your-branch>
 ```
 
-Create and submit your pull request against the `main` branch. 
+Create and submit your pull request against the `main` branch.
 
 To switch back to the released version of zkApp CLI:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zkapp-cli",
-  "version": "0.22.2",
+  "version": "0.22.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zkapp-cli",
-      "version": "0.22.2",
+      "version": "0.22.3",
       "license": "Apache-2.0",
       "dependencies": {
         "acorn": "^8.12.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zkapp-cli",
-  "version": "0.22.1",
+  "version": "0.22.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zkapp-cli",
-      "version": "0.22.1",
+      "version": "0.22.2",
       "license": "Apache-2.0",
       "dependencies": {
         "acorn": "^8.12.1",
@@ -34,7 +34,7 @@
         "zkapp-cli": "src/bin/index.js"
       },
       "devDependencies": {
-        "@playwright/test": "^1.45.1",
+        "@playwright/test": "^1.49.0",
         "@shimkiv/cli-testing-library": "^0.1.7",
         "@types/fs-extra": "^11.0.4",
         "@types/jest": "^29.5.12",
@@ -1913,13 +1913,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.45.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.45.1.tgz",
-      "integrity": "sha512-Wo1bWTzQvGA7LyKGIZc8nFSTFf2TkthGIFBR+QVNilvwouGzFd4PYukZe3rvf5PSqjHi1+1NyKSDZKcQWETzaA==",
+      "version": "1.49.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.49.0.tgz",
+      "integrity": "sha512-DMulbwQURa8rNIQrf94+jPJQ4FmOVdpE5ZppRNvWVjvhC+6sOeo28r8MgIpQRYouXRtt/FCCXU7zn20jnHR4Qw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.45.1"
+        "playwright": "1.49.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -3190,10 +3190,11 @@
       }
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -6468,9 +6469,9 @@
       }
     },
     "node_modules/micromatch": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.7.tgz",
-      "integrity": "sha512-LPP/3KorzCwBxfeUuZmaR6bG2kdeHSbe0P2tY3FLRU4vYrjYz5hI4QZwV0njUx3jeuKe67YukQ1LSPZBKDqO/Q==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "license": "MIT",
       "dependencies": {
         "braces": "^3.0.3",
@@ -7081,13 +7082,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.45.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.45.1.tgz",
-      "integrity": "sha512-Hjrgae4kpSQBr98nhCj3IScxVeVUixqj+5oyif8TdIn2opTCPEzqAqNMeK42i3cWDCVu9MI+ZsGWw+gVR4ISBg==",
+      "version": "1.49.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.49.0.tgz",
+      "integrity": "sha512-eKpmys0UFDnfNb3vfsf8Vx2LEOtflgRebl0Im2eQQnYMA4Aqd+Zw8bEOB+7ZKvN76901mRnqdsiOGKxzVTbi7A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.45.1"
+        "playwright-core": "1.49.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -7100,9 +7101,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.45.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.45.1.tgz",
-      "integrity": "sha512-LF4CUUtrUu2TCpDw4mcrAIuYrEjVDfT1cHbJMfwnE2+1b8PZcFzPNgvZCvq2JfQ4aTjRCCHw5EJ2tmr2NSzdPg==",
+      "version": "1.49.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.49.0.tgz",
+      "integrity": "sha512-R+3KKTQF3npy5GTiKH/T+kdhoJfJojjHESR1YEWhYuEKRVfVaxH3+4+GvXE5xyCngCxhxnykk0Vlah9v8fs3jA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zkapp-cli",
-  "version": "0.22.2",
+  "version": "0.22.3",
   "description": "CLI to create zkApps (zero-knowledge apps) for Mina Protocol",
   "homepage": "https://github.com/o1-labs/zkapp-cli/",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "yargs": "^17.7.2"
   },
   "devDependencies": {
-    "@playwright/test": "^1.45.1",
+    "@playwright/test": "^1.49.0",
     "@shimkiv/cli-testing-library": "^0.1.7",
     "@types/fs-extra": "^11.0.4",
     "@types/jest": "^29.5.12",

--- a/src/lib/ui/next/customNextPage.js
+++ b/src/lib/ui/next/customNextPage.js
@@ -6,16 +6,12 @@ import GradientBG from '../components/GradientBG.js';
 import styles from '../styles/Home.module.css';
 import heroMinaLogo from '../public/assets/hero-mina-logo.svg';
 import arrowRightSmall from '../public/assets/arrow-right-small.svg';
-import './reactCOIServiceWorker';
 import {fetchAccount, Mina, PublicKey} from "o1js";
 import {Add} from "../../contracts";
-
 
 // We've already deployed the Add contract on testnet at this address
 // https://minascan.io/devnet/account/B62qnTDEeYtBHBePA4yhCt4TCgDtA4L2CGvK7PirbJyX4pKH8bmtWe5
 const zkAppAddress = "B62qnTDEeYtBHBePA4yhCt4TCgDtA4L2CGvK7PirbJyX4pKH8bmtWe5";
-
-import './reactCOIServiceWorker';
 
 export default function Home() {
   const zkApp = useRef<Add>(new Add(PublicKey.fromBase58(zkAppAddress)));


### PR DESCRIPTION
- Fixes issues introduced by https://github.com/o1-labs/zkapp-cli/pull/709
  - `package-lock` file update;
  - Next.js project without GH Pages enabled (duplicated and redundant import).
- Dependencies vulnerabilities fix (audit).
- Version bump to re-release the app.