### PR TITLE
Display error message when `docker ps -a` command fails

### DIFF
--- a/src/lib/lightnet.js
+++ b/src/lib/lightnet.js
@@ -754,11 +754,13 @@ async function checkDockerEngineAvailability() {
       );
       shell.exit(1);
     }
-    const { code } = await executeCmd('docker ps -a');
-    if (code !== 0) {
+    const result = await executeCmd('docker ps -a');
+    if (result.code !== 0) {
       console.log(
         chalk.red(
-          '\n\nPlease ensure that Docker Engine is running, then try again.'
+          '\n\nThe command "docker ps -a" failed with the following error:\n' +
+            result.stderr +
+            '\nPlease ensure that Docker Engine is running properly, then try again.'
         )
       );
       shell.exit(1);


### PR DESCRIPTION
Currently, when the `docker ps -a` command fails, the CLI displays a generic error message that does not clearly indicate the underlying issue, making debugging difficult. For instance, in my case, the Docker Engine was running but encountered permission issues. The generic error message left me confused until I manually ran `docker ps -a` in the shell, which provided the actual error details.