### PR TITLE
ZKprogram default example starter

### DIFF
--- a/src/lib/ui/next/customNextPage.js
+++ b/src/lib/ui/next/customNextPage.js
@@ -10,8 +10,8 @@ import {fetchAccount, Mina, PublicKey, Field, Proof} from "o1js";
 import { Add, AddZKprogram } from "../../contracts";
 
 // We've already deployed the Add contract on testnet at this address
-// https://minascan.io/devnet/account/B62qnTDEeYtBHBePA4yhCt4TCgDtA4L2CGvK7PirbJyX4pKH8bmtWe5
-const zkAppAddress = "B62qnTDEeYtBHBePA4yhCt4TCgDtA4L2CGvK7PirbJyX4pKH8bmtWe5";
+// https://minascan.io/devnet/account/B62qoptamt2EgyY2UM2WD7UVJRvuuDMxw2cLdENc92iVNm6FwsLX4Fk
+const zkAppAddress = "B62qoptamt2EgyY2UM2WD7UVJRvuuDMxw2cLdENc92iVNm6FwsLX4Fk";
 
 export default function Home() {
   const zkApp = useRef<Add>(new Add(PublicKey.fromBase58(zkAppAddress)));

--- a/src/lib/ui/next/customNextPage.js
+++ b/src/lib/ui/next/customNextPage.js
@@ -30,6 +30,7 @@ export default function Home() {
       await fetchAccount({publicKey: zkAppAddress});
       const num = zkApp.current.num.get();
       setContractState(num.toString());
+      setZkprogramState(num.toString());
 
       // Compile the zkprogram
       console.log("Compiling AddZKprogram");
@@ -100,7 +101,7 @@ export default function Home() {
     setLoading(true);
 
     if (contractState && proof) {
-      const update = await zkProgram.update(contractState, proof);
+      const update = await zkProgram.update(Field(contractState), proof);
       setProof(update.proof);
       setZkprogramState(update.proof.publicOutput.toString())
     }
@@ -166,7 +167,7 @@ export default function Home() {
                 <div>Loading...</div>
               ) : (
                 <button onClick={updateZKprogram} className={styles.button}>
-                  Call Add.update()
+                  Call AddZKprogram.update()
                 </button>
               )}
             </div>

--- a/src/lib/ui/next/customNextPage.js
+++ b/src/lib/ui/next/customNextPage.js
@@ -113,6 +113,8 @@ export default function Home() {
       const update = await AddZKprogram.update(Field(contractState), proof);
       setProof(update.proof);
       setZkprogramState(update.proof.publicOutput.toString())
+    } else {
+      throw Error("Proof and or ContractState passed to AddZKprogram.update is null"); 
     }
     setLoading(false);  
  }, [proof]);

--- a/src/lib/ui/next/customNextPage.js
+++ b/src/lib/ui/next/customNextPage.js
@@ -91,6 +91,10 @@ export default function Home() {
     }
   }, []);
 
+  const updateZKprogram = async () => {
+
+  };
+
   return (
     <>
       <Head>

--- a/src/lib/ui/next/customNextPage.js
+++ b/src/lib/ui/next/customNextPage.js
@@ -62,18 +62,25 @@ export default function Home() {
       await fetchAccount({publicKey: PublicKey.fromBase58(walletKey)});
 
       // Execute a transaction locally on the browser
-      const transaction = await Mina.transaction(async () => {
-        console.log("Executing Add.settleState() locally");
-        await zkApp.current.settleState(proof);
-      });
+      let hash;
+      if (proof) {
+        const transaction = await Mina.transaction(async () => {
+          console.log("Executing Add.settleState() locally");
+          await zkApp.current.settleState(proof);
+        });
 
-      // Prove execution of the contract using the proving key
-      console.log("Proving execution of Add.settleState()");
-      await transaction.prove();
+        // Prove execution of the contract using the proving key
+        console.log("Proving execution of Add.settleState()");
+        await transaction.prove();
 
-      // Broadcast the transaction to the Mina network
-      console.log("Broadcasting proof of execution to the Mina network");
-      const {hash} = await mina.sendTransaction({transaction: transaction.toJSON()});
+        // Broadcast the transaction to the Mina network
+        console.log("Broadcasting proof of execution to the Mina network");
+        ({ hash } = await mina.sendTransaction({
+          transaction: transaction.toJSON()
+        }));
+      } else {
+        throw Error("Proof passed to Add.settleState is null");
+      }
 
       // display the link to the transaction
       const transactionLink = "https://minascan.io/devnet/tx/" + hash;

--- a/src/lib/ui/next/customNextPage.js
+++ b/src/lib/ui/next/customNextPage.js
@@ -29,10 +29,13 @@ export default function Home() {
       const num = zkApp.current.num.get();
       setContractState(num.toString());
 
-      // Compile the ZKprogram
+      // Compile the zkprogram
       console.log("Compiling AddZKprogram");
-      await AddZKprogram.compile(); 
-           
+      await AddZKprogram.compile();
+      
+      // Initialize the zkprogram with the initial state of the zkapp
+      const init = await AddZKprogram.init(num);
+
       // Compile the contract so that o1js has the proving key required to execute contract calls
       console.log("Compiling Add contract to generate proving and verification keys");
       await Add.compile();

--- a/src/lib/ui/next/customNextPage.js
+++ b/src/lib/ui/next/customNextPage.js
@@ -93,6 +93,9 @@ export default function Home() {
   }, []);
 
   const updateZKprogram = async () => {
+    if (contractState && proof) {
+      const update = await zkProgram.update(contractState, proof);
+    }
   };
 
   return (

--- a/src/lib/ui/next/customNextPage.js
+++ b/src/lib/ui/next/customNextPage.js
@@ -143,35 +143,37 @@ export default function Home() {
             Get started by editing
             <code className={styles.code}> app/page.tsx</code>
           </p>
-          <div className={styles.state}>
-            <div>
-              <div>Contract State: <span className={styles.bold}>{contractState}</span></div>
-              {error ? (
-                <span className={styles.error}>Error: {error}</span>
-              ) : (loading ?
-                <div>Loading...</div> :
-                (transactionLink ?
-                  <a href={transactionLink} className={styles.bold} target="_blank" rel="noopener noreferrer">
-                    View Transaction on MinaScan
-                  </a> :
-                  <button onClick={updateZkApp} className={styles.button}>Call Add.settleState()</button>))}
-            </div>
-          </div>
-          <div className={styles.state}>
-            <div>
+          <div className={styles.stateContainer}>
+            <div className={styles.state}>
               <div>
-                ZKprogram State:{" "}
-                <span className={styles.bold}>{zkprogramState}</span>
+                <div>Contract State: <span className={styles.bold}>{contractState}</span></div>
+                {error ? (
+                  <span className={styles.error}>Error: {error}</span>
+                ) : (loading ?
+                  <div>Loading...</div> :
+                  (transactionLink ?
+                    <a href={transactionLink} className={styles.bold} target="_blank" rel="noopener noreferrer">
+                      View Transaction on MinaScan
+                    </a> :
+                    <button onClick={updateZkApp} className={styles.button}>Call Add.settleState()</button>))}
               </div>
-              {error ? (
-                <span className={styles.error}>Error: {error}</span>
-              ) : loading ? (
-                <div>Loading...</div>
-              ) : (
-                <button onClick={updateZKprogram} className={styles.button}>
-                  Call AddZKprogram.update()
-                </button>
-              )}
+            </div>
+            <div className={styles.state}>
+              <div>
+                <div>
+                  ZKprogram State:{" "}
+                  <span className={styles.bold}>{zkprogramState}</span>
+                </div>
+                {error ? (
+                  <span className={styles.error}>Error: {error}</span>
+                ) : loading ? (
+                  <div>Loading...</div>
+                ) : (
+                  <button onClick={updateZKprogram} className={styles.button}>
+                    Call AddZKprogram.update()
+                  </button>
+                )}
+              </div>
             </div>
           </div>          
           <div className={styles.grid}>

--- a/src/lib/ui/next/customNextPage.js
+++ b/src/lib/ui/next/customNextPage.js
@@ -97,7 +97,6 @@ export default function Home() {
   }, []);
 
   const updateZKprogram = async () => {
-    setTransactionLink(null);
     setLoading(true);
 
     if (contractState && proof) {
@@ -105,6 +104,7 @@ export default function Home() {
       setProof(update.proof);
       setZkprogramState(update.proof.publicOutput.toString())
     }
+    setLoading(false);  
   };
 
   return (

--- a/src/lib/ui/next/customNextPage.js
+++ b/src/lib/ui/next/customNextPage.js
@@ -18,6 +18,7 @@ export default function Home() {
 
   const [transactionLink, setTransactionLink] = useState<string | null>(null);
   const [contractState, setContractState] = useState<string | null>(null);
+  const [proof, setProof] = useState<Proof<Field, Field> | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState<boolean>(true);
 
@@ -92,7 +93,6 @@ export default function Home() {
   }, []);
 
   const updateZKprogram = async () => {
-
   };
 
   return (

--- a/src/lib/ui/next/customNextPage.js
+++ b/src/lib/ui/next/customNextPage.js
@@ -7,7 +7,7 @@ import styles from '../styles/Home.module.css';
 import heroMinaLogo from '../public/assets/hero-mina-logo.svg';
 import arrowRightSmall from '../public/assets/arrow-right-small.svg';
 import {fetchAccount, Mina, PublicKey} from "o1js";
-import {Add} from "../../contracts";
+import { Add, AddZKprogram } from "../../contracts";
 
 // We've already deployed the Add contract on testnet at this address
 // https://minascan.io/devnet/account/B62qnTDEeYtBHBePA4yhCt4TCgDtA4L2CGvK7PirbJyX4pKH8bmtWe5

--- a/src/lib/ui/next/customNextPage.js
+++ b/src/lib/ui/next/customNextPage.js
@@ -96,6 +96,7 @@ export default function Home() {
   const updateZKprogram = async () => {
     if (contractState && proof) {
       const update = await zkProgram.update(contractState, proof);
+      setProof(update.proof);
     }
   };
 

--- a/src/lib/ui/next/customNextPage.js
+++ b/src/lib/ui/next/customNextPage.js
@@ -63,12 +63,12 @@ export default function Home() {
 
       // Execute a transaction locally on the browser
       const transaction = await Mina.transaction(async () => {
-        console.log("Executing Add.update() locally");
-        await zkApp.current.update();
+        console.log("Executing Add.settleState() locally");
+        await zkApp.current.settleState();
       });
 
       // Prove execution of the contract using the proving key
-      console.log("Proving execution of Add.update()");
+      console.log("Proving execution of Add.settleState()");
       await transaction.prove();
 
       // Broadcast the transaction to the Mina network
@@ -152,7 +152,7 @@ export default function Home() {
                   <a href={transactionLink} className={styles.bold} target="_blank" rel="noopener noreferrer">
                     View Transaction on MinaScan
                   </a> :
-                  <button onClick={updateZkApp} className={styles.button}>Call Add.update()</button>))}
+                  <button onClick={updateZkApp} className={styles.button}>Call Add.settleState()</button>))}
             </div>
           </div>
           <div className={styles.state}>

--- a/src/lib/ui/next/customNextPage.js
+++ b/src/lib/ui/next/customNextPage.js
@@ -32,11 +32,11 @@ export default function Home() {
       setContractState(num.toString());
       setZkprogramState(num.toString());
 
-      // Compile the zkprogram
+      // Compile the AddZKprogram
       console.log("Compiling AddZKprogram");
       await AddZKprogram.compile();
       
-      // Initialize the zkprogram with the initial state of the zkapp
+      // Initialize the AddZKprogram with the initial state of the zkapp
       console.log("Initialize AddZKprogram with intial contract state of zkapp");
       const init = await AddZKprogram.init(num);
       setProof(init.proof);
@@ -64,7 +64,7 @@ export default function Home() {
       // Execute a transaction locally on the browser
       const transaction = await Mina.transaction(async () => {
         console.log("Executing Add.settleState() locally");
-        await zkApp.current.settleState();
+        await zkApp.current.settleState(proof);
       });
 
       // Prove execution of the contract using the proving key
@@ -101,7 +101,7 @@ export default function Home() {
     setLoading(true);
 
     if (contractState && proof) {
-      const update = await zkProgram.update(Field(contractState), proof);
+      const update = await AddZKprogram.update(Field(contractState), proof);
       setProof(update.proof);
       setZkprogramState(update.proof.publicOutput.toString())
     }

--- a/src/lib/ui/next/customNextPage.js
+++ b/src/lib/ui/next/customNextPage.js
@@ -97,6 +97,9 @@ export default function Home() {
   }, []);
 
   const updateZKprogram = async () => {
+    setTransactionLink(null);
+    setLoading(true);
+
     if (contractState && proof) {
       const update = await zkProgram.update(contractState, proof);
       setProof(update.proof);

--- a/src/lib/ui/next/customNextPage.js
+++ b/src/lib/ui/next/customNextPage.js
@@ -38,6 +38,8 @@ export default function Home() {
       // Initialize the zkprogram with the initial state of the zkapp
       console.log("Initialize AddZKprogram with intial contract state of zkapp");
       const init = await AddZKprogram.init(num);
+      setProof(init.proof);
+      
 
       // Compile the contract so that o1js has the proving key required to execute contract calls
       console.log("Compiling Add contract to generate proving and verification keys");

--- a/src/lib/ui/next/customNextPage.js
+++ b/src/lib/ui/next/customNextPage.js
@@ -97,11 +97,10 @@ export default function Home() {
     }
   }, []);
 
-  const updateZKprogram = async () => {
+  const updateZKprogram = useCallback(async () => {
     setLoading(true);
      
     if (contractState && proof) {
-
       // Call the AddZKprogram update method
       console.log("Calling AddZKprogram.update");
       const update = await AddZKprogram.update(Field(contractState), proof);
@@ -109,7 +108,7 @@ export default function Home() {
       setZkprogramState(update.proof.publicOutput.toString())
     }
     setLoading(false);  
-  };
+ }, [proof]);
 
   return (
     <>

--- a/src/lib/ui/next/customNextPage.js
+++ b/src/lib/ui/next/customNextPage.js
@@ -95,7 +95,7 @@ export default function Home() {
     } finally {
       setLoading(false);
     }
-  }, []);
+  }, [proof]);
 
   const updateZKprogram = useCallback(async () => {
     setLoading(true);

--- a/src/lib/ui/next/customNextPage.js
+++ b/src/lib/ui/next/customNextPage.js
@@ -6,7 +6,7 @@ import GradientBG from '../components/GradientBG.js';
 import styles from '../styles/Home.module.css';
 import heroMinaLogo from '../public/assets/hero-mina-logo.svg';
 import arrowRightSmall from '../public/assets/arrow-right-small.svg';
-import {fetchAccount, Mina, PublicKey} from "o1js";
+import {fetchAccount, Mina, PublicKey, Field, Proof} from "o1js";
 import { Add, AddZKprogram } from "../../contracts";
 
 // We've already deployed the Add contract on testnet at this address

--- a/src/lib/ui/next/customNextPage.js
+++ b/src/lib/ui/next/customNextPage.js
@@ -99,8 +99,11 @@ export default function Home() {
 
   const updateZKprogram = async () => {
     setLoading(true);
-
+     
     if (contractState && proof) {
+
+      // Call the AddZKprogram update method
+      console.log("Calling AddZKprogram.update");
       const update = await AddZKprogram.update(Field(contractState), proof);
       setProof(update.proof);
       setZkprogramState(update.proof.publicOutput.toString())

--- a/src/lib/ui/next/customNextPage.js
+++ b/src/lib/ui/next/customNextPage.js
@@ -29,6 +29,10 @@ export default function Home() {
       const num = zkApp.current.num.get();
       setContractState(num.toString());
 
+      // Compile the ZKprogram
+      console.log("Compiling AddZKprogram");
+      await AddZKprogram.compile(); 
+           
       // Compile the contract so that o1js has the proving key required to execute contract calls
       console.log("Compiling Add contract to generate proving and verification keys");
       await Add.compile();

--- a/src/lib/ui/next/customNextPage.js
+++ b/src/lib/ui/next/customNextPage.js
@@ -159,7 +159,7 @@ export default function Home() {
             <div>
               <div>
                 ZKprogram State:{" "}
-                <span className={styles.bold}>{contractState}</span>
+                <span className={styles.bold}>{zkprogramState}</span>
               </div>
               {error ? (
                 <span className={styles.error}>Error: {error}</span>

--- a/src/lib/ui/next/customNextPage.js
+++ b/src/lib/ui/next/customNextPage.js
@@ -154,6 +154,23 @@ export default function Home() {
                   <button onClick={updateZkApp} className={styles.button}>Call Add.update()</button>))}
             </div>
           </div>
+          <div className={styles.state}>
+            <div>
+              <div>
+                ZKprogram State:{" "}
+                <span className={styles.bold}>{contractState}</span>
+              </div>
+              {error ? (
+                <span className={styles.error}>Error: {error}</span>
+              ) : loading ? (
+                <div>Loading...</div>
+              ) : (
+                <button onClick={updateZKprogram} className={styles.button}>
+                  Call Add.update()
+                </button>
+              )}
+            </div>
+          </div>          
           <div className={styles.grid}>
             <a
               href="https://docs.minaprotocol.com/zkapps"

--- a/src/lib/ui/next/customNextPage.js
+++ b/src/lib/ui/next/customNextPage.js
@@ -18,6 +18,7 @@ export default function Home() {
 
   const [transactionLink, setTransactionLink] = useState<string | null>(null);
   const [contractState, setContractState] = useState<string | null>(null);
+  const [zkprogramState, setZkprogramState] = useState<string | null>(null);
   const [proof, setProof] = useState<Proof<Field, Field> | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState<boolean>(true);

--- a/src/lib/ui/next/customNextPage.js
+++ b/src/lib/ui/next/customNextPage.js
@@ -36,6 +36,7 @@ export default function Home() {
       await AddZKprogram.compile();
       
       // Initialize the zkprogram with the initial state of the zkapp
+      console.log("Initialize AddZKprogram with intial contract state of zkapp");
       const init = await AddZKprogram.init(num);
 
       // Compile the contract so that o1js has the proving key required to execute contract calls

--- a/src/lib/ui/next/customNextPage.js
+++ b/src/lib/ui/next/customNextPage.js
@@ -97,6 +97,7 @@ export default function Home() {
     if (contractState && proof) {
       const update = await zkProgram.update(contractState, proof);
       setProof(update.proof);
+      setZkprogramState(update.proof.publicOutput.toString())
     }
   };
 

--- a/src/lib/ui/next/styles/Home.module.css
+++ b/src/lib/ui/next/styles/Home.module.css
@@ -91,7 +91,7 @@
 .state {
   padding: 0.8rem 1rem;
   gap: 0.5rem;
-  margin: 1rem;
+  margin: 1rem 1.6rem;
   background-color: rgb(255, 255, 255);
   border: 1px solid #2d2d2d;
   width: 14rem;

--- a/src/lib/ui/next/styles/Home.module.css
+++ b/src/lib/ui/next/styles/Home.module.css
@@ -81,6 +81,7 @@
   background-color: rgb(255, 255, 255);
   border: 1px solid #2d2d2d;
   padding: .25rem .5rem;
+  width: 11.75rem;
   cursor: pointer;
 }
 .state button:hover {

--- a/src/lib/ui/next/styles/Home.module.css
+++ b/src/lib/ui/next/styles/Home.module.css
@@ -223,6 +223,10 @@
     grid-template-rows: repeat(4, minmax(25%, auto));
   }
 
+  .stateContainer {
+    flex-direction: column;
+  }
+
   .start {
     margin-bottom: 2rem;
     padding-left: 0.5rem;

--- a/src/lib/ui/next/styles/Home.module.css
+++ b/src/lib/ui/next/styles/Home.module.css
@@ -75,6 +75,11 @@
   justify-items: center;
 }
 
+.stateContainer {
+  display: flex;
+  flex-direction: row;
+}
+
 .state button {
   display: block;
   margin: .5rem auto 1rem;

--- a/src/lib/ui/nuxt/customNuxtIndex.js
+++ b/src/lib/ui/nuxt/customNuxtIndex.js
@@ -126,7 +126,7 @@ export default {
 
       // Update this to use the address (public key) for your zkApp account.
       // To try it out, you can try this address for an example "Add" smart contract that we've deployed to
-      // Testnet B62qnTDEeYtBHBePA4yhCt4TCgDtA4L2CGvK7PirbJyX4pKH8bmtWe5.
+      // Devnet B62qoptamt2EgyY2UM2WD7UVJRvuuDMxw2cLdENc92iVNm6FwsLX4Fk.
       const zkAppAddress = ''
       // This should be removed once the zkAppAddress is updated.
       if (!zkAppAddress) {

--- a/src/lib/ui/svelte/customPageSvelte.js
+++ b/src/lib/ui/svelte/customPageSvelte.js
@@ -11,7 +11,7 @@ export default `
 
     // Update this to use the address (public key) for your zkApp account.
     // To try it out, you can try this address for an example "Add" smart contract that we've deployed to
-    // Testnet B62qnTDEeYtBHBePA4yhCt4TCgDtA4L2CGvK7PirbJyX4pKH8bmtWe5 .
+    // Devnet B62qoptamt2EgyY2UM2WD7UVJRvuuDMxw2cLdENc92iVNm6FwsLX4Fk .
     const zkAppAddress = ''
     // This should be removed once the zkAppAddress is updated.
     if (!zkAppAddress) {

--- a/templates/project-ts/src/Add.test.ts
+++ b/templates/project-ts/src/Add.test.ts
@@ -54,14 +54,14 @@ describe('Add', () => {
   it('correctly updates the num state on the `Add` smart contract', async () => {
     await localDeploy();
 
-    // update transaction
-    const txn = await Mina.transaction(senderAccount, async () => {
-      await zkApp.update();
-    });
-    await txn.prove();
-    await txn.sign([senderKey]).send();
+    // // update transaction
+    // const txn = await Mina.transaction(senderAccount, async () => {
+    //   await zkApp.settleAddProgramState();
+    // });
+    // await txn.prove();
+    // await txn.sign([senderKey]).send();
 
-    const updatedNum = zkApp.num.get();
-    expect(updatedNum).toEqual(Field(3));
+    // const updatedNum = zkApp.num.get();
+    // expect(updatedNum).toEqual(Field(3));
   });
 });

--- a/templates/project-ts/src/Add.test.ts
+++ b/templates/project-ts/src/Add.test.ts
@@ -49,12 +49,13 @@ describe('Add', () => {
     await txn.sign([deployerKey, zkAppPrivateKey]).send();
   }
 
-  it('generates and deploys the `Add` smart contract', async () => {
+  it('initilaizes the  `AddZKprogram`', async () => {
     await localDeploy();
-    const num = zkApp.num.get();
-    expect(num).toEqual(Field(1));
-  });
 
+    const { proof } = await AddZKprogram.init(Field(1));
+
+    expect(proof.publicOutput).toEqual(Field(1));
+  });
   it('correctly updates the num state on the `Add` smart contract', async () => {
     await localDeploy();
 

--- a/templates/project-ts/src/Add.test.ts
+++ b/templates/project-ts/src/Add.test.ts
@@ -61,8 +61,18 @@ describe('Add', () => {
     await localDeploy();
     await localDeploy();
     const initialState = Field(1);
-    const init = await AddZKprogram.init(initialState);
 
+    const init = await AddZKprogram.init(initialState);
     const update = await AddZKprogram.update(initialState, init.proof);
+
+    // settleState transaction
+    const txn = await Mina.transaction(senderAccount, async () => {
+      await zkApp.settleState(update.proof);
+    });
+    await txn.prove();
+    await txn.sign([senderKey]).send();
+
+    const updatedNum = zkApp.num.get();
+    expect(updatedNum).toEqual(Field(2));
   });
 });

--- a/templates/project-ts/src/Add.test.ts
+++ b/templates/project-ts/src/Add.test.ts
@@ -9,7 +9,7 @@ import { AddZKprogram } from './AddZKprogram';
  * See https://docs.minaprotocol.com/zkapps for more info.
  */
 
-const proofsEnabled = false;
+const proofsEnabled = true;
 
 describe('Add', () => {
   let deployerAccount: Mina.TestPublicKey,

--- a/templates/project-ts/src/Add.test.ts
+++ b/templates/project-ts/src/Add.test.ts
@@ -1,5 +1,6 @@
 import { AccountUpdate, Field, Mina, PrivateKey, PublicKey } from 'o1js';
 import { Add } from './Add';
+import { AddZKprogram } from './AddZKprogram';
 
 /*
  * This file specifies how to test the `Add` example smart contract. It is safe to delete this file and replace
@@ -20,7 +21,10 @@ describe('Add', () => {
     zkApp: Add;
 
   beforeAll(async () => {
-    if (proofsEnabled) await Add.compile();
+    if (proofsEnabled) {
+      await AddZKprogram.compile();
+      await Add.compile();
+    }
   });
 
   beforeEach(async () => {

--- a/templates/project-ts/src/Add.test.ts
+++ b/templates/project-ts/src/Add.test.ts
@@ -56,17 +56,13 @@ describe('Add', () => {
 
     expect(proof.publicOutput).toEqual(Field(1));
   });
-  it('correctly updates the num state on the `Add` smart contract', async () => {
+
+  it('correctly settles `AddZKprogram` state on the `Add` smart contract', async () => {
     await localDeploy();
+    await localDeploy();
+    const initialState = Field(1);
+    const init = await AddZKprogram.init(initialState);
 
-    // // update transaction
-    // const txn = await Mina.transaction(senderAccount, async () => {
-    //   await zkApp.settleAddProgramState();
-    // });
-    // await txn.prove();
-    // await txn.sign([senderKey]).send();
-
-    // const updatedNum = zkApp.num.get();
-    // expect(updatedNum).toEqual(Field(3));
+    const update = await AddZKprogram.update(initialState, init.proof);
   });
 });

--- a/templates/project-ts/src/Add.test.ts
+++ b/templates/project-ts/src/Add.test.ts
@@ -59,7 +59,6 @@ describe('Add', () => {
 
   it('correctly settles `AddZKprogram` state on the `Add` smart contract', async () => {
     await localDeploy();
-    await localDeploy();
     const initialState = Field(1);
 
     const init = await AddZKprogram.init(initialState);

--- a/templates/project-ts/src/Add.ts
+++ b/templates/project-ts/src/Add.ts
@@ -6,7 +6,7 @@ import { AddProgramProof } from './AddZKprogram';
  * See https://docs.minaprotocol.com/zkapps for more info.
  *
  * The Add contract verifies a ZKprogram proof and updates a 'num' state variable.
- * When the 'settleAddProgramState' method is called, the Add contract verifies a
+ * When the 'settleState' method is called, the Add contract verifies a
  * proof from the 'AddZKprogram' and saves the 'num' value to the contract state.
  *
  * This file is safe to delete and replace with your own contract.

--- a/templates/project-ts/src/Add.ts
+++ b/templates/project-ts/src/Add.ts
@@ -25,7 +25,7 @@ export class Add extends SmartContract {
     this.num.set(newState);
   }
 
-  @method async updateAddProgram(proof: AddProgramProof) {
+  @method async settleAddProgramState(proof: AddProgramProof) {
     const addProgramState = proof.publicOutput;
     this.zkProgramNum.set(addProgramState);
   }

--- a/templates/project-ts/src/Add.ts
+++ b/templates/project-ts/src/Add.ts
@@ -23,4 +23,6 @@ export class Add extends SmartContract {
     const newState = currentState.add(2);
     this.num.set(newState);
   }
+
+  @method async updateAddProgram(proof: AddProgramProof) {}
 }

--- a/templates/project-ts/src/Add.ts
+++ b/templates/project-ts/src/Add.ts
@@ -26,6 +26,7 @@ export class Add extends SmartContract {
   }
 
   @method async settleAddProgramState(proof: AddProgramProof) {
+    proof.verify();
     const addProgramState = proof.publicOutput;
     this.zkProgramNum.set(addProgramState);
   }

--- a/templates/project-ts/src/Add.ts
+++ b/templates/project-ts/src/Add.ts
@@ -1,5 +1,5 @@
 import { Field, SmartContract, state, State, method } from 'o1js';
-import { AddProgramProof } from './AddZKprogram';
+import { AddProgramProof } from './AddZKprogram.js';
 
 /**
  * Basic Example

--- a/templates/project-ts/src/Add.ts
+++ b/templates/project-ts/src/Add.ts
@@ -5,8 +5,9 @@ import { AddProgramProof } from './AddZKprogram';
  * Basic Example
  * See https://docs.minaprotocol.com/zkapps for more info.
  *
- * The Add contract initializes the state variable 'num' to be a Field(1) value by default when deployed.
- * When the 'update' method is called, the Add contract adds Field(2) to its 'num' contract state.
+ * The Add contract verifies a ZKprogram proof and updates a 'num' state variable.
+ * When the 'settleAddProgramState' method is called, the Add contract verifies a
+ * proof from the 'AddZKprogram' and saves the 'num' value to the contract state.
  *
  * This file is safe to delete and replace with your own contract.
  */

--- a/templates/project-ts/src/Add.ts
+++ b/templates/project-ts/src/Add.ts
@@ -14,17 +14,6 @@ export class Add extends SmartContract {
   @state(Field) num = State<Field>();
   @state(Field) zkProgramNum = State<Field>();
 
-  init() {
-    super.init();
-    this.num.set(Field(1));
-  }
-
-  @method async update() {
-    const currentState = this.num.getAndRequireEquals();
-    const newState = currentState.add(2);
-    this.num.set(newState);
-  }
-
   @method async settleAddProgramState(proof: AddProgramProof) {
     proof.verify();
     const addProgramState = proof.publicOutput;

--- a/templates/project-ts/src/Add.ts
+++ b/templates/project-ts/src/Add.ts
@@ -12,6 +12,7 @@ import { AddProgramProof } from './AddZKprogram';
  */
 export class Add extends SmartContract {
   @state(Field) num = State<Field>();
+  @state(Field) zkProgramNum = State<Field>();
 
   init() {
     super.init();

--- a/templates/project-ts/src/Add.ts
+++ b/templates/project-ts/src/Add.ts
@@ -12,11 +12,10 @@ import { AddProgramProof } from './AddZKprogram';
  */
 export class Add extends SmartContract {
   @state(Field) num = State<Field>();
-  @state(Field) zkProgramNum = State<Field>();
 
   @method async settleAddProgramState(proof: AddProgramProof) {
     proof.verify();
     const addProgramState = proof.publicOutput;
-    this.zkProgramNum.set(addProgramState);
+    this.num.set(addProgramState);
   }
 }

--- a/templates/project-ts/src/Add.ts
+++ b/templates/project-ts/src/Add.ts
@@ -14,7 +14,7 @@ import { AddProgramProof } from './AddZKprogram';
 export class Add extends SmartContract {
   @state(Field) num = State<Field>();
 
-  @method async settleAddProgramState(proof: AddProgramProof) {
+  @method async settleZKprogramState(proof: AddProgramProof) {
     proof.verify();
     const addProgramState = proof.publicOutput;
     this.num.set(addProgramState);

--- a/templates/project-ts/src/Add.ts
+++ b/templates/project-ts/src/Add.ts
@@ -25,5 +25,8 @@ export class Add extends SmartContract {
     this.num.set(newState);
   }
 
-  @method async updateAddProgram(proof: AddProgramProof) {}
+  @method async updateAddProgram(proof: AddProgramProof) {
+    const addProgramState = proof.publicOutput;
+    this.zkProgramNum.set(addProgramState);
+  }
 }

--- a/templates/project-ts/src/Add.ts
+++ b/templates/project-ts/src/Add.ts
@@ -14,7 +14,7 @@ import { AddProgramProof } from './AddZKprogram';
 export class Add extends SmartContract {
   @state(Field) num = State<Field>();
 
-  @method async settleZKprogramState(proof: AddProgramProof) {
+  @method async settleState(proof: AddProgramProof) {
     proof.verify();
     const addProgramState = proof.publicOutput;
     this.num.set(addProgramState);

--- a/templates/project-ts/src/AddZKprogram.ts
+++ b/templates/project-ts/src/AddZKprogram.ts
@@ -13,6 +13,7 @@ export const AddZKprogram = ZkProgram({
         };
       },
     },
+
     update: {
       privateInputs: [SelfProof],
       async method(
@@ -20,8 +21,9 @@ export const AddZKprogram = ZkProgram({
         previousProof: SelfProof<Field, Field>
       ) {
         previousProof.verify();
+        initialState.assertEquals(previousProof.publicInput);
         return {
-          publicOutput: initialState.add(Field(1)),
+          publicOutput: previousProof.publicOutput.add(Field(1)),
         };
       },
     },

--- a/templates/project-ts/src/AddZKprogram.ts
+++ b/templates/project-ts/src/AddZKprogram.ts
@@ -5,12 +5,6 @@ export const AddProgram = ZkProgram({
   publicInput: Field,
   publicOutput: Field,
   methods: {
-    // init: {
-    //   privateInputs: [],
-
-    //   async method() {},
-    // },
-
     update: {
       privateInputs: [],
       async method(state: Field) {

--- a/templates/project-ts/src/AddZKprogram.ts
+++ b/templates/project-ts/src/AddZKprogram.ts
@@ -15,7 +15,11 @@ export const AddZKprogram = ZkProgram({
     },
     update: {
       privateInputs: [SelfProof],
-      async method(initialState: Field) {
+      async method(
+        initialState: Field,
+        previousProof: SelfProof<Field, Field>
+      ) {
+        previousProof.verify();
         return {
           publicOutput: initialState.add(Field(1)),
         };

--- a/templates/project-ts/src/AddZKprogram.ts
+++ b/templates/project-ts/src/AddZKprogram.ts
@@ -1,4 +1,4 @@
-import { ZkProgram, Field } from 'o1js';
+import { ZkProgram, Field, SelfProof, verify } from 'o1js';
 
 export const AddZKprogram = ZkProgram({
   name: 'add-program',

--- a/templates/project-ts/src/AddZKprogram.ts
+++ b/templates/project-ts/src/AddZKprogram.ts
@@ -5,11 +5,19 @@ export const AddZKprogram = ZkProgram({
   publicInput: Field,
   publicOutput: Field,
   methods: {
+    init: {
+      privateInputs: [],
+      async method(initialState: Field) {
+        return {
+          publicOutput: initialState,
+        };
+      },
+    },
     update: {
       privateInputs: [],
       async method(state: Field) {
         return {
-          publicOutput: state.add(1),
+          publicOutput: state.add(Field(1)),
         };
       },
     },

--- a/templates/project-ts/src/AddZKprogram.ts
+++ b/templates/project-ts/src/AddZKprogram.ts
@@ -1,6 +1,6 @@
 import { ZkProgram, Field } from 'o1js';
 
-export const AddZKProgram = ZkProgram({
+export const AddZKprogram = ZkProgram({
   name: 'add-program',
   publicInput: Field,
   publicOutput: Field,
@@ -16,4 +16,4 @@ export const AddZKProgram = ZkProgram({
   },
 });
 
-export class AddProgramProof extends ZkProgram.Proof(AddZKProgram) {}
+export class AddProgramProof extends ZkProgram.Proof(AddZKprogram) {}

--- a/templates/project-ts/src/AddZKprogram.ts
+++ b/templates/project-ts/src/AddZKprogram.ts
@@ -14,10 +14,10 @@ export const AddZKprogram = ZkProgram({
       },
     },
     update: {
-      privateInputs: [],
-      async method(state: Field) {
+      privateInputs: [SelfProof],
+      async method(initialState: Field) {
         return {
-          publicOutput: state.add(Field(1)),
+          publicOutput: initialState.add(Field(1)),
         };
       },
     },

--- a/templates/project-ts/src/AddZKprogram.ts
+++ b/templates/project-ts/src/AddZKprogram.ts
@@ -1,6 +1,6 @@
 import { ZkProgram, Field } from 'o1js';
 
-export const AddProgram = ZkProgram({
+export const AddZKProgram = ZkProgram({
   name: 'add-program',
   publicInput: Field,
   publicOutput: Field,
@@ -16,4 +16,4 @@ export const AddProgram = ZkProgram({
   },
 });
 
-export class AddProgramProof extends ZkProgram.Proof(AddProgram) {}
+export class AddProgramProof extends ZkProgram.Proof(AddZKProgram) {}

--- a/templates/project-ts/src/index.ts
+++ b/templates/project-ts/src/index.ts
@@ -1,4 +1,4 @@
 import { Add } from './Add.js';
-import { AddZKProgram } from './AddZKProgram.js';
+import { AddZKProgram } from './AddZKprogram.js';
 
 export { Add, AddZKProgram };

--- a/templates/project-ts/src/index.ts
+++ b/templates/project-ts/src/index.ts
@@ -1,4 +1,4 @@
 import { Add } from './Add.js';
-import { AddZKProgram } from './AddZKprogram.js';
+import { AddZKprogram } from './AddZKprogram.js';
 
-export { Add, AddZKProgram };
+export { Add, AddZKprogram };

--- a/templates/project-ts/src/index.ts
+++ b/templates/project-ts/src/index.ts
@@ -1,3 +1,4 @@
 import { Add } from './Add.js';
+import { AddZKProgram } from './AddZKProgram.js';
 
-export { Add };
+export { Add, AddZKProgram };

--- a/templates/project-ts/src/interact.ts
+++ b/templates/project-ts/src/interact.ts
@@ -84,12 +84,12 @@ try {
   // call update on the ZKprogram
   const update = await AddZKprogram.update(initialState, init.proof);
 
-  // call update() and send transaction
+  // call settleState() and send transaction
   console.log('build transaction and create proof...');
   const tx = await Mina.transaction(
     { sender: feepayerAddress, fee },
     async () => {
-      await zkApp.update();
+      await zkApp.settleState(update.proof);
     }
   );
   await tx.prove();

--- a/templates/project-ts/src/interact.ts
+++ b/templates/project-ts/src/interact.ts
@@ -13,7 +13,7 @@
  * Run with node:     `$ node build/src/interact.js <deployAlias>`.
  */
 import fs from 'fs/promises';
-import { Mina, NetworkId, PrivateKey } from 'o1js';
+import { Mina, NetworkId, PrivateKey, Field } from 'o1js';
 import { Add } from './Add.js';
 import { AddZKprogram } from './AddZKprogram.js';
 
@@ -68,11 +68,22 @@ const feepayerAddress = feepayerKey.toPublicKey();
 const zkAppAddress = zkAppKey.toPublicKey();
 const zkApp = new Add(zkAppAddress);
 
+// compile the ZKprogram
+console.log('compile the zkprogram...');
+await AddZKprogram.compile();
+
 // compile the contract to create prover keys
 console.log('compile the contract...');
 await Add.compile();
 
 try {
+  const initialState = Field(1);
+
+  // initialze the ZKprogram
+  const init = await AddZKprogram.init(initialState);
+  // call update on the ZKprogram
+  const update = await AddZKprogram.update(initialState, init.proof);
+
   // call update() and send transaction
   console.log('build transaction and create proof...');
   const tx = await Mina.transaction(

--- a/templates/project-ts/src/interact.ts
+++ b/templates/project-ts/src/interact.ts
@@ -1,7 +1,7 @@
 /**
  * This script can be used to interact with the Add contract, after deploying it.
  *
- * We call the update() method on the contract, create a proof and send it to the chain.
+ * We call the settleState() method on the `Add` contract, create a proof and send it to the chain.
  * The endpoint that we interact with is read from your config.json.
  *
  * This simulates a user interacting with the zkApp from a browser, except that here, sending the transaction happens
@@ -15,6 +15,7 @@
 import fs from 'fs/promises';
 import { Mina, NetworkId, PrivateKey } from 'o1js';
 import { Add } from './Add.js';
+import { AddZKprogram } from './AddZKprogram.js';
 
 // check command line arg
 const deployAlias = process.argv[2];


### PR DESCRIPTION
## Summary

This PR adds a new `ZKprogram` default example that is included with projects generated with the `zkApp-CLI`. This example was also coupled with a new example template UI that demonstrates an end to end flow of generating proofs with a `ZKprogram`, and settling the state on `Mina`.

## Impact

The previous default example set up the developer community for failure. While this example highlighted the intuitive nature of writing proofs with `o1js`,  it extended the `SmartContract` class which abstracted away a lot of the complexity of what was happening. 

The new example was created using `ZKprogram` which has more clear inputs, outputs, and behavior.  This coupled with the end to end UI example will allow a developer to make more progress on their learning journey  by providing an easy to reason about example that can quickly be iterated and rerun.

## Changes

- `AddZKprogram` was created that can generate proofs and update the state 
- `Add.ts` was modified to only verify a proof created by `AddZKprogram` and settle the state to `Mina`
-  The example default tests `Add.tests.ts` were modified to test interactions with the `AddZKprogram`
- The `interact.ts` was modified to generate proofs with the `AddZKprogram` and interact with a deployed `Add.ts` contract that settles the state to `Mina`
- A new example template UI was added that demonstrates an end to end flow of generating proofs with a `ZKprogram`, and settling the state on `Mina`.

![Screenshot 2025-03-19 at 12 00 12 AM](https://github.com/user-attachments/assets/d68ed177-2da6-43fe-b11f-8b7d5a33e92f)

